### PR TITLE
Can find Oracle JDK from Windows Registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@types/glob": {
       "version": "5.0.30",
-      "resolved": "http://registry.npmjs.org/@types/glob/-/glob-5.0.30.tgz",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.30.tgz",
       "integrity": "sha1-ECZAnFYlqGiQdGAoCNCCsoZ7ilE=",
       "dev": true,
       "requires": {
@@ -281,7 +281,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
@@ -382,7 +382,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-map": {
@@ -867,7 +867,7 @@
     },
     "buffer": {
       "version": "3.6.0",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "dev": true,
       "requires": {
@@ -995,7 +995,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -1473,7 +1473,7 @@
     "decompress-tar": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "integrity": "sha1-cYy9P8sWIJcW5womuE57pFkuWvE=",
       "dev": true,
       "requires": {
         "file-type": "^5.2.0",
@@ -1492,7 +1492,7 @@
     "decompress-tarbz2": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "integrity": "sha1-MIKluIDqQEOBY0nzeLVsUWvho5s=",
       "dev": true,
       "requires": {
         "decompress-tar": "^4.1.0",
@@ -1505,7 +1505,7 @@
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "integrity": "sha1-5QzXXTVv/tTjBtxPW89Sp5kDqRk=",
           "dev": true
         }
       }
@@ -1513,7 +1513,7 @@
     "decompress-targz": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "integrity": "sha1-wJvDXE0R894J8tLaU+neI+fOHu4=",
       "dev": true,
       "requires": {
         "decompress-tar": "^4.1.1",
@@ -2155,7 +2155,7 @@
     },
     "file-type": {
       "version": "3.9.0",
-      "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
       "dev": true
     },
@@ -2194,9 +2194,9 @@
       }
     },
     "find-java-home": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-0.2.0.tgz",
-      "integrity": "sha512-nq5PFOHxE1VSEbdDVkLoA2bAcRnG4ETqJO8ipFq3glIWA52hdWCXYX3emuUyMAQfaqFU4Ea85gqcgaPmOApEPA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-1.0.0.tgz",
+      "integrity": "sha512-eqC9OCUT3stF1zfDJ/g0Uz9XFPi5X+2ZAv84Y+itA2x5scCe6GCF585re8YjjoJeIOipjNMRMM7s2E3ige+6+w==",
       "requires": {
         "which": "~1.0.5",
         "winreg": "~1.2.2"
@@ -3194,7 +3194,7 @@
         },
         "through": {
           "version": "2.3.8",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "dev": true
         },
@@ -3592,7 +3592,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-builtin-module": {
@@ -3708,7 +3708,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -4296,14 +4296,14 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -4360,7 +4360,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4369,7 +4369,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -4784,7 +4784,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
@@ -4916,7 +4916,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -4984,7 +4984,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -5031,7 +5031,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -5876,7 +5876,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -5895,7 +5895,7 @@
     "strip-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "integrity": "sha1-SYdzYmT8NEzyD2w0rKnRPR1O1sU=",
       "dev": true,
       "requires": {
         "is-natural-number": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -532,7 +532,7 @@
   },
   "dependencies": {
     "vscode-languageclient": "5.3.0-next.6",
-    "find-java-home": "0.2.0",
+    "find-java-home": "1.0.0",
     "tmp": "^0.0.33",
     "path-exists": "^3.0.0",
     "expand-home-dir": "^0.0.3",

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -5,7 +5,7 @@ import * as cp from 'child_process';
 import * as path from 'path';
 import * as pathExists from 'path-exists';
 import * as expandHomeDir from 'expand-home-dir';
-import * as findJavaHome from 'find-java-home';
+import findJavaHome = require("find-java-home");
 import { Commands } from './commands';
 
 const isWindows = process.platform.indexOf('win') === 0;


### PR DESCRIPTION
**UPDATE**:
`find-java-home@1.0.0` has been released.

Just fixed some bugs in dependency `find-java-home`, it should recognize Oracle JDKs from Windows registry now. See: https://github.com/jsdevel/node-find-java-home/issues/19
This PR will resolve #836 