### PR TITLE
Add java.projectConfiguration.update command to explorer & editor menus, on build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,11 +237,23 @@
       }
     ],
     "menus": {
+      "explorer/context": [
+        {
+          "command": "java.projectConfiguration.update",
+          "when": "resourceFilename =~ /(.*\\.gradle)|(pom.xml)$/",
+          "group": "1_javaactions"
+        }
+      ],
       "editor/context": [
         {
           "command": "java.edit.organizeImports",
           "when": "resourceLangId == java",
-          "group": "1_modification"
+          "group": "1_javaactions"
+        },
+        {
+          "command": "java.projectConfiguration.update",
+          "when": "resourceFilename =~ /(.*\\.gradle)|(pom.xml)$/",
+          "group": "1_javaactions"
         }
       ]
     }


### PR DESCRIPTION
Requires vscode 1.20.

Fixes #159

Signed-off-by: Fred Bricon <fbricon@gmail.com>