### PR TITLE
Enable advanced "Generate getters and setters..." source action

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -126,4 +126,8 @@ export namespace Commands {
      * Generate toString().
      */
     export const GENERATE_TOSTRING_PROMPT = 'java.action.generateToStringPrompt';
+    /**
+     * Generate Getters and Setters.
+     */
+    export const GENERATE_ACCESSORS_PROMPT = 'java.action.generateAccessorsPrompt';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 							overrideMethodsPromptSupport: true,
 							hashCodeEqualsPromptSupport: true,
 							advancedOrganizeImportsSupport: true,
-							generateToStringPromptSupport: true
+							generateToStringPromptSupport: true,
+							advancedGenerateAccessorsSupport: true,
 						},
 						triggerFiles: getTriggerFiles()
 					},

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -206,3 +206,23 @@ export interface GenerateToStringParams {
 export namespace GenerateToStringRequest {
     export const type = new RequestType<GenerateToStringParams, WorkspaceEdit, void, void>('java/generateToString');
 }
+
+export interface AccessorField {
+    fieldName: string;
+    isStatic: boolean;
+    generateGetter: boolean;
+    generateSetter: boolean;
+}
+
+export namespace ResolveUnimplementedAccessorsRequest {
+    export const type = new RequestType<CodeActionParams, AccessorField[], void, void>('java/resolveUnimplementedAccessors');
+}
+
+export interface GenerateAccessorsParams {
+    context: CodeActionParams;
+    accessors: AccessorField[];
+}
+
+export namespace GenerateAccessorsRequest {
+    export const type = new RequestType<GenerateAccessorsParams, WorkspaceEdit, void, void>('java/generateAccessors');
+}

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -5,7 +5,7 @@ import { CodeActionParams, LanguageClient } from 'vscode-languageclient';
 import { Commands } from './commands';
 import { applyWorkspaceEdit } from './extension';
 import { ListOverridableMethodsRequest, AddOverridableMethodsRequest, CheckHashCodeEqualsStatusRequest, GenerateHashCodeEqualsRequest,
-OrganizeImportsRequest, ImportCandidate, ImportSelection, GenerateToStringRequest, CheckToStringStatusRequest, VariableField } from './protocol';
+OrganizeImportsRequest, ImportCandidate, ImportSelection, GenerateToStringRequest, CheckToStringStatusRequest, VariableField, ResolveUnimplementedAccessorsRequest, GenerateAccessorsRequest } from './protocol';
 
 export function registerCommands(languageClient: LanguageClient, context: ExtensionContext) {
     registerOverrideMethodsCommand(languageClient, context);
@@ -13,6 +13,7 @@ export function registerCommands(languageClient: LanguageClient, context: Extens
     registerOrganizeImportsCommand(languageClient, context);
     registerChooseImportCommand(context);
     registerGenerateToStringCommand(languageClient, context);
+    registerGenerateAccessorsCommand(languageClient, context);
 }
 
 function registerOverrideMethodsCommand(languageClient: LanguageClient, context: ExtensionContext): void {
@@ -198,6 +199,46 @@ function registerGenerateToStringCommand(languageClient: LanguageClient, context
         const workspaceEdit = await languageClient.sendRequest(GenerateToStringRequest.type, {
             context: params,
             fields,
+        });
+        applyWorkspaceEdit(workspaceEdit, languageClient);
+    }));
+}
+
+function registerGenerateAccessorsCommand(languageClient: LanguageClient, context: ExtensionContext): void {
+    context.subscriptions.push(commands.registerCommand(Commands.GENERATE_ACCESSORS_PROMPT, async (params: CodeActionParams) => {
+        const accessors = await languageClient.sendRequest(ResolveUnimplementedAccessorsRequest.type, params);
+        if (!accessors || !accessors.length) {
+            return;
+        }
+
+        const accessorItems = accessors.map((accessor) => {
+            const description = [];
+            if (accessor.isStatic) {
+                description.push('static');
+            }
+            if (accessor.generateGetter) {
+                description.push('getter');
+            }
+            if (accessor.generateSetter) {
+                description.push('setter');
+            }
+            return {
+                label: accessor.fieldName,
+                description: description.join(', '),
+                originalField: accessor,
+            };
+        });
+        const selectedAccessors = await window.showQuickPick(accessorItems, {
+            canPickMany: true,
+            placeHolder:  'Select the fields to generate getters and setters.'
+        });
+        if (!selectedAccessors.length) {
+            return;
+        }
+
+        const workspaceEdit = await languageClient.sendRequest(GenerateAccessorsRequest.type, {
+            context: params,
+            accessors: selectedAccessors.map((item) => item.originalField),
         });
         applyWorkspaceEdit(workspaceEdit, languageClient);
     }));

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -46,7 +46,8 @@ suite('Java Language Extension', () => {
 				Commands.OPEN_JSON_SETTINGS,
 				Commands.ORGANIZE_IMPORTS,
 				Commands.CHOOSE_IMPORTS,
-				Commands.GENERATE_TOSTRING_PROMPT
+				Commands.GENERATE_TOSTRING_PROMPT,
+				Commands.GENERATE_ACCESSORS_PROMPT
 			];
 			const foundJavaCommands = commands.filter(function(value) {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Enable the advanced "Generate getters and setters..." source action if the class has more than one field. It will prompt a quick pick box to select the target fields for generating the accessor methods.
![image](https://user-images.githubusercontent.com/14052197/56879033-8707a600-6a89-11e9-9765-7475521d4921.png)

