### PR TITLE
Marginally improve failed Java home detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2344,7 +2344,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2759,7 +2760,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2815,6 +2817,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2858,12 +2861,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -109,5 +109,9 @@ export namespace Commands {
     /**
      * Generate hashCode() and equals().
      */
-    export const HASHCODE_EQUALS_PROMPT = 'java.action.hashCodeEqualsPrompt';
+	export const HASHCODE_EQUALS_PROMPT = 'java.action.hashCodeEqualsPrompt';
+	/**
+     * Open settings.json
+     */
+    export const OPEN_JSON_SETTINGS = 'workbench.action.openSettingsJson';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,8 +30,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 	return requirements.resolveRequirements().catch(error => {
 		//show error
 		window.showErrorMessage(error.message, error.label).then((selection) => {
-			if (error.label && error.label === selection && error.openUrl) {
-				commands.executeCommand(Commands.OPEN_BROWSER, error.openUrl);
+			if (error.label && error.label === selection && error.command) {
+				commands.executeCommand(error.command, error.commandParam);
 			}
 		});
 		// rethrow to disrupt the chain.

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -42,7 +42,8 @@ suite('Java Language Extension', () => {
 				Commands.REMOVE_FROM_SOURCEPATH,
 				Commands.LIST_SOURCEPATHS,
 				Commands.OVERRIDE_METHODS_PROMPT,
-				Commands.HASHCODE_EQUALS_PROMPT
+				Commands.HASHCODE_EQUALS_PROMPT,
+				Commands.OPEN_JSON_SETTINGS
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Fixes #835, #836  

- display detected path
- check if java home ends with `bin`
- opens settings.json if java.home preference is invalid