### PR TITLE
Run with remote Java LS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,21 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/src",
+			"outFiles": [ "${workspaceRoot}/out/src/**" ],
+			"preLaunchTask": "compile"
+		},
+		{
+			"name": "Launch Extension - Remote Server",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [ "${workspaceRoot}/out/src/**" ],
+			"env": {
+				"JAVA_LS_NAMED_PIPE": "javals"
+			},
 			"preLaunchTask": "compile"
 		},
 		{
@@ -21,7 +35,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/test",
+			"outFiles": ["${workspaceRoot}/out/test/**"],
 			"preLaunchTask": "compile"
 		}
 	]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/out/src/**" ],
 			"env": {
-				"JAVA_LS_NAMED_PIPE": "javals"
+				"SERVER_PORT": "3333"
 			},
 			"preLaunchTask": "compile"
 		},

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,19 +44,23 @@ This will build and place the binaries under the `server` folder. Alternately yo
 	$ ./node_modules/.bin/gulp download_server
 	```
 
-## Connect to a remote JDT language server
+## Run with a remote JDT language server
 
-While developping the language server and the extension, you don't need to deploy the server every time to try out a change. Instead you can run the language server out of its Eclipse workspace:
+While developping the language server and the extension, you don't need to deploy the server every time to try out changes. Instead you can run the language server out of its Eclipse workspace:
 
-- Open VSCOde on the vscode-java folder
-- In the debug viewlet, tun the launch 'Launch Extension - Remote Server'
-- The extension will open a named pipe with the name `javals` and wait for the JavaLS to connect
-- In Eclipse run the JDT language server as an Eclipse application:
-   - in the main tab set the product to `org.eclipse.jdt.ls.core.product`
-   - in the environment, define a variable `INOUT_PIPE_NAME` with value `javals` 
-   - in the plug-ins tab make sure that 'org.eclipse.jdt.ui' is not part of the plugins. Otherwise the the java.ui will be loaded throigh some extension points and will replace the primary buffer provider
-- In the debug cosole of VSCode you will see if the connection was sucessful
-- Hot code replace lets you make simple fixes without restarting the server
+- Open VSCode on the `vscode-java` folder
+- In the debug viewlet, run the launch _Launch Extension - Remote Server_
+- The extension will open a socket on port 3333 and will wait for the JDT language server to connect
+- In Eclipse, run the JDT language server as an Eclipse application. 
+    - Create a debug configuration of type _Eclipse Application_.
+   - in the main tab of the debug configuration set the product to `org.eclipse.jdt.ls.core.product`.
+   - in the Environment tab, define a variable `CLIENT_PORT` with value `3333`.
+   - if your workspace contains 'org.eclipse.jdt.ui', use the Plug-Ins tab in the debug configuration to exclude the plug-in. The presence of 'org.eclipse.jdt.ui' will cause the language server to hang. 
+- In the debug console of VSCode you can see if the connection was sucessful.
+- When the server is running breakpoints can be reached and hot code replace can be used to make fixes without restarting the server.
+- You can modify `launch.json` to use a different port or switch to a named pipe instead:
+    - Use `SERVER_PORT` to specify the port the JST LS server should connect to.
+    - Alternativly, use `SERVER_PIPE` to specify the named pipe the JST LS server should connect to.
 
 ## Sideloading
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,20 @@ This will build and place the binaries under the `server` folder. Alternately yo
 	$ ./node_modules/.bin/gulp download_server
 	```
 
+## Connect to a remote JDT language server
+
+While developping the language server and the extension, you don't need to deploy the server every time to try out a change. Instead you can run the language server out of its Eclipse workspace:
+
+- Open VSCOde on the vscode-java folder
+- In the debug viewlet, tun the launch 'Launch Extension - Remote Server'
+- The extension will open a named pipe with the name `javals` and wait for the JavaLS to connect
+- In Eclipse run the JDT language server as an Eclipse application:
+   - in the main tab set the product to `org.eclipse.jdt.ls.core.product`
+   - in the environment, define a variable `INOUT_PIPE_NAME` with value `javals` 
+   - in the plug-ins tab make sure that 'org.eclipse.jdt.ui' is not part of the plugins. Otherwise the the java.ui will be loaded throigh some extension points and will replace the primary buffer provider
+- In the debug cosole of VSCode you will see if the connection was sucessful
+- Hot code replace lets you make simple fixes without restarting the server
+
 ## Sideloading
 
 You can create a binary that you can sideload to your VS Code installation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ While developping the language server and the extension, you don't need to deplo
    - if your workspace contains 'org.eclipse.jdt.ui', use the Plug-Ins tab in the debug configuration to exclude the plug-in. The presence of 'org.eclipse.jdt.ui' will cause the language server to hang. 
 - In the debug console of VSCode you can see if the connection was sucessful.
 - When the server is running breakpoints can be reached and hot code replace can be used to make fixes without restarting the server.
-- You can modify `launch.json` to use a different port or switch to a named pipe instead:
-    - Use `SERVER_PORT` to specify the port the JST LS server should connect to.
-    - Alternativly, use `SERVER_PIPE` to specify the named pipe the JST LS server should connect to.
+- You can modify `launch.json` to use a different port:
+    - Modify `SERVER_PORT` to specify the port the JST LS server should connect to.
 
 ## Sideloading
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,12 +62,11 @@ export function activate(context: ExtensionContext) {
 			}
 			let workspacePath = path.resolve(storagePath + '/jdt_ws');
 			let serverOptions;
-			let namedPipe = process.env['SERVER_PIPE'];
 			let port = process.env['SERVER_PORT'];
-			if (!namedPipe && !port) {
+			if (!port) {
 				serverOptions = runServer.bind(null, workspacePath, getJavaConfiguration());
 			} else {
-				serverOptions = awaitServerConnection.bind(null, namedPipe, port);
+				serverOptions = awaitServerConnection.bind(null, port);
 			}
 
 			// Options to control the language client

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { workspace, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, Uri, CancellationToken, TextDocumentContentProvider, TextEditor, WorkspaceConfiguration, languages, IndentAction, ProgressLocation, Progress } from 'vscode';
 import { LanguageClient, LanguageClientOptions, Position as LSPosition, Location as LSLocation } from 'vscode-languageclient';
-import { runServer } from './javaServerStarter';
+import { runServer, attachServer } from './javaServerStarter';
 import { Commands } from './commands';
 import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, ActionableMessage } from './protocol';
 
@@ -61,7 +61,13 @@ export function activate(context: ExtensionContext) {
 				storagePath = getTempWorkspace();
 			}
 			let workspacePath = path.resolve(storagePath + '/jdt_ws');
-			let serverOptions = runServer.bind(null, workspacePath, getJavaConfiguration());
+			let serverOptions
+			let remoteNamedPipe = process.env['JAVA_LS_NAMED_PIPE'];
+			if (!remoteNamedPipe) {
+				serverOptions = runServer.bind(null, workspacePath, getJavaConfiguration());
+			} else {
+				serverOptions = attachServer.bind(null, remoteNamedPipe);
+			}
 
 			// Options to control the language client
 			let clientOptions: LanguageClientOptions = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { workspace, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, Uri, CancellationToken, TextDocumentContentProvider, TextEditor, WorkspaceConfiguration, languages, IndentAction, ProgressLocation, Progress } from 'vscode';
 import { LanguageClient, LanguageClientOptions, Position as LSPosition, Location as LSLocation } from 'vscode-languageclient';
-import { runServer, attachServer } from './javaServerStarter';
+import { runServer, awaitServerConnection } from './javaServerStarter';
 import { Commands } from './commands';
 import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, ActionableMessage } from './protocol';
 
@@ -61,12 +61,13 @@ export function activate(context: ExtensionContext) {
 				storagePath = getTempWorkspace();
 			}
 			let workspacePath = path.resolve(storagePath + '/jdt_ws');
-			let serverOptions
-			let remoteNamedPipe = process.env['JAVA_LS_NAMED_PIPE'];
-			if (!remoteNamedPipe) {
+			let serverOptions;
+			let namedPipe = process.env['SERVER_PIPE'];
+			let port = process.env['SERVER_PORT'];
+			if (!namedPipe && !port) {
 				serverOptions = runServer.bind(null, workspacePath, getJavaConfiguration());
 			} else {
-				serverOptions = attachServer.bind(null, remoteNamedPipe);
+				serverOptions = awaitServerConnection.bind(null, namedPipe, port);
 			}
 
 			// Options to control the language client

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -19,7 +19,11 @@ export function attachServer(pipeName): Thenable<StreamInfo> {
 		pipePath = '\\\\.\\pipe\\' + pipeName;
 	} else {
 		pipePath = '/tmp/' + pipeName + '.sock';
-		fs.unlinkSync(pipePath);
+		try {
+			fs.unlinkSync(pipePath);
+		} catch (e) {
+			//ignore, likely file does not exist
+		}
 	}
 	return new Promise((res, rej) => {
 		let server = net.createServer(stream => {

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -13,35 +13,18 @@ declare var v8debug;
 const DEBUG = (typeof v8debug === 'object') || startedInDebugMode();
 let electron = require('./electron_j');
 
-export function awaitServerConnection(pipeName, port): Thenable<StreamInfo> {
-	let addr : string | number;
-	let connectionType;
-	if (port) {
-		addr = parseInt(port);
-		connectionType = 'port';
-	} else {
-		if (process.platform === 'win32') {
-			addr = '\\\\.\\pipe\\' + pipeName;
-		} else {
-			addr = '/tmp/' + pipeName + '.sock';
-			try {
-				fs.unlinkSync(addr);
-			} catch (e) {
-				//ignore, likely file does not exist
-			}
-		}
-		connectionType = 'named pipe';
-	}
+export function awaitServerConnection(port): Thenable<StreamInfo> {
+	let addr = parseInt(port);
 	return new Promise((res, rej) => {
 		let server = net.createServer(stream => {
 			server.close();
-			console.log('JDT LS connection established on ' + connectionType + ' ' + addr);
+			console.log('JDT LS connection established on port ' + addr);
 			res({ reader: stream, writer: stream });
 		});
 		server.on('error', rej);
 		server.listen(addr, () => {
 			server.removeListener('error', rej);
-			console.log('Awaiting JDT LS connection on ' + connectionType + ' ' + addr);
+			console.log('Awaiting JDT LS connection on port ' + addr);
 		});
 		return server;
 	});


### PR DESCRIPTION
Lets the vscode-java extension run with a Java LS server that is started separately, e.g. out of Eclipse. That speeds up development as the LS server doesn't need to be built every time for trying out changes. When the server is run out of Eclipse, hot code replace lets you make fixes without restarting the server

- run the new launch configuation 'Launch Extension - Remote Server'
- The extension will open a socket at given port (3333 is used by default) and wait for the JavaLS to connect
- In Eclipse run the JavaLS as an Eclipse application
   - in the main tab set the product to `org.eclipse.jdt.ls.core.product`
   - in the environment tab, set `CLIENT_PORT` to `3333` 
   - in the plug-ins tab make sure that 'org.eclipse.jdt.ui' is not part of the plugins. Otherwise the the java.ui will be loaded through some extension points and will replace the primary buffer provider
- In the debug cosole of VSCode you will see if the connection was sucessful