### PR TITLE
Use common VSCode UI for organize imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ The following commands are available:
 - `Java:Update Project configuration` (`Shift+Alt+U`):  is available when the editor is focused on a Maven pom.xml or a Gradle file. It forces project configuration / classpath updates (eg. dependency changes or Java compilation level), according to the project build descriptor.
 - `Java:Open Java Language Server log file`: opens the Java Language Server log file, useful for troubleshooting problems.
 - `Java:Force Java compilation` (`Shift+Alt+B`): manually triggers compilation of the workspace.
-- `Java:Organize imports` (`Shift+Alt+O`): Organize imports in the currently opened Java file.
 - `Java:Open Java formatter settings`: Open the Eclipse formatter settings. Creates a new settings file if none exists.
 - `Java:Clean the Java language server workspace`: Clean the Java language server workspace.
-
-*New in 0.34.0:*
 - `Java:Attach Source`: Attach a jar/zip source to the currently opened binary class file. This command is only available in the editor context menu.
+
+*Changes in 0.35.0:*
+- `Java:Organize imports` command has been removed from the editor context menu. It is now a code action item of the standard context menu `Source Action...`. Its default shortcut (`Shift+Alt+O`) is unchanged. See this [link](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions) about how to customize keybindings for code actions.
+
 
 Supported VS Code settings
 ==========================

--- a/package.json
+++ b/package.json
@@ -278,11 +278,6 @@
         "category": "Java"
       },
       {
-        "command": "java.edit.organizeImports",
-        "title": "Organize Imports",
-        "category": "Java"
-      },
-      {
         "command": "java.open.formatter.settings",
         "title": "Open Java formatter settings",
         "category": "Java"
@@ -305,11 +300,6 @@
         "when": "editorFocus"
       },
       {
-        "command": "java.edit.organizeImports",
-        "key": "shift+alt+o",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == java"
-      },
-      {
         "command": "java.workspace.compile",
         "key": "shift+alt+b"
       }
@@ -324,11 +314,6 @@
       ],
       "editor/context": [
         {
-          "command": "java.edit.organizeImports",
-          "when": "editorLangId == java",
-          "group": "1_javaactions"
-        },
-        {
           "command": "java.project.updateSourceAttachment",
           "when": "editorReadonly && editorLangId == java",
           "group": "1_javaactions"
@@ -340,10 +325,6 @@
         }
       ],
       "commandPalette": [
-        {
-          "command": "java.edit.organizeImports",
-          "when": "!editorReadonly && editorLangId == java"
-        },
         {
           "command": "java.project.updateSourceAttachment",
           "when": "false"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -75,10 +75,6 @@ export namespace Commands {
     export const OPEN_SERVER_LOG = 'java.open.serverLog';
 
     /**
-     * Organize Java file imports command from language server
-     */
-    export const EDIT_ORGANIZE_IMPORTS = 'java.edit.organizeImports';
-    /**
      * Open Java formatter settings
      */
     export const OPEN_FORMATTER = 'java.open.formatter.settings';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,16 +212,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						applyWorkspaceEdit(obj, languageClient);
 					});
 
-					commands.registerCommand(Commands.EDIT_ORGANIZE_IMPORTS, async () => {
-						let activeEditor = window.activeTextEditor;
-						if (!activeEditor || !activeEditor.document || activeEditor.document.languageId !== 'java') {
-							return;
-						}
-						if (activeEditor.document.uri instanceof Uri) {
-							await <any>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.EDIT_ORGANIZE_IMPORTS, activeEditor.document.uri.toString());
-						}
-					});
-
 					commands.registerCommand(Commands.EXECUTE_WORKSPACE_COMMAND, (command, ...rest) => {
 						const params: ExecuteCommandParams = {
 							command,

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -35,7 +35,6 @@ suite('Java Language Extension', () => {
 				Commands.EXECUTE_WORKSPACE_COMMAND,
 				Commands.OPEN_SERVER_LOG,
 				Commands.COMPILE_WORKSPACE,
-				Commands.EDIT_ORGANIZE_IMPORTS,
 				Commands.OPEN_FORMATTER,
 				Commands.CLEAN_WORKSPACE,
 				Commands.UPDATE_SOURCE_ATTACHMENT


### PR DESCRIPTION
Fixes #513 

depends on https://github.com/eclipse/eclipse.jdt.ls/pull/856