### PR TITLE
Optimize for better memory footprint management.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
             "string",
             "null"
           ],
-          "default": "-Xmx1G -XX:+UseG1GC -XX:+UseStringDeduplication",
-          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-Xmx1G  -XX:+UseG1GC -XX:+UseStringDeduplication` to increase the heap size to 1GB and enable String deduplication with the G1 Garbage collector",
+          "default": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m",
+          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m ` to optimize memory usage for container environments with the parallel garbage collector",
           "scope": "window"
         },
         "java.errors.incompleteClasspath.severity": {


### PR DESCRIPTION
The options can be found in the JVM configuration for the [java-maven devfile](https://github.com/eclipse/che-devfile-registry/blob/master/devfiles/java-maven/devfile.yaml) . Also some additional articles that explain the motivation, and benchmark these options :

https://developers.redhat.com/blog/2014/07/15/dude-wheres-my-paas-memory-tuning-javas-footprint-in-openshift-part-1/
https://developers.redhat.com/blog/2014/07/22/dude-wheres-my-paas-memory-tuning-javas-footprint-in-openshift-part-2/

Use a garbage collector (Parallel) that supports memory footprint
management :

- MinHeapFreeRatio : Heap will be expanded when free heap space is less
than this (%) amount
- MaxHeapFreeRatio : Heap will shrink when free heap space is more than
this (%) amount
- GCTimeRatio : Fraction of time (%) spent performing garbage collection
of total time
- AdaptiveSizePolicyWeight : The extent to which current GC times are
used when maintaining the timing goal as opposed to previous times

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>