### PR TITLE
Add APIs to get classpaths and settings

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -180,4 +180,8 @@ export namespace Commands {
      * Get the classpaths and modulepaths
      */
     export const GET_CLASSPATHS = 'java.project.getClasspaths';
+    /**
+     * Check the input file is a test file or not
+     */
+    export const IS_TEST_FILE = 'java.project.isTestFile';
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -172,4 +172,12 @@ export namespace Commands {
      * Show server task status
      */
     export const SHOW_SERVER_TASK_STATUS = 'java.show.server.task.status';
+    /**
+     * Get the project settings
+     */
+    export const GET_PROJECT_SETTINGS = 'java.project.getSettings';
+    /**
+     * Get the classpaths and modulepaths
+     */
+    export const GET_CLASSPATHS = 'java.project.getClasspaths';
 }

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -1,12 +1,43 @@
 import { getDocumentSymbolsCommand } from './documentSymbols';
 import { RequirementsData } from './requirements';
 import { TextDocumentPositionParams } from 'vscode-languageclient';
-import { CancellationToken, Command, ProviderResult } from 'vscode';
+import { CancellationToken, Command, ProviderResult, Uri } from 'vscode';
 
 export type provideHoverCommandFn = (params: TextDocumentPositionParams, token: CancellationToken) => ProviderResult<Command[] | undefined>;
 export type registerHoverCommand = (callback: provideHoverCommandFn) => void;
 
-export const ExtensionApiVersion = '0.3';
+/**
+ * Get the project settings.
+ * @param uri Uri of the source/class file needs to be queried.
+ * @param OptionKeys the settings want to query, for example: ["org.eclipse.jdt.core.compiler.compliance"]
+ * @returns An object with all the optionKeys.
+ * @throws Will throw errors if the Uri does not belong to any project.
+ */
+
+export type getProjectSettingsCommand = (uri: string, SettingKeys: string[]) => Promise<Object>;
+
+/**
+ * Get the classpaths and modulepaths.
+ * @param uri Uri of the source/class file needs to be queried.
+ * @param options Query options.
+ * @returns ClasspathResult containing both classpaths and modulepaths.
+ * @throws Will throw errors if the Uri does not belong to any project.
+ */
+
+export type getClasspathsCommand = (uri: string, options: ClasspathQueryOptions) => Promise<ClasspathResult>;
+export type ClasspathQueryOptions = {
+	/**
+     * determine whether the result should contain test or not.
+     */
+    excludingTests: boolean;
+};
+
+export type ClasspathResult = {
+    classpaths: string[];
+    modulepaths: string[];
+};
+
+export const ExtensionApiVersion = '0.4';
 
 export interface ExtensionAPI {
     readonly apiVersion: string;
@@ -14,4 +45,6 @@ export interface ExtensionAPI {
 	readonly status: "Started" | "Error";
 	readonly registerHoverCommand: registerHoverCommand;
 	readonly getDocumentSymbols: getDocumentSymbolsCommand;
+	readonly getProjectSettings: getProjectSettingsCommand;
+	readonly getClasspaths: getClasspathsCommand;
 }

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -27,9 +27,10 @@ export type getProjectSettingsCommand = (uri: string, SettingKeys: string[]) => 
 export type getClasspathsCommand = (uri: string, options: ClasspathQueryOptions) => Promise<ClasspathResult>;
 export type ClasspathQueryOptions = {
 	/**
-     * Determines whether the result should contain tests or not.
-     */
-    excludingTests: boolean;
+	 * Determines the scope of the classpath. Valid scopes are "runtime" and "test".
+	 * If the given scope is not supported, "runtime" will be used.
+	 */
+	scope: string;
 };
 
 export type ClasspathResult = {
@@ -44,7 +45,7 @@ export type ClasspathResult = {
 	/**
 	 * File path array for the modulepaths.
 	 */
-    modulepaths: string[];
+	modulepaths: string[];
 };
 
 /**
@@ -58,7 +59,7 @@ export type isTestFileCommand = (uri: string) => Promise<boolean>;
 export const ExtensionApiVersion = '0.4';
 
 export interface ExtensionAPI {
-    readonly apiVersion: string;
+	readonly apiVersion: string;
 	readonly javaRequirement: RequirementsData;
 	readonly status: "Started" | "Error";
 	readonly registerHoverCommand: registerHoverCommand;

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -1,15 +1,15 @@
 import { getDocumentSymbolsCommand } from './documentSymbols';
 import { RequirementsData } from './requirements';
 import { TextDocumentPositionParams } from 'vscode-languageclient';
-import { CancellationToken, Command, ProviderResult, Uri } from 'vscode';
+import { CancellationToken, Command, ProviderResult, Uri, Event } from 'vscode';
 
 export type provideHoverCommandFn = (params: TextDocumentPositionParams, token: CancellationToken) => ProviderResult<Command[] | undefined>;
 export type registerHoverCommand = (callback: provideHoverCommandFn) => void;
 
 /**
- * Get the project settings.
- * @param uri Uri of the source/class file needs to be queried.
- * @param OptionKeys the settings want to query, for example: ["org.eclipse.jdt.core.compiler.compliance"]
+ * Gets the project settings.
+ * @param uri Uri of the source/class file that needs to be queried.
+ * @param OptionKeys the settings we want to query, for example: ["org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source"]
  * @returns An object with all the optionKeys.
  * @throws Will throw errors if the Uri does not belong to any project.
  */
@@ -17,8 +17,8 @@ export type registerHoverCommand = (callback: provideHoverCommandFn) => void;
 export type getProjectSettingsCommand = (uri: string, SettingKeys: string[]) => Promise<Object>;
 
 /**
- * Get the classpaths and modulepaths.
- * @param uri Uri of the source/class file needs to be queried.
+ * Gets the classpaths and modulepaths.
+ * @param uri Uri of the source/class file that needs to be queried.
  * @param options Query options.
  * @returns ClasspathResult containing both classpaths and modulepaths.
  * @throws Will throw errors if the Uri does not belong to any project.
@@ -27,15 +27,33 @@ export type getProjectSettingsCommand = (uri: string, SettingKeys: string[]) => 
 export type getClasspathsCommand = (uri: string, options: ClasspathQueryOptions) => Promise<ClasspathResult>;
 export type ClasspathQueryOptions = {
 	/**
-     * determine whether the result should contain test or not.
+     * Determines whether the result should contain tests or not.
      */
     excludingTests: boolean;
 };
 
 export type ClasspathResult = {
-    classpaths: string[];
+	/**
+	 * Uri string of the project root path.
+	 */
+	projectRoot: string;
+	/**
+	 * File path array for the classpaths.
+	 */
+	classpaths: string[];
+	/**
+	 * File path array for the modulepaths.
+	 */
     modulepaths: string[];
 };
+
+/**
+ * Checks if the input uri is a test source file or not.
+ * @param uri Uri of the source file that needs to be queried.
+ * @returns `true` if the input uri is a test file in its belonging project, otherwise returns false.
+ * @throws Will throw errors if the Uri does not belong to any project.
+ */
+export type isTestFileCommand = (uri: string) => Promise<boolean>;
 
 export const ExtensionApiVersion = '0.4';
 
@@ -47,4 +65,15 @@ export interface ExtensionAPI {
 	readonly getDocumentSymbols: getDocumentSymbolsCommand;
 	readonly getProjectSettings: getProjectSettingsCommand;
 	readonly getClasspaths: getClasspathsCommand;
+	readonly isTestFile: isTestFileCommand;
+	/**
+	 * An event which fires on classpath update.
+	 *
+	 * Note:
+	 *   1. This event will only fire for Maven/Gradle projects.
+	 *   2. This event will fire when the project's configuration file (e.g. pom.xml for Maven) get changed,
+	 *      but the classpaths might still be the same as before.
+	 *   3. The Uri points to the project root path.
+	 */
+	readonly onDidClasspathUpdate: Event<Uri>;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,8 @@
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
-import { workspace, extensions, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, Uri, CancellationToken, TextDocumentContentProvider, WorkspaceConfiguration, languages, IndentAction, ProgressLocation, InputBoxOptions, Selection, Position, EventEmitter, OutputChannel, TextDocument } from 'vscode';
-import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, LanguageClientOptions, RevealOutputChannelOn, Position as LSPosition, Location as LSLocation, StreamInfo, VersionedTextDocumentIdentifier, ErrorHandler, Message, ErrorAction, CloseAction, InitializationFailedHandler, DidChangeConfigurationNotification } from 'vscode-languageclient';
+import { workspace, extensions, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, Uri, CancellationToken, TextDocumentContentProvider, languages, IndentAction, ProgressLocation, InputBoxOptions, Selection, Position, EventEmitter, OutputChannel, TextDocument } from 'vscode';
+import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, LanguageClientOptions, RevealOutputChannelOn, Position as LSPosition, Location as LSLocation, StreamInfo, ErrorHandler, Message, ErrorAction, CloseAction, DidChangeConfigurationNotification } from 'vscode-languageclient';
 import { onExtensionChange, collectJavaExtensions } from './plugin';
 import { prepareExecutable, awaitServerConnection } from './javaServerStarter';
 import { getDocumentSymbolsCommand, getDocumentSymbolsProvider } from './documentSymbols';
@@ -14,7 +14,7 @@ import {
 	StatusNotification, ClassFileContentsRequest, ProjectConfigurationUpdateRequest, MessageType, ActionableNotification, FeatureStatus, CompileWorkspaceRequest, CompileWorkspaceStatus, ProgressReportNotification, ExecuteClientCommandRequest, SendNotificationRequest,
 	SourceAttachmentRequest, SourceAttachmentResult, SourceAttachmentAttribute
 } from './protocol';
-import { ExtensionAPI, ExtensionApiVersion } from './extension.api';
+import { ExtensionAPI, ExtensionApiVersion, ClasspathQueryOptions, ClasspathResult } from './extension.api';
 import * as buildpath from './buildpath';
 import * as hoverAction from './hoverAction';
 import * as sourceAction from './sourceAction';
@@ -22,7 +22,7 @@ import * as refactorAction from './refactorAction';
 import * as pasteAction from './pasteAction';
 import * as net from 'net';
 import { getJavaConfiguration } from './utils';
-import { onConfigurationChange, excludeProjectSettingsFiles, getKey, IS_WORKSPACE_JDK_ALLOWED } from './settings';
+import { onConfigurationChange, excludeProjectSettingsFiles } from './settings';
 import { logger, initializeLogFile } from './log';
 import glob = require('glob');
 import { SnippetCompletionProvider } from './snippetCompletionProvider';
@@ -242,6 +242,14 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			const snippetProvider: SnippetCompletionProvider = new SnippetCompletionProvider();
 			context.subscriptions.push(languages.registerCompletionItemProvider({ scheme: 'file', language: 'java' }, snippetProvider));
 
+			const getProjectSettings = async (uri: string, SettingKeys: string[]) => {
+				return await commands.executeCommand<Object>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_PROJECT_SETTINGS, uri, SettingKeys);
+			};
+
+			const getClasspaths = async (uri: string, options: ClasspathQueryOptions) => {
+				return await commands.executeCommand<ClasspathResult>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_CLASSPATHS, uri, JSON.stringify(options));
+			};
+
 			languageClient.onReady().then(() => {
 				languageClient.onNotification(StatusNotification.type, (report) => {
 					switch (report.type) {
@@ -253,7 +261,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								javaRequirement: requirements,
 								status: report.type,
 								registerHoverCommand,
-								getDocumentSymbols
+								getDocumentSymbols,
+								getProjectSettings,
+								getClasspaths
 							});
 							snippetProvider.setActivation(false);
 							break;
@@ -264,7 +274,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								javaRequirement: requirements,
 								status: report.type,
 								registerHoverCommand,
-								getDocumentSymbols
+								getDocumentSymbols,
+								getProjectSettings,
+								getClasspaths
 							});
 							break;
 						case 'Starting':


### PR DESCRIPTION
This PR is to enable the SonarLint Java support in VS Code.

The context background can be found here: https://github.com/SonarSource/sonarlint-vscode/pull/28

Related PR for JDT.LS: https://github.com/eclipse/eclipse.jdt.ls/pull/1312

> Note: Please do not merge it until the design is tested and verified. The discussion is [here](https://github.com/SonarSource/sonarlint-vscode/pull/28).

Signed-off-by: Sheng Chen <sheche@microsoft.com>