### PR TITLE
A command for invoking rename action

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,16 @@
 				"kind": "build",
 				"isDefault": true
 			}
+		},{
+			"label": "watch-server",
+			"type": "process",
+			"command": "npm",
+			"args": [
+				"run","watch-server"
+			],
+			"problemMatcher": [],
+			"isBackground": true
+
 		}
 	]
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -77,5 +77,10 @@ export namespace Commands {
     /**
      * Organize Java file imports command from language server
      */
-    export const EDIT_ORGANIZE_IMPORTS = 'java.edit.organizeImports';
+	export const EDIT_ORGANIZE_IMPORTS = 'java.edit.organizeImports';
+
+	/**
+	 * Invokes a rename action
+	 */
+	export const START_RENAME = 'java.execute.rename';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 'use strict';
 
 import * as path from 'path';
-import { workspace, extensions, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, Uri, CancellationToken, TextDocumentContentProvider, TextEditor, WorkspaceConfiguration, languages, IndentAction, ProgressLocation, Progress } from 'vscode';
+import { workspace, extensions, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, Uri, CancellationToken, TextDocumentContentProvider, TextEditor, WorkspaceConfiguration, languages, IndentAction, ProgressLocation, Progress, Selection } from 'vscode';
 import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, LanguageClientOptions, RevealOutputChannelOn, ServerOptions, Position as LSPosition, Location as LSLocation } from 'vscode-languageclient';
 import { collectionJavaExtensions } from './plugin'
 import { prepareExecutable, awaitServerConnection } from './javaServerStarter';
@@ -157,6 +157,12 @@ export function activate(context: ExtensionContext) {
 
 					commands.registerCommand(Commands.APPLY_WORKSPACE_EDIT, (obj) => {
 						applyWorkspaceEdit(obj);
+					});
+
+					commands.registerCommand(Commands.START_RENAME, (position: LSPosition, suggestedName:string)=>{
+						let pos = languageClient.protocol2CodeConverter.asPosition(position);
+						window.activeTextEditor.selection = new Selection(pos, pos);
+						commands.executeCommand('editor.action.rename',suggestedName);
 					});
 
 					commands.registerCommand(Commands.EDIT_ORGANIZE_IMPORTS, async () => {

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -6,7 +6,6 @@ import { RequirementsData } from './requirements';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as net from 'net';
-import { Commands } from './commands';
 const glob = require('glob');
 
 declare var v8debug;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -9,7 +9,7 @@ import {Commands} from '../src/commands';
 
 suite('Java Language Extension', () => {
 
-	test('Extension should be present', () => {
+	test('should be present', () => {
 		assert.ok(vscode.extensions.getExtension('redhat.java'));
 	});
 
@@ -35,7 +35,8 @@ suite('Java Language Extension', () => {
 				Commands.EXECUTE_WORKSPACE_COMMAND,
 				Commands.OPEN_SERVER_LOG,
 				Commands.COMPILE_WORKSPACE,
-				Commands.EDIT_ORGANIZE_IMPORTS
+				Commands.EDIT_ORGANIZE_IMPORTS,
+				Commands.START_RENAME
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Adds a new command that invokes the rename action of the
editor.

requires https://github.com/eclipse/eclipse.jdt.ls/pull/430