### PR TITLE
Fix dev mode: Keep config.ini in the installtion location

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -115,7 +115,12 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 	} else if (process.platform === 'linux') {
 		configDir = 'config_linux';
 	}
-	params.push('-configuration'); params.push(resolveConfiguration(context, configDir));
+	params.push('-configuration');
+	if (DEBUG) { // Dev Mode: keep the config.ini in the installation location
+		params.push(path.resolve(__dirname, '../server', configDir));
+	} else {
+		params.push(resolveConfiguration(context, configDir));
+	}
 	params.push('-data'); params.push(workspacePath);
 	return params;
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

In order to avoid polluting the stable language server config directory, keep the config.ini in the original location during dev mode.