### PR TITLE
CodeLens for Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ The following settings are supported:
 * `java.trace.server` : Traces the communication between VS Code and the Java language server.
 * `java.referencesCodeLens.enabled` : Enable/disable the references code lens.
 * `java.signatureHelp.enabled` : Enable/disable the signature help.
+* `java.implementationsCodeLens.enabled` : Enable/disable the implementations code lens.
 * `java.configuration.maven.userSettings` : Absolute path to Maven's settings.xml.
+* `java.format.enabled` : Enable/disable default Java formatter.
+* `java.import.exclusions` : Exclude folders from import via glob patterns.
 
 
 Troubleshooting

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "activationEvents": [
     "onLanguage:java",
     "onCommand:java.show.references",
+    "onCommand:java.show.implementations",
     "onCommand:java.open.output",
     "onCommand:java.open.serverLog",
     "onCommand:java.projectConfiguration.update",
@@ -110,6 +111,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable/disable the signature help."
+        },
+        "java.implementationsCodeLens.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable/disable the implementations code lens."
         },
         "java.configuration.maven.userSettings": {
           "type": "string",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,6 +20,11 @@ export namespace Commands {
     export const SHOW_JAVA_REFERENCES = 'java.show.references';
 
     /**
+     * Show Java implementations
+     */
+    export const SHOW_JAVA_IMPLEMENTATIONS = 'java.show.implementations';
+
+    /**
      * Show editor references
      */
     export const SHOW_REFERENCES = 'editor.action.showReferences';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,6 +162,9 @@ export function activate(context: ExtensionContext) {
 			commands.registerCommand(Commands.SHOW_JAVA_REFERENCES, (uri: string, position: LSPosition, locations: LSLocation[]) => {
 				commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), languageClient.protocol2CodeConverter.asPosition(position), locations.map(languageClient.protocol2CodeConverter.asLocation));
 			});
+			commands.registerCommand(Commands.SHOW_JAVA_IMPLEMENTATIONS, (uri: string, position: LSPosition, locations: LSLocation[]) => {
+				commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), languageClient.protocol2CodeConverter.asPosition(position), locations.map(languageClient.protocol2CodeConverter.asLocation));
+			});
 
 			commands.registerCommand(Commands.CONFIGURATION_UPDATE, uri => projectConfigurationUpdate(languageClient, uri));
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -21,6 +21,7 @@ suite('Java Language Extension', () => {
 			const JAVA_COMMANDS = [
 				Commands.OPEN_OUTPUT,
 				Commands.SHOW_JAVA_REFERENCES,
+				Commands.SHOW_JAVA_IMPLEMENTATIONS,
 				Commands.CONFIGURATION_UPDATE,
 				Commands.IGNORE_INCOMPLETE_CLASSPATH,
 				Commands.IGNORE_INCOMPLETE_CLASSPATH_HELP,


### PR DESCRIPTION
Fixes https://github.com/eclipse/eclipse.jdt.ls/issues/99

I have added the java.implementationsCodeLens.enabled property, false by default.
To enable the codeLens implementors, you have to add the following:
```
"java.implementationsCodeLens.enabled": true
```
The implementations will be shown for interfaces and abstract classes.

Requires https://github.com/eclipse/eclipse.jdt.ls/pull/301

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>