### PR TITLE
Ignore archetype-resources folder during import

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "java.import.exclusions": {
           "type": "array",
           "description": "Configure glob patterns for excluding folders",
-          "default": "['**/node_modules', '**/.metadata']"
+          "default": "['**/node_modules', '**/.metadata', '**/archetype-resources']"
         },
         "java.contentProvider.preferred": {
           "type": "string",


### PR DESCRIPTION
Fixes #331

also depends on https://github.com/eclipse/eclipse.jdt.ls/pull/417

Signed-off-by: Fred Bricon <fbricon@gmail.com>