### PR TITLE
Add support for external Eclipse formatter settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ The following settings are supported:
 * `java.completion.importOrder` : Defines the sorting order of import statements.
 * `java.progressReports.enabled` : [Experimental] Enable/disable progress reports from background processes on the server.
 * `java.completion.overwrite` : When set to true, code completion overwrites the current text. When set to false, code is simply added instead.
+* `java.format.settings.url` : Specifies the url or file path to the formatter xml file.
+* `java.format.settings.profile` : Specifies the formatter profile name.
+* `java.format.comments.enabled` : Includes the comments during the formatting.
 
 Troubleshooting
 ===============

--- a/package.json
+++ b/package.json
@@ -217,6 +217,24 @@
           "description": "[Experimental] Enable/disable progress reports from background processes on the server.",
           "default": true,
           "scope": "window"
+        },
+        "java.format.settings.url": {
+          "type": "string",
+          "description": "Specifies the url or file path to the formatter xml file.",
+          "default": null,
+          "scope": "window"
+        },
+        "java.format.settings.profile": {
+          "type": "string",
+          "description": "Specifies the formatter profile name.",
+          "default": null,
+          "scope": "window"
+        },
+        "java.format.comments.enabled": {
+          "type": "boolean",
+          "description": "Includes the comments during the formatting.",
+          "default": true,
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
Fixes #2 
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/640

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>