### PR TITLE
Fix the failure to get trigger file if irrelevant window pops up

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -860,7 +860,7 @@ async function getTriggerFiles(): Promise<string[]> {
 			}
 		}
 
-		for (const javaFile of await workspace.findFiles("**/src/**/*.java", undefined, 1)) { // Find at most 1 java file
+		for (const javaFile of await workspace.findFiles("src/**/*.java", undefined, 1)) { // Find at most 1 java file
             if (isPrefix(rootPath, javaFile.fsPath)) {
 				openedJavaFiles.push(javaFile.toString());
 				return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -860,7 +860,14 @@ async function getTriggerFiles(): Promise<string[]> {
 			}
 		}
 
-		for (const javaFile of await workspace.findFiles("src/**/*.java", undefined, 1)) { // Find at most 1 java file
+		for (const javaFile of await workspace.findFiles("*.java", undefined, 1)) { // Find at most 1 java file
+            if (isPrefix(rootPath, javaFile.fsPath)) {
+				openedJavaFiles.push(javaFile.toString());
+				return;
+			}
+		}
+
+		for (const javaFile of await workspace.findFiles("{src, test}/**/*.java", undefined, 1)) {
             if (isPrefix(rootPath, javaFile.fsPath)) {
 				openedJavaFiles.push(javaFile.toString());
 				return;


### PR DESCRIPTION
Fix #1198 

Trigger file will now try to get documents from all opened text documents, if all trials from previous version failed.