### PR TITLE
Add `java.project.referencedLibraries` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,32 @@
           ],
           "scope": "window"
         },
+        "java.project.referencedLibraries": {
+          "type": [
+            "array",
+            "object"
+          ],
+          "description": "Configure glob patterns for referencing local libraries to a Java project.",
+          "default": [
+            "lib/**/*.jar"
+          ],
+          "properties": {
+            "include": {
+              "type": "array"
+            },
+            "exclude": {
+              "type": "array"
+            },
+            "sources": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "include"
+          ],
+          "additionalProperties": false,
+          "scope": "resource"
+        },
         "java.contentProvider.preferred": {
           "type": "string",
           "description": "Preferred content provider (a 3rd party decompiler id, usually)",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
             "include"
           ],
           "additionalProperties": false,
-          "scope": "resource"
+          "scope": "window"
         },
         "java.contentProvider.preferred": {
           "type": "string",


### PR DESCRIPTION
This PR adds a setting `java.project.referencedLibraries` based on https://github.com/eclipse/eclipse.jdt.ls/pull/1305.