### PR TITLE
Make intrusive language server output less intrusive

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import { workspace, extensions, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, Uri, CancellationToken, TextDocumentContentProvider, TextEditor, WorkspaceConfiguration, languages, IndentAction, ProgressLocation, Progress } from 'vscode';
-import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, LanguageClientOptions, ServerOptions, Position as LSPosition, Location as LSLocation } from 'vscode-languageclient';
+import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, LanguageClientOptions, RevealOutputChannelOn, ServerOptions, Position as LSPosition, Location as LSLocation } from 'vscode-languageclient';
 import { collectionJavaExtensions } from './plugin'
 import { prepareExecutable, awaitServerConnection } from './javaServerStarter';
 import * as requirements from './requirements';
@@ -54,7 +54,8 @@ export function activate(context: ExtensionContext) {
 					},
 					initializationOptions: {
 						bundles: collectionJavaExtensions(extensions.all)
-					}
+					},
+					revealOutputChannelOn: RevealOutputChannelOn.Never
 				};
 
 				let item = window.createStatusBarItem(StatusBarAlignment.Right, Number.MIN_VALUE);


### PR DESCRIPTION
Every single time I remove lines or characters of code from a java file, the Language Server outputs a BadLocationException, which always interrupts my typing by popping up VSCode's output panel, and the only real solution seems to be to resize that panel to as little height as possible.  I've recently experienced different issues with stale filenames, which result in a FileNotFoundException.  Error this, exception that, and every time I attempt to navigate a java file, it seems, I am interrupted by another complaint from the Language Server.  This is untenable.

I tested this feature on VSCode v1.17.0 and it worked.  The output window still shows issues that the Language Server has, but it no longer interrupts me.

This issue has been very frustrating and exasperating for me and many others for some time.  While the exceptions themselves should be tracked down and fixed, they are separate issues to the user experience failure that is the output window consistently interrupting me, so please consider as such and merge/release this modification.