### PR TITLE
Update JLS execution to new org.eclipse.* namespace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
 	"search.exclude": {
 		"out": true // set this to false to include "out" folder in search results
 	},
-	"typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "vsicons.presets.angular": false // we want to use the TS server from our node_modules folder to control its version
 }

--- a/src/downloadManager.ts
+++ b/src/downloadManager.ts
@@ -95,7 +95,7 @@ export function downloadAndInstallServer() {
 		const SERVER_FOLDER = path.resolve(__dirname, '../../server/');
 		// const SERVER_ARCHIVE = "https://dl.bintray.com/gorkem/java-language-server/java-server-1.0.0-201609020048.tar.gz";
 		// Always use HTTPS download for http adresses may not work over proxies.
-		const SERVER_ARCHIVE = 'https://download.jboss.org/jbosstools/static/vscode/java-server-1.0.0-201702081758.tar.gz';
+		const SERVER_ARCHIVE = 'https://download.jboss.org/jbosstools/static/vscode/jdt-language-server-0.1.0-201702092042.tar.gz';
 
 		return download(SERVER_ARCHIVE, proxy, strictSSL).then(is => {
 			tmp.file((err, tmpPath, fd, cleanupCallback) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,9 +41,9 @@ function runJavaServer() : Thenable<StreamInfo> {
 				// suspend=y is the default. Use this form if you need to debug the server startup code:
 				//  params.push('-agentlib:jdwp=transport=dt_socket,server=y,address=1044');
 			}
-			params.push('-Declipse.application=org.jboss.tools.vscode.java.id1');
+			params.push('-Declipse.application=org.eclipse.jdt.ls.core.id1');
 			params.push('-Dosgi.bundles.defaultStartLevel=4');
-			params.push('-Declipse.product=org.jboss.tools.vscode.java.product');
+			params.push('-Declipse.product=org.eclipse.jdt.ls.product');
 			if (DEBUG) {
 				params.push('-Dlog.protocol=true');
 				params.push('-Dlog.level=ALL');


### PR DESCRIPTION
This PR needs the JLS migration to eclipse.org to complete first.

Furthermore, a new JLS download url is required to complete this change

Signed-off-by: Fred Bricon <fbricon@gmail.com>