### PR TITLE
Add mockito as static imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,10 @@
             "org.junit.jupiter.api.Assertions.*",
             "org.junit.jupiter.api.Assumptions.*",
             "org.junit.jupiter.api.DynamicContainer.*",
-            "org.junit.jupiter.api.DynamicTest.*"
+            "org.junit.jupiter.api.DynamicTest.*",
+            "org.mockito.Mockito.*",
+            "org.mockito.ArgumentMatchers.*",
+            "org.mockito.Answers.*"            
           ],
           "scope": "window"
         },


### PR DESCRIPTION

[Mockito](https://site.mockito.org/) is a very widely used mocking framework for java. Just like JUnit itself, it promotes using static imports for many of its features.

This PR adds some common Mockito static imports so you can easily import them
![screenshot 2018-10-18 at 08 58 04](https://user-images.githubusercontent.com/933880/47136493-1bf83e00-d2b4-11e8-8b9a-b033cfc02b41.png)