### PR TITLE
Use hover to support 'Go To Super Implementation' action 

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -159,5 +159,5 @@ export namespace Commands {
     /**
      * Navigate To Super Method Command.
      */
-    export const NAVIGATE_TO_SUPER_METHOD_COMMAND = 'java.action.navigateToSuperMethod';
+    export const NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND = 'java.action.navigateToSuperImplementation';
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -157,7 +157,7 @@ export namespace Commands {
      */
     export const RENAME_COMMAND = 'java.action.rename';
     /**
-     * Navigate To Override Method Command.
+     * Navigate To Super Method Command.
      */
-    export const NAVIGATE_TO_OVERRIDE_COMMAND = 'java.action.navigateToOverride';
+    export const NAVIGATE_TO_SUPER_METHOD_COMMAND = 'java.action.navigateToSuperMethod';
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -156,4 +156,8 @@ export namespace Commands {
      * Rename Command.
      */
     export const RENAME_COMMAND = 'java.action.rename';
+    /**
+     * Navigate To Override Method Command.
+     */
+    export const NAVIGATE_TO_OVERRIDE_COMMAND = 'java.action.navigateToOverride';
 }

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -1,7 +1,13 @@
 import { RequirementsData } from './requirements';
+import { TextDocumentPositionParams } from 'vscode-languageclient';
+import { CancellationToken, Command, ProviderResult } from 'vscode';
+
+export type provideHoverCommandFn = (params: TextDocumentPositionParams, token: CancellationToken) => ProviderResult<Command[] | undefined>;
+export type registerHoverCommand = (callback: provideHoverCommandFn) => void;
 
 export interface ExtensionAPI {
     readonly apiVersion: string;
 	readonly javaRequirement: RequirementsData;
 	readonly status: "Started" | "Error";
+	readonly registerHoverCommand: registerHoverCommand;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
 } from './protocol';
 import { ExtensionAPI } from './extension.api';
 import * as buildpath from './buildpath';
+import * as hoverAction from './hoverAction';
 import * as sourceAction from './sourceAction';
 import * as refactorAction from './refactorAction';
 import * as net from 'net';
@@ -161,6 +162,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 							generateDelegateMethodsPromptSupport: true,
 							advancedExtractRefactoringSupport: true,
 							moveRefactoringSupport: true,
+							clientHoverProvider: true,
 						},
 						triggerFiles: getTriggerFiles()
 					},
@@ -203,6 +205,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				// Create the language client and start the client.
 				languageClient = new LanguageClient('java', extensionName, serverOptions, clientOptions);
 				languageClient.registerProposedFeatures();
