### PR TITLE
fix error on canceling source actions

### DIFF
--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -53,7 +53,7 @@ function registerOverrideMethodsCommand(languageClient: LanguageClient, context:
             canPickMany: true,
             placeHolder: `Select methods to override or implement in ${result.type}`
         });
-        if (!selectedItems.length) {
+        if (!selectedItems || !selectedItems.length) {
             return;
         }
 
@@ -95,7 +95,7 @@ function registerHashCodeEqualsCommand(languageClient: LanguageClient, context: 
             canPickMany: true,
             placeHolder:  'Select the fields to include in the hashCode() and equals() methods.'
         });
-        if (!selectedFields.length) {
+        if (!selectedFields || !selectedFields.length) {
             return;
         }
 
@@ -231,7 +231,7 @@ function registerGenerateAccessorsCommand(languageClient: LanguageClient, contex
             canPickMany: true,
             placeHolder:  'Select the fields to generate getters and setters.'
         });
-        if (!selectedAccessors.length) {
+        if (!selectedAccessors || !selectedAccessors.length) {
             return;
         }
 


### PR DESCRIPTION
Repro steps:
- open a .java file, right click, `Source Actions...`
- select `Generate Getters and Setters...`
- when dropdown list occurs, press `ESC` to cancel.
- boom! error occurs.

<img width="400" alt="Screen Shot 2020-02-21 at 12 29 30 AM" src="https://user-images.githubusercontent.com/2351748/74956586-4b3b3400-5441-11ea-8d09-050748c2f218.png">

This PR fixs the same error for:
- implement/override methods
- getters and setters 
- hashcode() and equals()