### PR TITLE
Experimental execute client-side command protocol extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { collectionJavaExtensions } from './plugin';
 import { prepareExecutable, awaitServerConnection } from './javaServerStarter';
 import * as requirements from './requirements';
 import { Commands } from './commands';
-import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, ActionableMessage, CompileWorkspaceRequest, CompileWorkspaceStatus, ProgressReportNotification } from './protocol';
+import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, ActionableMessage, CompileWorkspaceRequest, CompileWorkspaceStatus, ProgressReportNotification, ExecuteClientCommandRequest } from './protocol';
 
 let oldConfig;
 let lastStatus;
@@ -146,6 +146,9 @@ export function activate(context: ExtensionContext) {
 								}
 							}
 						});
+					});
+					languageClient.onRequest(ExecuteClientCommandRequest.type, (params) => {
+						return commands.executeCommand(params.command, ...params.arguments);
 					});
 					commands.registerCommand(Commands.OPEN_OUTPUT, () => {
 						languageClient.outputChannel.show(ViewColumn.Three);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { RequestType, NotificationType, TextDocumentIdentifier} from 'vscode-languageclient';
+import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams } from 'vscode-languageclient';
 import { Command } from 'vscode';
 
 /**
@@ -94,4 +94,8 @@ export namespace ActionableNotification {
 
 export namespace CompileWorkspaceRequest {
     export const type = new RequestType<boolean, CompileWorkspaceStatus, void, void>('java/buildWorkspace');
+}
+
+export namespace ExecuteClientCommandRequest {
+    export const type = new RequestType<ExecuteCommandParams, any, void, void>("workspace/executeClientCommand");
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -97,5 +97,5 @@ export namespace CompileWorkspaceRequest {
 }
 
 export namespace ExecuteClientCommandRequest {
-    export const type = new RequestType<ExecuteCommandParams, any, void, void>("workspace/executeClientCommand");
+    export const type = new RequestType<ExecuteCommandParams, any, void, void>('workspace/executeClientCommand');
 }


### PR DESCRIPTION
This is the other half of https://github.com/eclipse/eclipse.jdt.ls/pull/596

It adds client-side handling for `workspace/executeCommand` request. This allows the language server to request command execution on the client-side.

It fits in with the discussion here: https://github.com/eclipse/eclipse.jdt.ls/issues/595