### PR TITLE
Global jenv support for vscode-java

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2194,9 +2194,9 @@
       }
     },
     "find-java-home": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-1.0.0.tgz",
-      "integrity": "sha512-eqC9OCUT3stF1zfDJ/g0Uz9XFPi5X+2ZAv84Y+itA2x5scCe6GCF585re8YjjoJeIOipjNMRMM7s2E3ige+6+w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-1.1.0.tgz",
+      "integrity": "sha512-bSTCKNZ193UM/+ZZoNDzICAEHcVywovkhsWCkZALjCvRXQ+zXTe/XATrrP4CpxkaP6YFhQJOpyRpH0P2U/woDA==",
       "requires": {
         "which": "~1.0.5",
         "winreg": "~1.2.2"

--- a/package.json
+++ b/package.json
@@ -554,7 +554,7 @@
   },
   "dependencies": {
     "vscode-languageclient": "5.3.0-next.9",
-    "find-java-home": "1.0.0",
+    "find-java-home": "1.1.0",
     "tmp": "^0.0.33",
     "path-exists": "^3.0.0",
     "expand-home-dir": "^0.0.3",


### PR DESCRIPTION
This is achieved by updating `find-java-home` to which I made patch which should allow it to properly discover the actual sdk paths from the jenv shims. Included in this update there is also some enhanced windows registry based sdk resolving logic.

Also do note, I've not tested this fully in use with vscode, I just played around with the `find-java-home` and it should work. I tired quickly to build this and install it, but then vscode failed to load it always with or without my fixes.