### PR TITLE
Added getDocumentSymbols call to extension API

### DIFF
--- a/src/documentSymbols.ts
+++ b/src/documentSymbols.ts
@@ -1,0 +1,12 @@
+'use strict';
+
+import { LanguageClient, DocumentSymbolParams } from "vscode-languageclient";
+import { DocumentSymbolRequest, DocumentSymbolsResponse } from "./protocol";
+
+export type getDocumentSymbolsCommand = (params: DocumentSymbolParams) => Promise<DocumentSymbolsResponse>;
+
+export function getDocumentSymbolsProvider(languageClient: LanguageClient): getDocumentSymbolsCommand {
+    return async (params: DocumentSymbolParams): Promise<DocumentSymbolsResponse> => {
+        return languageClient.sendRequest(DocumentSymbolRequest.type, params);
+    };
+}

--- a/src/documentSymbols.ts
+++ b/src/documentSymbols.ts
@@ -2,11 +2,14 @@
 
 import {
     CancellationToken,
+    DocumentSymbol,
     DocumentSymbolParams,
     DocumentSymbolRequest,
-    LanguageClient
+    LanguageClient,
+    SymbolInformation
 } from "vscode-languageclient";
-import { DocumentSymbolsResponse } from "./protocol";
+
+type DocumentSymbolsResponse = DocumentSymbol[] | SymbolInformation[] | null;
 
 export type getDocumentSymbolsCommand = (params: DocumentSymbolParams, token?: CancellationToken) => Promise<DocumentSymbolsResponse>;
 

--- a/src/documentSymbols.ts
+++ b/src/documentSymbols.ts
@@ -1,12 +1,20 @@
 'use strict';
 
-import { LanguageClient, DocumentSymbolParams } from "vscode-languageclient";
-import { DocumentSymbolRequest, DocumentSymbolsResponse } from "./protocol";
+import {
+    CancellationToken,
+    DocumentSymbolParams,
+    DocumentSymbolRequest,
+    LanguageClient
+} from "vscode-languageclient";
+import { DocumentSymbolsResponse } from "./protocol";
 
-export type getDocumentSymbolsCommand = (params: DocumentSymbolParams) => Promise<DocumentSymbolsResponse>;
+export type getDocumentSymbolsCommand = (params: DocumentSymbolParams, token?: CancellationToken) => Promise<DocumentSymbolsResponse>;
 
 export function getDocumentSymbolsProvider(languageClient: LanguageClient): getDocumentSymbolsCommand {
-    return async (params: DocumentSymbolParams): Promise<DocumentSymbolsResponse> => {
+    return async (params: DocumentSymbolParams, token?: CancellationToken): Promise<DocumentSymbolsResponse> => {
+        if (token !== undefined) {
+            return languageClient.sendRequest(DocumentSymbolRequest.type, params, token);
+        }
         return languageClient.sendRequest(DocumentSymbolRequest.type, params);
     };
 }

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -1,3 +1,4 @@
+import { getDocumentSymbolsCommand } from './documentSymbols';
 import { RequirementsData } from './requirements';
 import { TextDocumentPositionParams } from 'vscode-languageclient';
 import { CancellationToken, Command, ProviderResult } from 'vscode';
@@ -5,9 +6,12 @@ import { CancellationToken, Command, ProviderResult } from 'vscode';
 export type provideHoverCommandFn = (params: TextDocumentPositionParams, token: CancellationToken) => ProviderResult<Command[] | undefined>;
 export type registerHoverCommand = (callback: provideHoverCommandFn) => void;
 
+export const ExtensionApiVersion = '0.3';
+
 export interface ExtensionAPI {
     readonly apiVersion: string;
 	readonly javaRequirement: RequirementsData;
 	readonly status: "Started" | "Error";
 	readonly registerHoverCommand: registerHoverCommand;
+	readonly getDocumentSymbols: getDocumentSymbolsCommand;
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,6 +1,20 @@
 'use strict';
 
-import { RequestType, NotificationType, TextDocumentIdentifier, ExecuteCommandParams, CodeActionParams, WorkspaceEdit, FormattingOptions, WorkspaceSymbolParams, SymbolInformation, TextDocumentPositionParams, Location } from 'vscode-languageclient';
+import {
+    CodeActionParams,
+    DocumentSymbol,
+    DocumentSymbolParams,
+    ExecuteCommandParams,
+    FormattingOptions,
+    Location,
+    NotificationType,
+    RequestType,
+    SymbolInformation,
+    TextDocumentIdentifier,
+    TextDocumentPositionParams,
+    WorkspaceEdit,
+    WorkspaceSymbolParams,
+} from 'vscode-languageclient';
 import { Command, Range } from 'vscode';
 
 /**
@@ -355,4 +369,10 @@ export interface LinkLocation extends Location {
 
 export namespace FindLinks {
     export const type = new RequestType<FindLinksParams, LinkLocation[], void, void>('java/findLinks');
+}
+
+export type DocumentSymbolsResponse = DocumentSymbol[] | SymbolInformation[] | null;
+
+export namespace DocumentSymbolRequest {
+    export const type = new RequestType<DocumentSymbolParams, DocumentSymbolsResponse, void, void>('textDocument/documentSymbol');
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -2,7 +2,6 @@
 
 import {
     CodeActionParams,
-    DocumentSymbol,
     ExecuteCommandParams,
     FormattingOptions,
     Location,
@@ -369,5 +368,3 @@ export interface LinkLocation extends Location {
 export namespace FindLinks {
     export const type = new RequestType<FindLinksParams, LinkLocation[], void, void>('java/findLinks');
 }
-
-export type DocumentSymbolsResponse = DocumentSymbol[] | SymbolInformation[] | null;

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -3,7 +3,6 @@
 import {
     CodeActionParams,
     DocumentSymbol,
-    DocumentSymbolParams,
     ExecuteCommandParams,
     FormattingOptions,
     Location,
@@ -372,7 +371,3 @@ export namespace FindLinks {
 }
 
 export type DocumentSymbolsResponse = DocumentSymbol[] | SymbolInformation[] | null;
-
-export namespace DocumentSymbolRequest {
-    export const type = new RequestType<DocumentSymbolParams, DocumentSymbolsResponse, void, void>('textDocument/documentSymbol');
-}


### PR DESCRIPTION
Hello everyone,

at Qore Technologies we are working on a VSCode extension and in it we need support for finding symbols in Java files. Adding a whole language server in it and supporting it would be way too much work, especially since your extension already has everything we need. There just wasn't a way to call the language server you are using from outside the extension.

This PR adds function `getDocumentSymbols` to the extension API, which can then be called by other extensions. This function performs `textDocument/documentSymbol` call to the language server and returns a promise with the result.

If you have any questions just ask, or if this PR has incorrect style etc. then I can fix that, no problem.

Signed-off-by: Ondřej Musil <ondrej.musil@qoretechnologies.com>