### PR TITLE
Second argument is replaced upon completing the first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following settings are supported:
 * `java.completion.favoriteStaticMembers` : Defines a list of static members or types with static members.
 * `java.completion.importOrder` : Defines the sorting order of import statements.
 * `java.progressReports.enabled` : [Experimental] Enable/disable progress reports from background processes on the server.
+* `java.completion.overwrite` : When set to true, code completion overwrites the current text. When set to false, code is simply added instead.
 
 Troubleshooting
 ===============

--- a/package.json
+++ b/package.json
@@ -182,6 +182,12 @@
           "description": "Enable/disable the 'auto build'",
           "scope": "window"
         },
+        "java.completion.overwrite": {
+          "type": "boolean",
+          "default": true,
+          "description": "When set to true, code completion overwrites the current text. When set to false, code is simply added instead.",
+          "scope": "window"
+        },
         "java.completion.favoriteStaticMembers": {
           "type": "array",
           "description": "Defines a list of static members or types with static members. Content assist will propose those static members even if the import is missing.",


### PR DESCRIPTION
Fixes #462 
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/619

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>