### PR TITLE
Adopt the send notification to avoid deadlock.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { collectionJavaExtensions } from './plugin';
 import { prepareExecutable, awaitServerConnection } from './javaServerStarter';
 import * as requirements from './requirements';
 import { Commands } from './commands';
-import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, ActionableMessage, CompileWorkspaceRequest, CompileWorkspaceStatus, ProgressReportNotification, ExecuteClientCommandRequest } from './protocol';
+import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, ActionableMessage, CompileWorkspaceRequest, CompileWorkspaceStatus, ProgressReportNotification, ExecuteClientCommandRequest, SendNotificationRequest } from './protocol';
 
 let oldConfig;
 let lastStatus;
@@ -157,6 +157,11 @@ export function activate(context: ExtensionContext) {
 					languageClient.onRequest(ExecuteClientCommandRequest.type, (params) => {
 						return commands.executeCommand(params.command, ...params.arguments);
 					});
+
+					languageClient.onRequest(SendNotificationRequest.type, (params) => {
+						return commands.executeCommand(params.command, ...params.arguments);
+					});
+
 					commands.registerCommand(Commands.OPEN_OUTPUT, () => {
 						languageClient.outputChannel.show(ViewColumn.Three);
 					});

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -99,3 +99,8 @@ export namespace CompileWorkspaceRequest {
 export namespace ExecuteClientCommandRequest {
     export const type = new RequestType<ExecuteCommandParams, any, void, void>('workspace/executeClientCommand');
 }
+
+
+export namespace SendNotificationRequest {
+    export const type = new RequestType<ExecuteCommandParams, any, void, void>('workspace/notify');
+}


### PR DESCRIPTION
We have deadlock issue when installed both vscode-lombok & vscode-java-test: 
https://github.com/Microsoft/vscode-java-test/issues/260
And potential related issue: https://github.com/redhat-developer/vscode-java/issues/627

Adopt this https://github.com/eclipse/eclipse.jdt.ls/pull/779/files to client to avoid deadlock.

@fbricon 