### PR TITLE
update loading icon in status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				};
 
 				const item = window.createStatusBarItem(StatusBarAlignment.Right, Number.MIN_VALUE);
-				item.text = '$(rocket)';
+				item.text = '$(sync~spin)';
 				item.command = Commands.OPEN_OUTPUT;
 				const progressBar = window.createStatusBarItem(StatusBarAlignment.Left, Number.MIN_VALUE + 1);
 


### PR DESCRIPTION
Current rocket icon does not indicate the "loading language server" progress well. It turns out lots of users are not aware of the rocket/thumsup icons at all. The[ spin animation](https://code.visualstudio.com/api/references/icons-in-labels#animation) might serve better, telling users that some features are not yet ready.

![rocket](https://user-images.githubusercontent.com/2351748/57906598-1b0ca680-78ad-11e9-8fbf-61a4e6b4bdee.gif)
