### PR TITLE
API that is returning Disposable should be added to subscriptions extension's context

### DIFF
--- a/src/buildpath.ts
+++ b/src/buildpath.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { window, commands, Uri } from 'vscode';
+import { window, commands, ExtensionContext, Uri } from 'vscode';
 import { Commands } from './commands';
 
 interface Result {
@@ -19,26 +19,26 @@ interface ListCommandResult extends Result {
     data?: SourcePath[];
 }
 
-export function registerCommands() {
-    commands.registerCommand(Commands.ADD_TO_SOURCEPATH, async (uri: Uri) => {
+export function registerCommands(context: ExtensionContext) {
+    context.subscriptions.push(commands.registerCommand(Commands.ADD_TO_SOURCEPATH, async (uri: Uri) => {
         const result = await <any>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.ADD_TO_SOURCEPATH, uri.toString());
         if (result.status) {
             window.showInformationMessage(result.message ? result.message : 'Successfully added the folder to the source path.');
         } else {
             window.showErrorMessage(result.message);
         }
-    });
+    }));
 
-    commands.registerCommand(Commands.REMOVE_FROM_SOURCEPATH, async (uri: Uri) => {
+    context.subscriptions.push(commands.registerCommand(Commands.REMOVE_FROM_SOURCEPATH, async (uri: Uri) => {
         const result = await <any>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.REMOVE_FROM_SOURCEPATH, uri.toString());
         if (result.status) {
             window.showInformationMessage(result.message ? result.message : 'Successfully removed the folder from the source path.');
         } else {
             window.showErrorMessage(result.message);
         }
-    });
+    }));
 
-    commands.registerCommand(Commands.LIST_SOURCEPATHS, async() => {
+    context.subscriptions.push(commands.registerCommand(Commands.LIST_SOURCEPATHS, async() => {
         const result: ListCommandResult = await commands.executeCommand<ListCommandResult>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.LIST_SOURCEPATHS);
         if (result.status) {
             if (!result.data || !result.data.length) {
@@ -54,5 +54,5 @@ export function registerCommands() {
         } else {
             window.showErrorMessage(result.message);
         }
-    });
+    }));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -190,39 +190,39 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						return commands.executeCommand(params.command, ...params.arguments);
 					});
 
-					commands.registerCommand(Commands.OPEN_OUTPUT, () => {
+					context.subscriptions.push(commands.registerCommand(Commands.OPEN_OUTPUT, () => {
 						languageClient.outputChannel.show(ViewColumn.Three);
-					});
-					commands.registerCommand(Commands.SHOW_JAVA_REFERENCES, (uri: string, position: LSPosition, locations: LSLocation[]) => {
+					}));
+					context.subscriptions.push(commands.registerCommand(Commands.SHOW_JAVA_REFERENCES, (uri: string, position: LSPosition, locations: LSLocation[]) => {
 						commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), languageClient.protocol2CodeConverter.asPosition(position), locations.map(languageClient.protocol2CodeConverter.asLocation));
-					});
-					commands.registerCommand(Commands.SHOW_JAVA_IMPLEMENTATIONS, (uri: string, position: LSPosition, locations: LSLocation[]) => {
+					}));
+					context.subscriptions.push(commands.registerCommand(Commands.SHOW_JAVA_IMPLEMENTATIONS, (uri: string, position: LSPosition, locations: LSLocation[]) => {
 						commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), languageClient.protocol2CodeConverter.asPosition(position), locations.map(languageClient.protocol2CodeConverter.asLocation));
-					});
+					}));
 
-					commands.registerCommand(Commands.CONFIGURATION_UPDATE, uri => projectConfigurationUpdate(languageClient, uri));
+					context.subscriptions.push(commands.registerCommand(Commands.CONFIGURATION_UPDATE, uri => projectConfigurationUpdate(languageClient, uri)));
 
