### PR TITLE
use `vscode.env.appName` instead of hardcoding `VS Code`

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -43,7 +43,7 @@ export function onExtensionChange(extensions: readonly vscode.Extension<any>[]) 
 	}
 
 	if (hasChanged) {
-		const msg = 'Extensions to the Java Language Server changed, reloading Visual Studio Code is required for the changes to take effect.';
+		const msg = `Extensions to the Java Language Server changed, reloading ${vscode.env.appName} is required for the changes to take effect.`;
 		const action = 'Reload';
 		const restartId = Commands.RELOAD_WINDOW;
 		vscode.window.showWarningMessage(msg, action).then((selection) => {

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { workspace, Uri } from 'vscode';
+import { workspace, Uri, env } from 'vscode';
 import * as cp from 'child_process';
 import * as path from 'path';
 import * as pathExists from 'path-exists';
@@ -40,7 +40,7 @@ function checkJavaRuntime(): Promise<string> {
         let source: string;
         let javaHome: string = readJavaConfig();
         if (javaHome) {
-            source = 'java.home variable defined in VS Code settings';
+            source = `java.home variable defined in ${env.appName} settings`;
         } else {
             javaHome = process.env['JDK_HOME'];
             if (javaHome) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { window, Uri, workspace, WorkspaceConfiguration, commands, ConfigurationTarget } from 'vscode';
+import { window, Uri, workspace, WorkspaceConfiguration, commands, ConfigurationTarget, env } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient';
 import { Commands } from './commands';
 import { getJavaConfiguration } from './utils';
@@ -27,7 +27,7 @@ export function onConfigurationChange() {
 			excludeProjectSettingsFiles();
 		}
 		if (hasJavaConfigChanged(oldConfig, newConfig)) {
-			const msg = 'Java Language Server configuration changed, please restart VS Code.';
+			const msg = `Java Language Server configuration changed, please restart ${env.appName}.`;
 			const action = 'Restart Now';
 			const restartId = Commands.RELOAD_WINDOW;
 			oldConfig = newConfig;
@@ -70,7 +70,7 @@ function excludeProjectSettingsFilesForWorkspace(workspaceUri: Uri) {
 				items.unshift(changeItem.global);
 			}
 
-			window.showInformationMessage('Do you want to exclude the VS Code Java project settings files (.classpath, .project. .settings, .factorypath) from the file explorer?', ...items).then((result) => {
+			window.showInformationMessage(`Do you want to exclude the ${env.appName} Java project settings files (.classpath, .project. .settings, .factorypath) from the file explorer?`, ...items).then((result) => {
 				if (result === changeItem.global) {
 					excludedInspectedValue.globalValue = excludedInspectedValue.globalValue || {};
 					for (const hiddenFile of needExcludeFiles) {


### PR DESCRIPTION
fix #1066

`vscode.env.appName` in VS Code is `Visual Studio Code`