### PR TITLE
Remove progress title

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ let lastStatus;
 
 export function activate(context: ExtensionContext) {
 
-	window.withProgress({ location: ProgressLocation.Window, title: 'Starting Java Language Server' }, p => {
+	window.withProgress({ location: ProgressLocation.Window }, p => {
 		return new Promise((resolve, reject) => {
 			// Let's enable Javadoc symbols autocompletion, shamelessly copied from MIT licensed code at
 			// https://github.com/Microsoft/vscode/blob/9d611d4dfd5a4a101b5201b8c9e21af97f06e7a7/extensions/typescript/src/typescriptMain.ts#L186


### PR DESCRIPTION
Fix to play together with https://github.com/eclipse/eclipse.jdt.ls/pull/305.

VS renders the status a bit strange: it appends the title to the message. I filed an issue against VSCode: https://github.com/Microsoft/vscode/issues/30672.

For optimal status rendering and not depend on what VSCode does, it's better to not give a title, but have the full message coming from the status.