### PR TITLE
disable organize imports to be shown in the output channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
       "editor/context": [
         {
           "command": "java.edit.organizeImports",
-          "when": "resourceLangId == java",
+          "when": "editorLangId == java",
           "group": "1_javaactions"
         },
         {


### PR DESCRIPTION
fix #539 