### PR TITLE
[Discussion] [Live Share] Restricting language services on file scheme

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,6 @@ export function activate(context: ExtensionContext) {
 				let languageClient = new LanguageClient('java', 'Language Support for Java', serverOptions, clientOptions);
 				languageClient.registerProposedFeatures();
 				languageClient.onReady().then(() => {
-					toggleItem(window.activeTextEditor, item);
 					languageClient.onNotification(StatusNotification.type, (report) => {
 						switch (report.type) {
 							case 'Started':
@@ -242,7 +241,8 @@ export function activate(context: ExtensionContext) {
 				// client can be deactivated on extension deactivation
 				context.subscriptions.push(disposable);
 				context.subscriptions.push(onConfigurationChange());
-
+				toggleItem(window.activeTextEditor, item);
+				
 				function applyWorkspaceEdit(obj) {
 					let edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(obj);
 					if (edit) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -242,7 +242,7 @@ export function activate(context: ExtensionContext) {
 				context.subscriptions.push(disposable);
 				context.subscriptions.push(onConfigurationChange());
 				toggleItem(window.activeTextEditor, item);
-				
+
 				function applyWorkspaceEdit(obj) {
 					let edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(obj);
 					if (edit) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ export function activate(context: ExtensionContext) {
 					// Register the server for java
 					documentSelector: [
 						{ scheme: 'file', language: 'java' },
+						{ scheme: 'jdt', language: 'java' },
 						{ scheme: 'untitled', language: 'java' }
 					],
 					synchronize: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,10 @@ export function activate(context: ExtensionContext) {
 				// Options to control the language client
 				let clientOptions: LanguageClientOptions = {
 					// Register the server for java
-					documentSelector: ['java'],
+					documentSelector: [
+						{ scheme: 'file', language: 'java' },
+						{ scheme: 'untitled', language: 'java' }
+					],
 					synchronize: {
 						configurationSection: 'java',
 						// Notify the server about file changes to .java and project/build files contained in the workspace
@@ -82,6 +85,7 @@ export function activate(context: ExtensionContext) {
 				let languageClient = new LanguageClient('java', 'Language Support for Java', serverOptions, clientOptions);
 				languageClient.registerProposedFeatures();
 				languageClient.onReady().then(() => {
+					toggleItem(window.activeTextEditor, item);
 					languageClient.onNotification(StatusNotification.type, (report) => {
 						switch (report.type) {
 							case 'Started':
@@ -237,7 +241,6 @@ export function activate(context: ExtensionContext) {
 				// client can be deactivated on extension deactivation
 				context.subscriptions.push(disposable);
 				context.subscriptions.push(onConfigurationChange());
-				toggleItem(window.activeTextEditor, item);
 
 				function applyWorkspaceEdit(obj) {
 					let edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(obj);


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](http://aka.ms/vsls) adding support for "guests" to receive remote language services for Java, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a Java project using Live Share, and doesn't have this extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Java extension installed. Additionally, this wouldn't impact the "local" Java development experience.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*