### PR TITLE
Add rename after 'extract to variable/constant/method' refactoring

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -138,4 +138,12 @@ export namespace Commands {
      * Generate Delegate Methods.
      */
     export const GENERATE_DELEGATE_METHODS_PROMPT = 'java.action.generateDelegateMethodsPrompt';
+    /**
+     * Apply Refactoring Command.
+     */
+    export const APPLY_REFACTORING_COMMAND = 'java.action.applyRefactoringCommand';
+    /**
+     * Rename Command.
+     */
+    export const RENAME_COMMAND = 'java.action.rename';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
 import { ExtensionAPI } from './extension.api';
 import * as buildpath from './buildpath';
 import * as sourceAction from './sourceAction';
+import * as refactorAction from './refactorAction';
 import * as net from 'net';
 import { getJavaConfiguration } from './utils';
 import { onConfigurationChange, excludeProjectSettingsFiles } from './settings';
@@ -72,6 +73,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 							advancedGenerateAccessorsSupport: true,
 							generateConstructorsPromptSupport: true,
 							generateDelegateMethodsPromptSupport: true,
+							advancedExtractRefactoringSupport: true,
 						},
 						triggerFiles: getTriggerFiles()
 					},
@@ -286,6 +288,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 					buildpath.registerCommands(context);
 					sourceAction.registerCommands(languageClient, context);
+					refactorAction.registerCommands(languageClient, context);
 
 					context.subscriptions.push(window.onDidChangeActiveTextEditor((editor) => {
 						toggleItem(editor, item);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams, CodeActionParams, WorkspaceEdit } from 'vscode-languageclient';
+import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams, CodeActionParams, WorkspaceEdit, FormattingOptions } from 'vscode-languageclient';
 import { Command, Range } from 'vscode';
 
 /**
@@ -277,4 +277,25 @@ export interface GenerateDelegateMethodsParams {
 
 export namespace GenerateDelegateMethodsRequest {
     export const type = new RequestType<GenerateDelegateMethodsParams, WorkspaceEdit, void, void>('java/generateDelegateMethods');
+}
+
+export interface RenamePosition {
+    uri: string;
+    offset: number;
+    length: number;
+}
+
+export interface RefactorWorkspaceEdit {
+    edit: WorkspaceEdit;
+    command?: Command;
+}
+
+export interface GetRefactorEditParams {
+    command: string;
+    context: CodeActionParams;
+    options: FormattingOptions;
+}
+
+export namespace GetRefactorEditRequest {
+    export const type = new RequestType<GetRefactorEditParams, RefactorWorkspaceEdit, void, void>('java/getRefactorEdit');
 }

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -1,0 +1,69 @@
+'use strict';
+
+import { commands, window, ExtensionContext, workspace, Position, Uri, TextDocument } from 'vscode';
+import { LanguageClient, FormattingOptions } from 'vscode-languageclient';
+import { Commands as javaCommands } from './commands';
+import { GetRefactorEditRequest, RefactorWorkspaceEdit, RenamePosition } from './protocol';
+
+export function registerCommands(languageClient: LanguageClient, context: ExtensionContext) {
+    registerApplyRefactorCommand(languageClient, context);
+}
+
+function registerApplyRefactorCommand(languageClient: LanguageClient, context: ExtensionContext): void {
+    context.subscriptions.push(commands.registerCommand(javaCommands.RENAME_COMMAND, async (position: RenamePosition) => {
+        try {
+            const uri: Uri = Uri.parse(position.uri);
+            const document: TextDocument = await workspace.openTextDocument(uri);
+            if (document == null) {
+                return;
+            }
+
+            const renamePosition: Position = document.positionAt(position.offset);
+            await commands.executeCommand('editor.action.rename', [
+                document.uri,
+                renamePosition,
+            ]);
+        } catch (error) {
+            // do nothing.
+        }
+    }));
+
+    context.subscriptions.push(commands.registerCommand(javaCommands.APPLY_REFACTORING_COMMAND, async (command: string, params: any) => {
+        if (command === 'extractVariable'
+            || command === 'extractVariableAllOccurrence'
+            || command === 'extractConstant'
+            || command === 'extractMethod') {
+            const currentEditor = window.activeTextEditor;
+            if (!currentEditor || !currentEditor.options) {
+                return;
+            }
+
+            const formattingOptions: FormattingOptions = {
+                tabSize: <number> currentEditor.options.tabSize,
+                insertSpaces: <boolean> currentEditor.options.insertSpaces,
+            };
+            const result: RefactorWorkspaceEdit = await languageClient.sendRequest(GetRefactorEditRequest.type, {
+                command,
+                context: params,
+                options: formattingOptions,
+            });
+
+            if (!result || !result.edit) {
+                return;
+            }
+
+            const edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(result.edit);
+            if (edit) {
+                await workspace.applyEdit(edit);
+            }
+            
+            if (result.command) {
+                if (result.command.arguments) {
+                    await commands.executeCommand(result.command.command, ...result.command.arguments);
+                } else {
+                    await commands.executeCommand(result.command.command);
+                }
+            }
+        }
+    }));
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -50,6 +50,8 @@ suite('Java Language Extension', () => {
 				Commands.GENERATE_ACCESSORS_PROMPT,
 				Commands.GENERATE_CONSTRUCTORS_PROMPT,
 				Commands.GENERATE_DELEGATE_METHODS_PROMPT,
+				Commands.APPLY_REFACTORING_COMMAND,
+				Commands.RENAME_COMMAND
 			];
 			const foundJavaCommands = commands.filter(function(value) {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix #952
- Currently, when execute "extract" refactoring, the jdt.ls will generate the code by using the formatting options from project settings. But regarding `tabSize` and `insertSpace`, jdt prefers to use `\t`, and vscode prefers to use whitespace by default. So if no formatting option is passed to jdt.ls, the generated code snippet will use `\t` as indentation. As a workaround (#557), vscode-java will manually format the generated code. But formatting is actually another code edit operation, it cannot make sure the cursor position is rightly displayed. 
- The fix is to pass the formatting info to the jdt.ls during code action, and let the jdt.ls to generate the right code at one time.

Fix #333
- jdt.ls will carry rename position info in the code action response, then vscode-java client is able to invoke vscode rename command to pop up rename box.

