### PR TITLE
Optionally disable loading gradle from gradle wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ The following settings are supported:
 * `java.codeGeneration.toString.listArrayContents`: List contents of arrays instead of using native toString(). Defaults to `true`.
 * `java.codeGeneration.toString.limitElements`: Limit number of items in arrays/collections/maps to list, if 0 then list all. Defaults to `0`.
 
+*New in 0.45.0:*
+* `java.import.gradle.wrapper.enabled`: Enable/disable the Gradle wrapper.
+* `java.import.gradle.version`: Gradle version, used if the gradle wrapper is missing or disabled.
+
 Troubleshooting
 ===============
 1. Check the status of the language tools on the lower right corner (marked with A on image below).

--- a/package.json
+++ b/package.json
@@ -114,16 +114,28 @@
           "description": "Traces the communication between VS Code and the Java language server.",
           "scope": "window"
         },
+        "java.import.maven.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the Maven importer.",
+          "scope": "window"
+        },
         "java.import.gradle.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable/disable the Gradle importer.",
           "scope": "window"
         },
-        "java.import.maven.enabled": {
+        "java.import.gradle.wrapper.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Enable/disable the Maven importer.",
+          "description": "Enable/disable the Gradle wrapper.",
+          "scope": "window"
+        },
+        "java.import.gradle.version": {
+          "type": "string",
+          "default": null,
+          "description": "Gradle version, used if the gradle wrapper is missing or disabled.",
           "scope": "window"
         },
         "java.maven.downloadSources": {


### PR DESCRIPTION
Fixes #875 
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/1026

I have added two new properties: `java.import.gradle.wrapper.enabled` and `java.import.gradle.version`

Importing a gradle project works in the following way:

- if there is gradlew and java.gradle.wrapper.enabled=true (default), the gradle wrapper distribution will be used
- in the case that gradlew doesn't exist or java.import.gradle.wrapper.enabled=false,  Java LS checks for the existence of the java.import.gradle.version property. If it exists,  Java LS will use the required version
- if there's no java.import.gradle.version property, Java LS checks for existence of the GRADLE_HOME env variable or the GRADLE_HOME system property. If it exists,  Java LS will use the GRADLE_HOME local installation,
-  else Java LS will use default buildship version (5.0).

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>