### PR TITLE
Gradle error message on Maven project with Less.js node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable/disable default Java formatter"
+        },
+        "java.import.exclusions": {
+          "type": "array",
+          "description": "Configure glob patterns for excluding folders",
+          "default": "['**/node_modules', '**/.metadata']"
         }
       }
     },


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/229

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>

The java.import.exclusions property can be set as follows:

```
"java.import.exclusions": ["**/node_modules", "/somedir"]
```

Requires https://github.com/eclipse/eclipse.jdt.ls/pull/298