### PR TITLE
Exclude ParentProcessWatcher by default

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -64,6 +64,10 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 	if (vmargs.indexOf(encodingKey) < 0) {
 		params.push(encodingKey + getJavaEncoding());
 	}
+	const watchParentProcess = '-DwatchParentProcess=';
+	if (vmargs.indexOf(watchParentProcess) < 0) {
+		params.push(watchParentProcess + 'false');
+	}
 
 	parseVMargs(params, vmargs);
 	let server_home: string = path.resolve(__dirname, '../server');


### PR DESCRIPTION
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/961

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>