### PR TITLE
Don't set the -noverify flag if JDK >= 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
             "string",
             "null"
           ],
-          "default": "-noverify -Xmx1G -XX:+UseG1GC -XX:+UseStringDeduplication",
-          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-noverify -Xmx1G  -XX:+UseG1GC -XX:+UseStringDeduplication` to bypass class verification, increase the heap size to 1GB and enable String deduplication with the G1 Garbage collector",
+          "default": "-Xmx1G -XX:+UseG1GC -XX:+UseStringDeduplication",
+          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-Xmx1G  -XX:+UseG1GC -XX:+UseStringDeduplication` to increase the heap size to 1GB and enable String deduplication with the G1 Garbage collector",
           "scope": "window"
         },
         "java.errors.incompleteClasspath.severity": {

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -92,6 +92,13 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 	}
 
 	parseVMargs(params, vmargs);
+	// "OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify
+	// were deprecated in JDK 13 and will likely be removed in a future release."
+	// so only add -noverify for older versions
+	if (params.indexOf('-noverify') < 0 && params.indexOf('-Xverify:none') < 0 && requirements.java_version < 13) {
+		params.push('-noverify');
+	}
+
 	const serverHome: string = path.resolve(__dirname, '../server');
 	const launchersFound: Array<string> = glob.sync('**/plugins/org.eclipse.equinox.launcher_*.jar', { cwd: serverHome });
 	if (launchersFound.length) {


### PR DESCRIPTION
This is to avoid warnings like 
```
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
```