### PR TITLE
Add command to add/remove/list the project's source path

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,6 +298,21 @@
         "command": "java.project.updateSourceAttachment",
         "title": "Attach Source",
         "category": "Java"
+      },
+      {
+        "command": "java.project.addToSourcePath",
+        "title": "Add Folder to Java Source Path",
+        "category": "Java"
+      },
+      {
+        "command": "java.project.removeFromSourcePath",
+        "title": "Remove Folder from Java Source Path",
+        "category": "Java"
+      },
+      {
+        "command": "java.project.listSourcePaths",
+        "title": "List all Java source paths",
+        "category": "Java"
       }
     ],
     "keybindings": [
@@ -317,6 +332,16 @@
           "command": "java.projectConfiguration.update",
           "when": "resourceFilename =~ /(.*\\.gradle)|(pom.xml)$/",
           "group": "1_javaactions"
+        },
+        {
+          "when": "explorerResourceIsFolder&&javaLSReady",
+          "command": "java.project.addToSourcePath",
+          "group": "1_javaactions@1"
+        },
+        {
+          "when": "explorerResourceIsFolder&&javaLSReady",
+          "command": "java.project.removeFromSourcePath",
+          "group": "1_javaactions@2"
         }
       ],
       "editor/context": [
@@ -334,6 +359,14 @@
       "commandPalette": [
         {
           "command": "java.project.updateSourceAttachment",
+          "when": "false"
+        },
+        {
+          "command": "java.project.addToSourcePath",
+          "when": "false"
+        },
+        {
+          "command": "java.project.removeFromSourcePath",
           "when": "false"
         }
       ]

--- a/src/buildpath.ts
+++ b/src/buildpath.ts
@@ -1,0 +1,58 @@
+'use strict';
+
+import { window, commands, Uri } from 'vscode';
+import { Commands } from './commands';
+
+interface Result {
+    status: boolean;
+    message: string;
+}
+
+interface SourcePath {
+    path: string;
+    displayPath: string;
+    projectName: string;
+    projectType: string;
+}
+
+interface ListCommandResult extends Result {
+    data?: SourcePath[];
+}
+
+export function registerCommands() {
+    commands.registerCommand(Commands.ADD_TO_SOURCEPATH, async (uri: Uri) => {
+        const result = await <any>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.ADD_TO_SOURCEPATH, uri.toString());
+        if (result.status) {
+            window.showInformationMessage(result.message ? result.message : "Successfully added the folder to the source path.");
+        } else {
+            window.showErrorMessage(result.message);
+        }
+    });
+
+    commands.registerCommand(Commands.REMOVE_FROM_SOURCEPATH, async (uri: Uri) => {
+        const result = await <any>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.REMOVE_FROM_SOURCEPATH, uri.toString());
+        if (result.status) {
+            window.showInformationMessage(result.message ? result.message : "Successfully removed the folder from the source path.");
+        } else {
+            window.showErrorMessage(result.message);
+        }
+    });
+
+    commands.registerCommand(Commands.LIST_SOURCEPATHS, async() => {
+        const result: ListCommandResult = await commands.executeCommand<ListCommandResult>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.LIST_SOURCEPATHS);
+        if (result.status) {
+            if (!result.data || !result.data.length) {
+                window.showInformationMessage("No Java source directories found in the workspace, please use the command 'Add Folder to Java Source Path' first.");
+            } else {
+                window.showQuickPick(result.data.map(sourcePath => {
+                    return {
+                        label: sourcePath.displayPath,
+                        detail: `$(file-directory) ${sourcePath.projectType} Project: ${sourcePath.projectName}`, 
+                    };
+                }), { placeHolder: "All Java source directories recognized by the workspace."});
+            }
+        } else {
+            window.showErrorMessage(result.message);
+        }
+    });
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -90,4 +90,16 @@ export namespace Commands {
      * Resolve the source attachment information for the selected class file
      */
     export const RESOLVE_SOURCE_ATTACHMENT = 'java.project.resolveSourceAttachment';
+    /**
+     * Mark the folder as the source root of the closest project.
+     */
+    export const ADD_TO_SOURCEPATH = 'java.project.addToSourcePath';
+    /**
+     * Unmark the folder as the source root of the project.
+     */
+    export const REMOVE_FROM_SOURCEPATH = 'java.project.removeFromSourcePath';
+    /**
+     * List all recognized source roots in the workspace.
+     */
+    export const LIST_SOURCEPATHS = 'java.project.listSourcePaths';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { Commands } from './commands';
 import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, ActionableMessage, CompileWorkspaceRequest, CompileWorkspaceStatus, ProgressReportNotification, ExecuteClientCommandRequest, SendNotificationRequest,
 SourceAttachmentRequest, SourceAttachmentResult, SourceAttachmentAttribute } from './protocol';
 import { ExtensionAPI } from './extension.api';
+import * as buildpath from './buildpath';
 import * as net from 'net';
 
 let oldConfig;
@@ -113,6 +114,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								item.text = '$(thumbsup)';
 								p.report({ message: 'Finished' });
 								lastStatus = item.text;
+								commands.executeCommand('setContext', 'javaLSReady', true);
 								resolve({
 									apiVersion: '0.1',
 									javaRequirement: requirements,
@@ -283,6 +285,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 							return true;
 						}
 					});
+
+					buildpath.registerCommands();
 
 					window.onDidChangeActiveTextEditor((editor) => {
 						toggleItem(editor, item);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -37,7 +37,10 @@ suite('Java Language Extension', () => {
 				Commands.COMPILE_WORKSPACE,
 				Commands.OPEN_FORMATTER,
 				Commands.CLEAN_WORKSPACE,
-				Commands.UPDATE_SOURCE_ATTACHMENT
+				Commands.UPDATE_SOURCE_ATTACHMENT,
+				Commands.ADD_TO_SOURCEPATH,
+				Commands.REMOVE_FROM_SOURCEPATH,
+				Commands.LIST_SOURCEPATHS,
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

This is for feature https://github.com/redhat-developer/vscode-java/issues/619, it provides the UI to operate the project's source path.
- Add Folder to Java Source Path (context menu)
- Remove Folder from Java Source Path (context menu)
- List all Java source paths (command palette)

Fixes #619 