### PR TITLE
Add context menu to update source attachment for the binary classfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -346,7 +346,7 @@
         },
         {
           "command": "java.project.updateSourceAttachment",
-          "when": "false == true"
+          "when": "false"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
       },
       {
         "command": "java.project.updateSourceAttachment",
-        "title": "Update Source Attachment",
+        "title": "Attach Source",
         "category": "Java"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -291,6 +291,11 @@
         "command": "java.clean.workspace",
         "title": "Clean the Java language server workspace",
         "category": "Java"
+      },
+      {
+        "command": "java.project.updateSourceAttachment",
+        "title": "Update Source Attachment",
+        "category": "Java"
       }
     ],
     "keybindings": [
@@ -324,6 +329,11 @@
           "group": "1_javaactions"
         },
         {
+          "command": "java.project.updateSourceAttachment",
+          "when": "editorReadonly && editorLangId == java",
+          "group": "1_javaactions"
+        },
+        {
           "command": "java.projectConfiguration.update",
           "when": "resourceFilename =~ /(.*\\.gradle)|(pom.xml)$/",
           "group": "1_javaactions"
@@ -333,6 +343,10 @@
         {
           "command": "java.edit.organizeImports",
           "when": "!editorReadonly && editorLangId == java"
+        },
+        {
+          "command": "java.project.updateSourceAttachment",
+          "when": "false == true"
         }
       ]
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -86,4 +86,12 @@ export namespace Commands {
      * Clean the Java language server workspace
      */
     export const CLEAN_WORKSPACE = 'java.clean.workspace';
+    /**
+     * Update the source attachment for the selected class file
+     */
+    export const UPDATE_SOURCE_ATTACHMENT = 'java.project.updateSourceAttachment';
+    /**
+     * Resolve the source attachment information for the selected class file
+     */
+    export const RESOLVE_SOURCE_ATTACHMENT = 'java.project.resolveSourceAttachment';
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -104,3 +104,20 @@ export namespace ExecuteClientCommandRequest {
 export namespace SendNotificationRequest {
     export const type = new RequestType<ExecuteCommandParams, any, void, void>('workspace/notify');
 }
+
+export interface SourceAttachmentRequest {
+    classFileUri: string;
+    attributes?: SourceAttachmentAttribute;
+}
+
+export interface SourceAttachmentResult {
+    errorMessage?: string;
+    attributes?: SourceAttachmentAttribute;
+}
+
+export interface SourceAttachmentAttribute {
+    jarPath?: string;
+    sourceAttachmentPath?: string;
+    sourceAttachmentEncoding?: string;
+    canEditEncoding?: boolean;
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -37,7 +37,8 @@ suite('Java Language Extension', () => {
 				Commands.COMPILE_WORKSPACE,
 				Commands.EDIT_ORGANIZE_IMPORTS,
 				Commands.OPEN_FORMATTER,
-				Commands.CLEAN_WORKSPACE
+				Commands.CLEAN_WORKSPACE,
+				Commands.UPDATE_SOURCE_ATTACHMENT
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It fixes the bug https://github.com/redhat-developer/vscode-java/issues/233 (Add ability to attach missing source). This PR will enable the context menu `Update Source Attachment` on the jdt content provider. See the peer PR on eclipse.jdt.ls https://github.com/eclipse/eclipse.jdt.ls/pull/837