### PR TITLE
Autocompletion should return javadoc in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following settings are supported:
 
 *New in 0.25.0:*
 * `java.format.onType.enabled` : Enable/disable on-type formatting (triggered on `;`, `}` or `<return>`).
+* `java.completion.documentation.markdown` : Returns javadoc in Markdown during autocompletion.
 
 
 Troubleshooting

--- a/package.json
+++ b/package.json
@@ -243,6 +243,12 @@
           "description": "Enable/disable automatic block formatting when typing `;`, `<enter>` or `}`",
           "default": true,
           "scope": "window"
+        },
+        "java.completion.documentation.markdown" : {
+          "type": "boolean",
+          "description": "Returns javadoc in Markdown during autocompletion.",
+          "default": true,
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
Fixes https://github.com/eclipse/eclipse.jdt.ls/issues/654
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/666

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>