### PR TITLE
Disable the keybinding of formatting document

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,11 @@
           "type": "string",
           "default": null,
           "description": "Absolute path to Maven's settings.xml"
+        },
+        "java.format.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable default Java formatter"
         }
       }
     },


### PR DESCRIPTION
Fixes #186

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>

You have to set the following

```
{
"java.format.enabled": false
}
```
in order to disable the Eclipse Java formatting.

Requires https://github.com/eclipse/eclipse.jdt.ls/pull/272