### PR TITLE
Fix tslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,5 @@ install:
 - ls -ll java-*vsix
 
 script:
+- npm run tslint
 - npm test --silent

--- a/package.json
+++ b/package.json
@@ -510,7 +510,8 @@
     "pretest": "npm run compile",
     "test": "node ./out/test/runtest.js",
     "build-server": "./node_modules/.bin/gulp build_server",
-    "watch-server": "./node_modules/.bin/gulp watch_server"
+    "watch-server": "./node_modules/.bin/gulp watch_server",
+    "tslint": "tslint -p ."
   },
   "devDependencies": {
     "@types/glob": "5.0.30",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -79,7 +79,6 @@ export namespace Commands {
     */
     export const OPEN_CLIENT_LOG = 'java.open.clientLog';
 
-    
     /**
      * Open Java formatter settings
      */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -515,8 +515,7 @@ function openClientLogFile(logFile: string): Thenable<boolean> {
 	});
 }
 
-
-function openLogFile(logFile, openingFailureWarning:string ): Thenable<boolean> {
+function openLogFile(logFile, openingFailureWarning: string): Thenable<boolean> {
 	if (!fs.existsSync(logFile)) {
 		return window.showWarningMessage('No log file available').then(() => false);
 	}

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -223,7 +223,7 @@ function registerGenerateAccessorsCommand(languageClient: LanguageClient, contex
             }
             return {
                 label: accessor.fieldName,
-                description: (accessor.isStatic?'static ':'')+ description.join(', '),
+                description: (accessor.isStatic ? 'static ' : '')+ description.join(', '),
                 originalField: accessor,
             };
         });
@@ -323,12 +323,12 @@ function registerGenerateDelegateMethodsCommand(languageClient: LanguageClient, 
             selectedDelegateField = selectedFieldItem.originalField;
         }
 
-        let delegateEntryItems = selectedDelegateField.delegateMethods.map(delegateMethod => {
+        const delegateEntryItems = selectedDelegateField.delegateMethods.map(delegateMethod => {
             return {
                 label: `${selectedDelegateField.field.name}.${delegateMethod.name}(${delegateMethod.parameters.join(',')})`,
                 originalField: selectedDelegateField.field,
                 originalMethod: delegateMethod,
-            }
+            };
         });
 
         if (!delegateEntryItems.length) {


### PR DESCRIPTION
TS Lint fails according to current `tslint.json`. See below:
```
ERROR: /Users/sechs/Work/vscode-java/src/commands.ts[82, 1]: Consecutive blank lines are forbidden
ERROR: /Users/sechs/Work/vscode-java/src/commands.ts[82, 1]: trailing whitespace
ERROR: /Users/sechs/Work/vscode-java/src/extension.ts[518, 1]: Consecutive blank lines are forbidden
ERROR: /Users/sechs/Work/vscode-java/src/extension.ts[519, 53]: missing whitespace
ERROR: /Users/sechs/Work/vscode-java/src/extension.ts[519, 53]: expected onespace after colon in parameter
ERROR: /Users/sechs/Work/vscode-java/src/sourceAction.ts[226, 59]: missing whitespace
ERROR: /Users/sechs/Work/vscode-java/src/sourceAction.ts[326, 13]: Identifier 'delegateEntryItems' is never reassigned; use 'const' instead of 'let'.
ERROR: /Users/sechs/Work/vscode-java/src/sourceAction.ts[331, 14]: Missing semicolon
```

This PR fixes these errors and addes tslint check to travis CI.