### PR TITLE
Changing "JDK 8" to just "JDK" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Supported VS Code settings
 ==========================
 The following settings are supported:
 
-* `java.home` : Absolute path to JDK 8 home folder used to launch the Java Language Server. Requires VS Code restart.
+* `java.home` : Absolute path to JDK home folder used to launch the Java Language Server. Requires VS Code restart.
 * `java.jdt.ls.vmargs` : Extra VM arguments used to launch the Java Language Server. Requires VS Code restart.
 * `java.configuration.updateBuildConfiguration` : Specifies how modifications on build files update the Java classpath/configuration. Supported values are `disabled` (nothing happens), `interactive` (asks about updating on every modification), `automatic` (updating is automatically triggered).
 * `java.errors.incompleteClasspath.severity` : Specifies the severity of the message when the classpath is incomplete for a Java file. Supported values are `ignore`, `info`, `warning`, `error`.


### PR DESCRIPTION
I Just found out JDK 11 is fully compatible so i used "java.home" with my JDK 11 folder and it works with no problems. That's why i'm doing this fix in the README