### PR TITLE
Support starting the Java Language Server with JDK 9. Fixes #43

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,13 @@ function runJavaServer() : Thenable<StreamInfo> {
 				// suspend=y is the default. Use this form if you need to debug the server startup code:
 				//  params.push('-agentlib:jdwp=transport=dt_socket,server=y,address=1044');
 			}
+			if (requirements.java_version > 8) {
+				params.push('--add-modules=ALL-SYSTEM');
+				params.push('--add-opens');
+				params.push('java.base/java.util=ALL-UNNAMED');
+				params.push('--add-opens');
+				params.push('java.base/java.lang=ALL-UNNAMED');
+			}
 			params.push('-Declipse.application=org.eclipse.jdt.ls.core.id1');
 			params.push('-Dosgi.bundles.defaultStartLevel=4');
 			params.push('-Declipse.product=org.eclipse.jdt.ls.core.product');

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -14,6 +14,7 @@ const JAVAC_FILENAME = 'javac' + (isWindows?'.exe':'');
 
 interface RequirementsData {
     java_home: string;
+    java_version: number;
 }
 
 interface ErrorData {
@@ -31,9 +32,9 @@ interface ErrorData {
  */
 export async function resolveRequirements(): Promise<RequirementsData> {
     let java_home = await checkJavaRuntime();
-    await checkJavaVersion(java_home);
+    let javaVersion = await checkJavaVersion(java_home);
     await checkServerInstalled();
-    return Promise.resolve({ 'java_home': java_home });
+    return Promise.resolve({ 'java_home': java_home, 'java_version': javaVersion});
 }
 
 function checkJavaRuntime(): Promise<any> {
@@ -81,11 +82,13 @@ function readJavaConfig() : string {
 function checkJavaVersion(java_home: string): Promise<any> {
     return new Promise((resolve, reject) => {
         cp.execFile(java_home + '/bin/java', ['-version'], {}, (error, stdout, stderr) => {
-            if (stderr.indexOf('1.8') < 0){
+            if (stderr.indexOf('version "9') > -1){
+                resolve(9);
+            } if (stderr.indexOf('1.8') < 0){
                 openJDKDownload(reject, 'Java 8 is required to run. Please download and install a JDK 8.');
             }
             else{
-                resolve(true);
+                resolve(8);
             }
         });
     });


### PR DESCRIPTION
A bit of clarification  : this PR provides a way to start the language server with JDK 9, but doesn't provide support for building Java 9 projects.

Signed-off-by: Fred Bricon <fbricon@gmail.com>