### PR TITLE
Support advanced organizeImports to resolve ambiguous imports

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -114,4 +114,12 @@ export namespace Commands {
      * Open settings.json
      */
     export const OPEN_JSON_SETTINGS = 'workbench.action.openSettingsJson';
+    /**
+     * Organize imports.
+     */
+    export const ORGANIZE_IMPORTS = "java.action.organizeImports";
+    /**
+     * Choose type to import.
+     */
+    export const CHOOSE_IMPORT = "java.action.organizeImports.chooseImport";
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -121,5 +121,5 @@ export namespace Commands {
     /**
      * Choose type to import.
      */
-    export const CHOOSE_IMPORT = "java.action.organizeImports.chooseImport";
+    export const CHOOSE_IMPORTS = "java.action.organizeImports.chooseImports";
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 							progressReportProvider: getJavaConfiguration().get('progressReports.enabled'),
 							classFileContentsSupport:true,
 							overrideMethodsPromptSupport:true,
-							hashCodeEqualsPromptSupport:true
+							hashCodeEqualsPromptSupport:true,
+							advancedOrganizeImportsSupport:true
 						},
 						triggerFiles: getTriggerFiles()
 					},

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -187,5 +187,4 @@ export interface ImportCandidate {
 export interface ImportSelection {
     candidates: ImportCandidate[];
     range: Range;
-    defaultSelection: null | number;
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -179,13 +179,13 @@ export namespace OrganizeImportsRequest {
     export const type = new RequestType<CodeActionParams, WorkspaceEdit, void, void>('java/organizeImports');
 }
 
-export interface ImportChoice {
-    qualifiedName: string;
+export interface ImportCandidate {
+    fullyQualifiedName: string;
     id: string;
 }
 
 export interface ImportSelection {
-    candidates: ImportChoice[];
+    candidates: ImportCandidate[];
     range: Range;
     defaultSelection: number;
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -174,3 +174,12 @@ export interface GenerateHashCodeEqualsParams {
 export namespace GenerateHashCodeEqualsRequest {
     export const type = new RequestType<GenerateHashCodeEqualsParams, WorkspaceEdit, void, void>('java/generateHashCodeEquals');
 }
+
+export namespace OrganizeImportsRequest {
+    export const type = new RequestType<CodeActionParams, WorkspaceEdit, void, void>('java/organizeImports');
+}
+
+export interface ImportChoice {
+    qualifiedName: string;
+    id: string;
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams, CodeActionParams, WorkspaceEdit } from 'vscode-languageclient';
-import { Command } from 'vscode';
+import { Command, Range } from 'vscode';
 
 /**
  * The message type. Copied from vscode protocol
@@ -182,4 +182,10 @@ export namespace OrganizeImportsRequest {
 export interface ImportChoice {
     qualifiedName: string;
     id: string;
+}
+
+export interface ImportSelection {
+    candidates: ImportChoice[];
+    range: Range;
+    defaultSelection: number;
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -187,5 +187,5 @@ export interface ImportCandidate {
 export interface ImportSelection {
     candidates: ImportCandidate[];
     range: Range;
-    defaultSelection: number;
+    defaultSelection: null | number;
 }

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -120,13 +120,6 @@ function registerChooseImportCommand(context: ExtensionContext): void {
             // Move the cursor to the code line with ambiguous import choices.
             await window.showTextDocument(fileUri, { preserveFocus: true, selection: selection.range, viewColumn: ViewColumn.One });
             const candidates: ImportCandidate[] = selection.candidates;
-            // Move the recommend type to the top.
-            if (selection.defaultSelection && selection.defaultSelection < candidates.length) {
-                const defaultChoice: ImportCandidate = candidates[selection.defaultSelection];
-                candidates.splice(selection.defaultSelection, 1);
-                candidates.unshift(defaultChoice);
-            }
-
             const items = candidates.map((item) => {
                 return {
                     label: item.fullyQualifiedName,

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -1,14 +1,17 @@
 'use strict';
 
-import { commands, window, ExtensionContext } from 'vscode';
+import { commands, window, ExtensionContext, Range, ViewColumn, Uri, Disposable} from 'vscode';
 import { CodeActionParams, LanguageClient } from 'vscode-languageclient';
 import { Commands } from './commands';
 import { applyWorkspaceEdit } from './extension';
-import { ListOverridableMethodsRequest, AddOverridableMethodsRequest, CheckHashCodeEqualsStatusRequest, GenerateHashCodeEqualsRequest } from './protocol';
+import { ListOverridableMethodsRequest, AddOverridableMethodsRequest, CheckHashCodeEqualsStatusRequest, GenerateHashCodeEqualsRequest,
+OrganizeImportsRequest, ImportChoice } from './protocol';
 
 export function registerCommands(languageClient: LanguageClient, context: ExtensionContext) {
     registerOverrideMethodsCommand(languageClient, context);
     registerHashCodeEqualsCommand(languageClient, context);
+    registerOrganizeImportsCommand(languageClient, context);
+    registerChooseImportCommand(context);
 }
 
 function registerOverrideMethodsCommand(languageClient: LanguageClient, context: ExtensionContext): void {
@@ -98,5 +101,56 @@ function registerHashCodeEqualsCommand(languageClient: LanguageClient, context: 
             regenerate
         });
         applyWorkspaceEdit(workspaceEdit, languageClient);
+    }));
+}
+
+function registerOrganizeImportsCommand(languageClient: LanguageClient, context: ExtensionContext): void {
+    context.subscriptions.push(commands.registerCommand(Commands.ORGANIZE_IMPORTS, async (params: CodeActionParams) => {
+        const workspaceEdit = await languageClient.sendRequest(OrganizeImportsRequest.type, params);
+        applyWorkspaceEdit(workspaceEdit, languageClient);
+    }));
+}
+
+function registerChooseImportCommand(context: ExtensionContext): void {
+    context.subscriptions.push(commands.registerCommand(Commands.CHOOSE_IMPORT, async (importChoices: ImportChoice[][], ranges: Range[], uri: string) => {
+        const chosen: ImportChoice[] = [];
+        for (let i = 0; i < importChoices.length; i++) {
+            // Move the cursor to the code line with ambiguous import choices.
+            await window.showTextDocument(Uri.parse(uri), { preserveFocus: true, selection: ranges[i], viewColumn: ViewColumn.One });
+            const items = importChoices[i].map((item) => {
+                return {
+                    label: item.qualifiedName,
+                    origin: item
+                };
+            });
+            const qualifiedName = importChoices[i].length ? importChoices[i][0].qualifiedName : "";
+            const typeName = qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1);
+            const disposables: Disposable[] = [];
+            try {
+                const pick = await new Promise<any>((resolve, reject) => {
+                    const input = window.createQuickPick();
+                    input.title = "Organize Imports";
+                    input.step = i + 1;
+                    input.totalSteps = importChoices.length;
+                    input.placeholder = `Choose type '${typeName}' to import`;
+                    input.items = items;
+                    disposables.push(
+                        input.onDidChangeSelection(items => resolve(items[0])),
+                        input.onDidHide(() => {
+                            reject(undefined);
+                        }),
+                        input
+                    );
+                    input.show();
+                });
+                chosen.push(pick ? pick.origin : null);
+            } catch (err) {
+                break;
+            } finally {
+                disposables.forEach(d => d.dispose());
+            }
+        }
+
+        return chosen;
     }));
 }

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -116,13 +116,14 @@ function registerChooseImportCommand(context: ExtensionContext): void {
         const chosen: ImportCandidate[] = [];
         const fileUri: Uri = Uri.parse(uri);
         for (let i = 0; i < selections.length; i++) {
+            const selection : ImportSelection = selections[i];
             // Move the cursor to the code line with ambiguous import choices.
-            await window.showTextDocument(fileUri, { preserveFocus: true, selection: selections[i].range, viewColumn: ViewColumn.One });
-            const candidates: ImportCandidate[] = selections[i].candidates;
+            await window.showTextDocument(fileUri, { preserveFocus: true, selection: selection.range, viewColumn: ViewColumn.One });
+            const candidates: ImportCandidate[] = selection.candidates;
             // Move the recommend type to the top.
-            if (selections[i].defaultSelection > 0 && selections[i].defaultSelection < candidates.length) {
-                const defaultChoice: ImportCandidate = candidates[selections[i].defaultSelection];
-                candidates.splice(selections[i].defaultSelection, 1);
+            if (selection.defaultSelection && selection.defaultSelection < candidates.length) {
+                const defaultChoice: ImportCandidate = candidates[selection.defaultSelection];
+                candidates.splice(selection.defaultSelection, 1);
                 candidates.unshift(defaultChoice);
             }
 
@@ -133,7 +134,7 @@ function registerChooseImportCommand(context: ExtensionContext): void {
                 };
             });
 
-            const fullyQualifiedName = candidates.length ? candidates[0].fullyQualifiedName : "";
+            const fullyQualifiedName = candidates[0].fullyQualifiedName;
             const typeName = fullyQualifiedName.substring(fullyQualifiedName.lastIndexOf(".") + 1);
             const disposables: Disposable[] = [];
             try {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -45,7 +45,7 @@ suite('Java Language Extension', () => {
 				Commands.HASHCODE_EQUALS_PROMPT,
 				Commands.OPEN_JSON_SETTINGS,
 				Commands.ORGANIZE_IMPORTS,
-				Commands.CHOOSE_IMPORT
+				Commands.CHOOSE_IMPORTS
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -43,7 +43,9 @@ suite('Java Language Extension', () => {
 				Commands.LIST_SOURCEPATHS,
 				Commands.OVERRIDE_METHODS_PROMPT,
 				Commands.HASHCODE_EQUALS_PROMPT,
-				Commands.OPEN_JSON_SETTINGS
+				Commands.OPEN_JSON_SETTINGS,
+				Commands.ORGANIZE_IMPORTS,
+				Commands.CHOOSE_IMPORT
 			];
 			let foundJavaCommands = commands.filter(function(value){
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fixes #673 
For the line with multiple ambiguous imports, list the available imports in pick box, meanwhile move the focus to the error line.
![organizeImports](https://user-images.githubusercontent.com/14052197/54737801-8a875200-4bec-11e9-8a6e-c5f2b3f57367.gif)
