### PR TITLE
Rework command and extension activation conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,9 @@
   ],
   "activationEvents": [
     "onLanguage:java",
-    "onCommand:java.show.references",
-    "onCommand:java.show.implementations",
-    "onCommand:java.open.output",
-    "onCommand:java.open.serverLog",
-    "onCommand:java.execute.workspaceCommand",
-    "onCommand:java.projectConfiguration.update",
     "workspaceContains:pom.xml",
-    "workspaceContains:build.gradle"
+    "workspaceContains:build.gradle",
+    "workspaceContains:.classpath"
   ],
   "main": "./dist/extension",
   "contributes": {
@@ -439,6 +434,18 @@
         }
       ],
       "commandPalette": [
+        {
+          "command": "java.projectConfiguration.update",
+          "when": "javaLSReady"
+        },
+        {
+          "command": "java.workspace.compile",
+          "when": "javaLSReady"
+        },
+        {
+          "command": "java.project.listSourcePaths",
+          "when": "javaLSReady"
+        },
         {
           "command": "java.project.updateSourceAttachment",
           "when": "false"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,6 +105,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				// Create the language client and start the client.
 				languageClient = new LanguageClient('java', 'Language Support for Java', serverOptions, clientOptions);
 				languageClient.registerProposedFeatures();
+
 				languageClient.onReady().then(() => {
 					languageClient.onNotification(StatusNotification.type, (report) => {
 						switch (report.type) {
@@ -186,9 +187,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						return commands.executeCommand(params.command, ...params.arguments);
 					});
 
-					context.subscriptions.push(commands.registerCommand(Commands.OPEN_OUTPUT, () => {
-						languageClient.outputChannel.show(ViewColumn.Three);
-					}));
 					context.subscriptions.push(commands.registerCommand(Commands.SHOW_JAVA_REFERENCES, (uri: string, position: LSPosition, locations: LSLocation[]) => {
 						commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), languageClient.protocol2CodeConverter.asPosition(position), locations.map(languageClient.protocol2CodeConverter.asLocation));
 					}));
@@ -319,6 +317,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 				languageClient.start();
 				// Register commands here to make it available even when the language client fails
+
+				context.subscriptions.push(commands.registerCommand(Commands.OPEN_OUTPUT, () =>  languageClient.outputChannel.show(ViewColumn.Three)));
+
 				context.subscriptions.push(commands.registerCommand(Commands.OPEN_SERVER_LOG, () => openServerLogFile(workspacePath)));
 
 				const extensionPath = context.extensionPath;
@@ -481,7 +482,7 @@ function deleteDirectory(dir) {
 
 function openServerLogFile(workspacePath): Thenable<boolean> {
 	const serverLogFile = path.join(workspacePath, '.metadata', '.log');
-	if (!serverLogFile) {
+	if (!fs.existsSync(serverLogFile)) {
 		return window.showWarningMessage('Java Language Server has not started logging.').then(() => false);
 	}
 


### PR DESCRIPTION
- early registration of `open output command`. Fixes #914
- activate extension when .classpath is found at the root
- only activate some commands in the palette if the server is started
- removed extension activation by commands needing the server to be
started in the 1st place
- fixed check for non-existing server log, in the `open server log`
command