### PR TITLE
Add new command to clean the server workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following commands are available:
 - `Java:Force Java compilation` (`Shift+Alt+B`): manually triggers compilation of the workspace.
 - `Java:Organize imports` (`Shift+Alt+O`): Organize imports in the currently opened Java file.
 - `Java:Open Java formatter settings`: Open the Eclipse formatter settings. Creates a new settings file if none exists.
+- `Java:Clean the Java language server workspace`: Clean the Java language server workspace.
 
 Supported VS Code settings
 ==========================
@@ -89,6 +90,9 @@ The following settings are supported:
 * `java.format.onType.enabled` : Enable/disable on-type formatting (triggered on `;`, `}` or `<return>`).
 * `java.completion.guessMethodArguments` : When set to true, method arguments are guessed when a method is selected from as list of code assist proposals.
 * `java.completion.enabled` : Enable/disable code completion support.
+
+*New in 0.33.0:*
+* `java.clean.workspace` : Clean the Java language server workspace.
 
 
 Troubleshooting

--- a/package.json
+++ b/package.json
@@ -283,6 +283,11 @@
         "command": "java.open.formatter.settings",
         "title": "Open Java formatter settings",
         "category": "Java"
+      },
+      {
+        "command": "java.clean.workspace",
+        "title": "Clean the Java language server workspace",
+        "category": "Java"
       }
     ],
     "keybindings": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -82,4 +82,8 @@ export namespace Commands {
      * Open Java formatter settings
      */
     export const OPEN_FORMATTER = 'java.open.formatter.settings';
+    /**
+     * Clean the Java language server workspace
+     */
+    export const CLEAN_WORKSPACE = 'java.clean.workspace';
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -36,7 +36,8 @@ suite('Java Language Extension', () => {
 				Commands.OPEN_SERVER_LOG,
 				Commands.COMPILE_WORKSPACE,
 				Commands.EDIT_ORGANIZE_IMPORTS,
-				Commands.OPEN_FORMATTER
+				Commands.OPEN_FORMATTER,
+				Commands.CLEAN_WORKSPACE
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Fixes #655 

@fbricon  I have tried to use your algorithm, but it doesn't work on Windows.
VS Code closes the connection and throws an exception after languageClient.stop().
I have done it in the following way:

- a user calls the java.clean.workspace command
- the command creates the .cleanWorkspace file in the workspace root and reloads VS Code
- when starting the Java LS client, we check if .cleanWorkspace exists, and if it does, remove the workspace directory

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>