-					commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH, (data?: any) => setIncompleteClasspathSeverity('ignore'));
+					context.subscriptions.push(commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH, (data?: any) => setIncompleteClasspathSeverity('ignore')));
 
-					commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH_HELP, (data?: any) => {
+					context.subscriptions.push(commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH_HELP, (data?: any) => {
 						commands.executeCommand(Commands.OPEN_BROWSER, Uri.parse('https://github.com/redhat-developer/vscode-java/wiki/%22Classpath-is-incomplete%22-warning'));
-					});
+					}));
 
-					commands.registerCommand(Commands.PROJECT_CONFIGURATION_STATUS, (uri, status) => setProjectConfigurationUpdate(languageClient, uri, status));
+					context.subscriptions.push(commands.registerCommand(Commands.PROJECT_CONFIGURATION_STATUS, (uri, status) => setProjectConfigurationUpdate(languageClient, uri, status)));
 
-					commands.registerCommand(Commands.APPLY_WORKSPACE_EDIT, (obj) => {
+					context.subscriptions.push(commands.registerCommand(Commands.APPLY_WORKSPACE_EDIT, (obj) => {
 						applyWorkspaceEdit(obj, languageClient);
-					});
+					}));
 
-					commands.registerCommand(Commands.EXECUTE_WORKSPACE_COMMAND, (command, ...rest) => {
+					context.subscriptions.push(commands.registerCommand(Commands.EXECUTE_WORKSPACE_COMMAND, (command, ...rest) => {
 						const params: ExecuteCommandParams = {
 							command,
 							arguments: rest
 						};
 						return languageClient.sendRequest(ExecuteCommandRequest.type, params);
-					});
+					}));
 
-					commands.registerCommand(Commands.COMPILE_WORKSPACE, (isFullCompile : boolean) => {
+					context.subscriptions.push(commands.registerCommand(Commands.COMPILE_WORKSPACE, (isFullCompile : boolean) => {
 						return window.withProgress({ location: ProgressLocation.Window }, async p => {
 							if (typeof isFullCompile !== 'boolean') {
 								const selection = await window.showQuickPick(['Incremental', 'Full'], {'placeHolder' : 'please choose compile type:'});
@@ -243,9 +243,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								}, humanVisibleDelay);
 							});
 						});
-					});
+					}));
 
-					commands.registerCommand(Commands.UPDATE_SOURCE_ATTACHMENT, async (classFileUri: Uri): Promise<boolean> => {
+					context.subscriptions.push(commands.registerCommand(Commands.UPDATE_SOURCE_ATTACHMENT, async (classFileUri: Uri): Promise<boolean> => {
 						const resolveRequest: SourceAttachmentRequest = {
 							classFileUri: classFileUri.toString(),
 						};
@@ -286,14 +286,14 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 							jdtEventEmitter.fire(classFileUri);
 							return true;
 						}
-					});
+					}));
 
-					buildpath.registerCommands();
-					sourceAction.registerCommands(languageClient);
+					buildpath.registerCommands(context);
+					sourceAction.registerCommands(languageClient, context);
 
-					window.onDidChangeActiveTextEditor((editor) => {
+					context.subscriptions.push(window.onDidChangeActiveTextEditor((editor) => {
 						toggleItem(editor, item);
-					});
+					}));
 
 					let provider: TextDocumentContentProvider = <TextDocumentContentProvider>{
 						onDidChange: jdtEventEmitter.event,
@@ -303,7 +303,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 							});
 						}
 					};
-					workspace.registerTextDocumentContentProvider('jdt', provider);
+					context.subscriptions.push(workspace.registerTextDocumentContentProvider('jdt', provider));
 					excludeProjectSettingsFiles();
 				});
 
@@ -318,12 +318,12 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 				languageClient.start();
 				// Register commands here to make it available even when the language client fails