+				const registerHoverCommand = hoverAction.registerClientHoverProvider(languageClient, context);
 
 				languageClient.onReady().then(() => {
 					languageClient.onNotification(StatusNotification.type, (report) => {
@@ -215,7 +218,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								resolve({
 									apiVersion: '0.2',
 									javaRequirement: requirements,
-									status: report.type
+									status: report.type,
+									registerHoverCommand,
 								});
 								break;
 							case 'Error':
@@ -226,7 +230,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								resolve({
 									apiVersion: '0.2',
 									javaRequirement: requirements,
-									status: report.type
+									status: report.type,
+									registerHoverCommand,
 								});
 								break;
 							case 'Starting':

--- a/src/hoverAction.ts
+++ b/src/hoverAction.ts
@@ -1,0 +1,106 @@
+'use strict';
+
+import { commands, ExtensionContext, HoverProvider, languages, CancellationToken, Hover, Position, TextDocument, MarkdownString, window, Uri, MarkedString, Command} from "vscode";
+import { LanguageClient, TextDocumentPositionParams, HoverRequest } from "vscode-languageclient";
+import { MethodOverride } from "./protocol";
+import { registerHoverCommand, provideHoverCommandFn } from "./extension.api";
+import { logger } from "./log";
+
+const NAVIGATE_TO_OVERRIDE_COMMAND = 'java.action.navigateToOverride';
+
+export function registerClientHoverProvider(languageClient: LanguageClient, context: ExtensionContext): registerHoverCommand {
+    const hoverProvider: JavaHoverProvider = new JavaHoverProvider(languageClient);
+    hoverProvider.registerHoverCommand(async (params: TextDocumentPositionParams, token: CancellationToken) => {
+        return await provideOverrideHoverCommand(languageClient, params, token);
+    });
+    context.subscriptions.push(languages.registerHoverProvider('java', hoverProvider));
+    context.subscriptions.push(commands.registerCommand(NAVIGATE_TO_OVERRIDE_COMMAND, (location: any) => {
+        navigateToOverride(languageClient, location);
+    }));
+    context.subscriptions.push()
+
+    return hoverProvider.registerHoverCommand;
+}
+
+async function provideOverrideHoverCommand(languageClient: LanguageClient, params: TextDocumentPositionParams, token: CancellationToken): Promise<Command[] | undefined> {
+    const response = await languageClient.sendRequest(MethodOverride.type, params, token);
+    if (response && response.length) {
+        const location = response[0];
+        return [{
+            title: 'Go To Override',
+            command: NAVIGATE_TO_OVERRIDE_COMMAND,
+            tooltip: `Go to override method '${location.declaringTypeName}.${location.methodName}'`,
+            arguments: [ location ],
+        }];
+    }
+}
+
+function navigateToOverride(languageClient: LanguageClient, location: any) {
+    const range = languageClient.protocol2CodeConverter.asRange(location.range);
+    window.showTextDocument(Uri.parse(location.uri), {
+        preserveFocus: true,
+        selection: range,
+    });
+}
+
+class JavaHoverProvider implements HoverProvider {
+    private _hoverRegistry: provideHoverCommandFn[] = [];
+
+    constructor(readonly languageClient: LanguageClient) {
+    }
+
+    async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover> {
+        const params = {
+            textDocument: this.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document),
+            position: this.languageClient.code2ProtocolConverter.asPosition(position),
+        };
+
+        // Fetch the javadoc from Java language server.
+        const hoverResponse = await this.languageClient.sendRequest(HoverRequest.type, params, token);
+        const serverHover = this.languageClient.protocol2CodeConverter.asHover(hoverResponse);
+
+        // Fetch the contributed hover commands from third party extensions.
+        const contributedCommands: Command[] = await this.getContributedHoverCommands(params, token);
+        if (!contributedCommands.length) {
+            return serverHover;
+        }
+
+        const contributed = new MarkdownString(contributedCommands.map((command) => this.convertCommandToMarkdown(command)).join(' | '));
+        contributed.isTrusted = true;
+        let contents: MarkedString[] = [ contributed ];
+        let range;
+        if (serverHover && serverHover.contents) {
+            contents = contents.concat(serverHover.contents);
+            range = serverHover.range;
+        }
+        return new Hover(contents, range);
+    }
+
+    registerHoverCommand(callback: provideHoverCommandFn) {
+        this._hoverRegistry.push(callback);
+    }
+
+    private async getContributedHoverCommands(params: TextDocumentPositionParams, token: CancellationToken): Promise<Command[]> {
+        const contributedCommands: Command[] = [];
+        for (const provideFn of this._hoverRegistry) {
+            try {
+                if (token.isCancellationRequested) {
+                    break;
+                }
+
+                const commands = (await provideFn(params, token)) || [];
+                commands.forEach((command) => {
+                    contributedCommands.push(command);
+                });
+            } catch (error) {
+                logger.error(`Failed to provide hover command ${String(error)}`);
+            }
+        }
+
+        return contributedCommands;
+    }
+
+    private convertCommandToMarkdown(command: Command): string {
+        return `[${command.title}](command:${command.command}?${encodeURIComponent(JSON.stringify(command.arguments || []))} "${command.tooltip || command.command}")`;
+    }
+}

--- a/src/hoverAction.ts
+++ b/src/hoverAction.ts
@@ -31,7 +31,7 @@ async function provideHoverCommand(languageClient: LanguageClient, params: TextD
         if (location.kind === 'method') {
             tooltip = `Go to super method '${location.displayName}'`;
         } else {
-            tooltip = `Go to super implementation '${location.displayName}}'`;
+            tooltip = `Go to super implementation '${location.displayName}'`;
         }
 
         return [{
@@ -39,7 +39,7 @@ async function provideHoverCommand(languageClient: LanguageClient, params: TextD
             command: javaCommands.NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND,
             tooltip,
             arguments: [{
-                uri: location.uri,
+                uri: encodeBase64(location.uri),
                 range: location.range,
             }],
         }];
@@ -48,10 +48,18 @@ async function provideHoverCommand(languageClient: LanguageClient, params: TextD
 
 function navigateToSuperImplementation(languageClient: LanguageClient, location: any) {
     const range = languageClient.protocol2CodeConverter.asRange(location.range);
-    window.showTextDocument(Uri.parse(location.uri), {
+    window.showTextDocument(Uri.parse(decodeBase64(location.uri)), {
         preserveFocus: true,
         selection: range,
     });
+}
+
+function encodeBase64(text: string): string {
+    return Buffer.from(text).toString('base64');
+}
+
+function decodeBase64(text: string): string {
+    return Buffer.from(text, 'base64').toString('ascii');
 }
 
 class JavaHoverProvider implements HoverProvider {

--- a/src/hoverAction.ts
+++ b/src/hoverAction.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { commands, ExtensionContext, HoverProvider, languages, CancellationToken, Hover, Position, TextDocument, MarkdownString, window, Uri, MarkedString, Command} from "vscode";
+import { commands, ExtensionContext, HoverProvider, languages, CancellationToken, Hover, Position, TextDocument, MarkdownString, window, Uri, MarkedString, Command } from "vscode";
 import { LanguageClient, TextDocumentPositionParams, HoverRequest } from "vscode-languageclient";
 import { MethodOverride } from "./protocol";
 import { registerHoverCommand, provideHoverCommandFn } from "./extension.api";
@@ -17,7 +17,6 @@ export function registerClientHoverProvider(languageClient: LanguageClient, cont
     context.subscriptions.push(commands.registerCommand(NAVIGATE_TO_OVERRIDE_COMMAND, (location: any) => {
         navigateToOverride(languageClient, location);
     }));
-    context.subscriptions.push()
 
     return hoverProvider.registerHoverCommand;
 }

--- a/src/hoverAction.ts
+++ b/src/hoverAction.ts
@@ -2,11 +2,10 @@
 
 import { commands, ExtensionContext, HoverProvider, languages, CancellationToken, Hover, Position, TextDocument, MarkdownString, window, Uri, MarkedString, Command } from "vscode";
 import { LanguageClient, TextDocumentPositionParams, HoverRequest } from "vscode-languageclient";
+import { Commands as javaCommands } from "./commands";
 import { MethodOverride } from "./protocol";
 import { registerHoverCommand, provideHoverCommandFn } from "./extension.api";
 import { logger } from "./log";
-
-const NAVIGATE_TO_OVERRIDE_COMMAND = 'java.action.navigateToOverride';
 
 export function registerClientHoverProvider(languageClient: LanguageClient, context: ExtensionContext): registerHoverCommand {
     const hoverProvider: JavaHoverProvider = new JavaHoverProvider(languageClient);
@@ -14,7 +13,7 @@ export function registerClientHoverProvider(languageClient: LanguageClient, cont
         return await provideOverrideHoverCommand(languageClient, params, token);
     });
     context.subscriptions.push(languages.registerHoverProvider('java', hoverProvider));
-    context.subscriptions.push(commands.registerCommand(NAVIGATE_TO_OVERRIDE_COMMAND, (location: any) => {
+    context.subscriptions.push(commands.registerCommand(javaCommands.NAVIGATE_TO_OVERRIDE_COMMAND, (location: any) => {
         navigateToOverride(languageClient, location);
     }));
 
@@ -27,7 +26,7 @@ async function provideOverrideHoverCommand(languageClient: LanguageClient, param
         const location = response[0];
         return [{
             title: 'Go To Override',
-            command: NAVIGATE_TO_OVERRIDE_COMMAND,
+            command: javaCommands.NAVIGATE_TO_OVERRIDE_COMMAND,
             tooltip: `Go to override method '${location.declaringTypeName}.${location.methodName}'`,
             arguments: [ location ],
         }];

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -343,11 +343,16 @@ export namespace SearchSymbols {
     export const type = new RequestType<SearchSymbolParams, SymbolInformation[], void, void>('java/searchSymbols');
 }
 
-export interface MethodLocation extends Location {
-    declaringTypeName: string;
-    methodName: string;
+export interface FindLinksParams {
+    type: string;
+    position: TextDocumentPositionParams;
 }
 
-export namespace SuperMethod {
-    export const type = new RequestType<TextDocumentPositionParams, MethodLocation[], void, void>('java/superMethod');
+export interface LinkLocation extends Location {
+    displayName: string;
+    kind: string;
+}
+
+export namespace FindLinks {
+    export const type = new RequestType<FindLinksParams, LinkLocation[], void, void>('java/findLinks');
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams, CodeActionParams, WorkspaceEdit, FormattingOptions, WorkspaceSymbolParams, SymbolInformation } from 'vscode-languageclient';
+import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams, CodeActionParams, WorkspaceEdit, FormattingOptions, WorkspaceSymbolParams, SymbolInformation, TextDocumentPositionParams, Location } from 'vscode-languageclient';
 import { Command, Range } from 'vscode';
 
 /**
@@ -341,4 +341,13 @@ export interface SearchSymbolParams extends WorkspaceSymbolParams {
 
 export namespace SearchSymbols {
     export const type = new RequestType<SearchSymbolParams, SymbolInformation[], void, void>('java/searchSymbols');
+}
+
+export interface MethodLocation extends Location {
+    declaringTypeName: string;
+    methodName: string;
+}
+
+export namespace MethodOverride {
+    export const type = new RequestType<TextDocumentPositionParams, MethodLocation[], void, void>('java/methodOverride');
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -348,6 +348,6 @@ export interface MethodLocation extends Location {
     methodName: string;
 }
 
-export namespace MethodOverride {
-    export const type = new RequestType<TextDocumentPositionParams, MethodLocation[], void, void>('java/methodOverride');
+export namespace SuperMethod {
+    export const type = new RequestType<TextDocumentPositionParams, MethodLocation[], void, void>('java/superMethod');
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -54,7 +54,7 @@ suite('Java Language Extension', () => {
 				Commands.GENERATE_DELEGATE_METHODS_PROMPT,
 				Commands.APPLY_REFACTORING_COMMAND,
 				Commands.RENAME_COMMAND,
-				Commands.NAVIGATE_TO_OVERRIDE_COMMAND
+				Commands.NAVIGATE_TO_SUPER_METHOD_COMMAND
 			];
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -54,7 +54,7 @@ suite('Java Language Extension', () => {
 				Commands.GENERATE_DELEGATE_METHODS_PROMPT,
 				Commands.APPLY_REFACTORING_COMMAND,
 				Commands.RENAME_COMMAND,
-				Commands.NAVIGATE_TO_SUPER_METHOD_COMMAND
+				Commands.NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND
 			];
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -53,7 +53,8 @@ suite('Java Language Extension', () => {
 				Commands.GENERATE_CONSTRUCTORS_PROMPT,
 				Commands.GENERATE_DELEGATE_METHODS_PROMPT,
 				Commands.APPLY_REFACTORING_COMMAND,
-				Commands.RENAME_COMMAND
+				Commands.RENAME_COMMAND,
+				Commands.NAVIGATE_TO_OVERRIDE_COMMAND
 			];
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Close #553

It requires https://github.com/eclipse/eclipse.jdt.ls/pull/1165

When hovering on a subtype method who overrides a parent method, show `Go To Super Implementation` link in the top of hover ui, and clicking it will jump to the overridden method.

![image](https://user-images.githubusercontent.com/14052197/65011505-4cbe7880-d946-11e9-910a-6615653e66df.png)

