### PR TITLE
Create a launch configuration for eclipse/eclipse.jdt.ls/pull/799

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,20 @@
 			"preLaunchTask": "npm: watch"
 		},
 		{
+			"name": "Launch Extension - JDTLS Client",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [ "${workspaceRoot}/out/src/**" ],
+			"env": {
+				"JDTLS_CLIENT_PORT": "5036"
+			},
+			"preLaunchTask": "npm: watch"
+		},
+		{
 			"name": "Launch Tests",
 			"type": "extensionHost",
 			"request": "launch",


### PR DESCRIPTION
Fixes #645 
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/799

To debug JDT.LS in Eclipse, you have to do the following:

- start the jdt.ls.socket-stream launch configuration in Eclipse
- start the Launch Extension - JDTLS Client in VS Code

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>