### PR TITLE
Enable Source Action 'Override/Implement Methods' with prompt

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -102,4 +102,8 @@ export namespace Commands {
      * List all recognized source roots in the workspace.
      */
     export const LIST_SOURCEPATHS = 'java.project.listSourcePaths';
+    /**
+     * Override or implements the methods from the supertypes.
+     */
+    export const OVERRIDE_METHODS_PROMPT = 'java.action.overrideMethodsPrompt';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdat
 SourceAttachmentRequest, SourceAttachmentResult, SourceAttachmentAttribute } from './protocol';
 import { ExtensionAPI } from './extension.api';
 import * as buildpath from './buildpath';
+import * as sourceAction from './sourceAction';
 import * as net from 'net';
 import { getJavaConfiguration } from './utils';
 import { onConfigurationChange, excludeProjectSettingsFiles } from './settings';
@@ -72,7 +73,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						settings: { java: getJavaConfiguration() },
 						extendedClientCapabilities:{
 							progressReportProvider: getJavaConfiguration().get('progressReports.enabled'),
-							classFileContentsSupport:true
+							classFileContentsSupport:true,
+							overrideMethodsPromptSupport:true
 						},
 						triggerFiles: getTriggerFiles()
 					},
@@ -286,6 +288,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 					});
 
 					buildpath.registerCommands();
+					sourceAction.registerCommands(languageClient);
 
 					window.onDidChangeActiveTextEditor((editor) => {
 						toggleItem(editor, item);
@@ -623,7 +626,7 @@ async function addFormatter(extensionPath, formatterUrl, defaultFormatter, relat
 	});
 }
 
-async function applyWorkspaceEdit(obj, languageClient) {
+export async function applyWorkspaceEdit(obj, languageClient) {
 	let edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(obj);
 	if (edit) {
 		await workspace.applyEdit(edit);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams } from 'vscode-languageclient';
+import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams, CodeActionParams, WorkspaceEdit } from 'vscode-languageclient';
 import { Command } from 'vscode';
 
 /**
@@ -120,4 +120,31 @@ export interface SourceAttachmentAttribute {
     sourceAttachmentPath?: string;
     sourceAttachmentEncoding?: string;
     canEditEncoding?: boolean;
+}
+
+export interface OverridableMethod {
+    key: string;
+    name: string;
+    parameters: string[];
+    unimplemented: boolean;
+    declaringClass: string;
+    declaringClassType: string;
+}
+
+export interface OverridableMethodsResponse {
+	type: string;
+	methods: OverridableMethod[];
+}
+
+export namespace OverridableMethodsRequest {
+    export const type = new RequestType<CodeActionParams, OverridableMethodsResponse, void, void>('java/overridableMethods');
+}
+
+export interface AddOverridableMethodParams {
+    context: CodeActionParams;
+    overridableMethods: OverridableMethod[];
+}
+
+export namespace AddOverridableMethodsRequest {
+    export const type = new RequestType<AddOverridableMethodParams, WorkspaceEdit, void, void>('java/addOverridableMethods');
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -136,8 +136,8 @@ export interface OverridableMethodsResponse {
 	methods: OverridableMethod[];
 }
 
-export namespace OverridableMethodsRequest {
-    export const type = new RequestType<CodeActionParams, OverridableMethodsResponse, void, void>('java/overridableMethods');
+export namespace ListOverridableMethodsRequest {
+    export const type = new RequestType<CodeActionParams, OverridableMethodsResponse, void, void>('java/listOverridableMethods');
 }
 
 export interface AddOverridableMethodParams {

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -1,0 +1,54 @@
+'use strict';
+
+import { commands, window } from 'vscode';
+import { CodeActionParams, LanguageClient } from 'vscode-languageclient';
+import { Commands } from './commands';
+import { applyWorkspaceEdit } from './extension';
+import { OverridableMethodsRequest, AddOverridableMethodsRequest } from './protocol';
+
+export function registerCommands(languageClient: LanguageClient) {
+    commands.registerCommand(Commands.OVERRIDE_METHODS_PROMPT, async (params: CodeActionParams) => {
+        const result = await languageClient.sendRequest(OverridableMethodsRequest.type, params);
+        if (!result || !result.methods || !result.methods.length) {
+            window.showWarningMessage('No overridable methods found in the super type.');
+            return;
+        }
+
+        result.methods.sort((a, b) => {
+            const declaringClass = a.declaringClass.localeCompare(b.declaringClass);
+            if (declaringClass !== 0) {
+                return declaringClass;
+            }
+
+            const methodName = a.name.localeCompare(b.name);
+            if (methodName !== 0) {
+                return methodName;
+            }
+
+            return a.parameters.length - b.parameters.length;
+        });
+
+        const quickPickItems = result.methods.map(method => {
+            return {
+                label: `${method.name}(${method.parameters.join(',')})`,
+                description: `${method.declaringClassType}: ${method.declaringClass}`,
+                picked: method.unimplemented,
+                originalMethod: method,
+            };
+        });
+
+        const selectedItems = await window.showQuickPick(quickPickItems, {
+            canPickMany: true,
+            placeHolder: `Select methods to override or implement in ${result.type}`
+        });
+        if (!selectedItems.length) {
+            return;
+        }
+
+        const workspaceEdit = await languageClient.sendRequest(AddOverridableMethodsRequest.type, {
+            context: params,
+            overridableMethods: selectedItems.map((item) => item.originalMethod),
+        });
+        applyWorkspaceEdit(workspaceEdit, languageClient);
+    });
+}

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -4,11 +4,11 @@ import { commands, window } from 'vscode';
 import { CodeActionParams, LanguageClient } from 'vscode-languageclient';
 import { Commands } from './commands';
 import { applyWorkspaceEdit } from './extension';
-import { OverridableMethodsRequest, AddOverridableMethodsRequest } from './protocol';
+import { ListOverridableMethodsRequest, AddOverridableMethodsRequest } from './protocol';
 
 export function registerCommands(languageClient: LanguageClient) {
     commands.registerCommand(Commands.OVERRIDE_METHODS_PROMPT, async (params: CodeActionParams) => {
-        const result = await languageClient.sendRequest(OverridableMethodsRequest.type, params);
+        const result = await languageClient.sendRequest(ListOverridableMethodsRequest.type, params);
         if (!result || !result.methods || !result.methods.length) {
             window.showWarningMessage('No overridable methods found in the super type.');
             return;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -41,6 +41,7 @@ suite('Java Language Extension', () => {
 				Commands.ADD_TO_SOURCEPATH,
 				Commands.REMOVE_FROM_SOURCEPATH,
 				Commands.LIST_SOURCEPATHS,
+				Commands.OVERRIDE_METHODS_PROMPT,
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It uses quick pick to list all possibles overridable methods from super types. And select the unimplemented methods by default.

![override_implement](https://user-images.githubusercontent.com/14052197/50200904-de3a9300-0392-11e9-9a23-ca06fe35cd8f.gif)