-				commands.registerCommand(Commands.OPEN_SERVER_LOG, () => openServerLogFile(workspacePath));
+				context.subscriptions.push(commands.registerCommand(Commands.OPEN_SERVER_LOG, () => openServerLogFile(workspacePath)));
 
 				let extensionPath = context.extensionPath;
-				commands.registerCommand(Commands.OPEN_FORMATTER, async () => openFormatter(extensionPath));
+				context.subscriptions.push(commands.registerCommand(Commands.OPEN_FORMATTER, async () => openFormatter(extensionPath)));
 
-				commands.registerCommand(Commands.CLEAN_WORKSPACE, () => cleanWorkspace(workspacePath));
+				context.subscriptions.push(commands.registerCommand(Commands.CLEAN_WORKSPACE, () => cleanWorkspace(workspacePath)));
 
 				context.subscriptions.push(onConfigurationChange());
 				toggleItem(window.activeTextEditor, item);

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -1,18 +1,18 @@
 'use strict';
 
-import { commands, window } from 'vscode';
+import { commands, window, ExtensionContext } from 'vscode';
 import { CodeActionParams, LanguageClient } from 'vscode-languageclient';
 import { Commands } from './commands';
 import { applyWorkspaceEdit } from './extension';
 import { ListOverridableMethodsRequest, AddOverridableMethodsRequest, CheckHashCodeEqualsStatusRequest, GenerateHashCodeEqualsRequest } from './protocol';
 
-export function registerCommands(languageClient: LanguageClient) {
-    registerOverrideMethodsCommand(languageClient);
-    registerHashCodeEqualsCommand(languageClient);
+export function registerCommands(languageClient: LanguageClient, context: ExtensionContext) {
+    registerOverrideMethodsCommand(languageClient, context);
+    registerHashCodeEqualsCommand(languageClient, context);
 }
 
-function registerOverrideMethodsCommand(languageClient: LanguageClient): void {
-    commands.registerCommand(Commands.OVERRIDE_METHODS_PROMPT, async (params: CodeActionParams) => {
+function registerOverrideMethodsCommand(languageClient: LanguageClient, context: ExtensionContext): void {
+    context.subscriptions.push(commands.registerCommand(Commands.OVERRIDE_METHODS_PROMPT, async (params: CodeActionParams) => {
         const result = await languageClient.sendRequest(ListOverridableMethodsRequest.type, params);
         if (!result || !result.methods || !result.methods.length) {
             window.showWarningMessage('No overridable methods found in the super type.');
@@ -55,11 +55,11 @@ function registerOverrideMethodsCommand(languageClient: LanguageClient): void {
             overridableMethods: selectedItems.map((item) => item.originalMethod),
         });
         applyWorkspaceEdit(workspaceEdit, languageClient);
-    });
+    }));
 }
 
-function registerHashCodeEqualsCommand(languageClient: LanguageClient): void {
-    commands.registerCommand(Commands.HASHCODE_EQUALS_PROMPT, async (params: CodeActionParams) => {
+function registerHashCodeEqualsCommand(languageClient: LanguageClient, context: ExtensionContext): void {
+    context.subscriptions.push(commands.registerCommand(Commands.HASHCODE_EQUALS_PROMPT, async (params: CodeActionParams) => {
         const result = await languageClient.sendRequest(CheckHashCodeEqualsStatusRequest.type, params);
         if (!result || !result.fields || !result.fields.length) {
             window.showErrorMessage(`The operation is not applicable to the type ${result.type}.`);
@@ -98,5 +98,5 @@ function registerHashCodeEqualsCommand(languageClient: LanguageClient): void {
             regenerate
         });
         applyWorkspaceEdit(workspaceEdit, languageClient);
-    });
+    }));
 }


### PR DESCRIPTION
so they're disposed during the stop lifecycle of the plug-in. (and avoid duplicate handlers/ commands for example when restarting it)

handle it for 
- [x] registerCommand
- [x] workspace.registerTextDocumentContentProvider
- [x] and window.onDidChangeActiveTextEditor