### PR TITLE
Enable syntax language server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,35 @@
 			"preLaunchTask": "npm: watch"
 		},
 		{
+			"name": "Launch Extension - SyntaxLS Client",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+			"env": {
+				"SYNTAXLS_CLIENT_PORT": "5037"
+			},
+			"preLaunchTask": "npm: watch"
+		},
+		{
+			"name": "Launch Extension - Hybrid Clients",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+			"env": {
+				"JDTLS_CLIENT_PORT": "5036",
+				"SYNTAXLS_CLIENT_PORT": "5037"
+			},
+			"preLaunchTask": "npm: watch"
+		},
+		{
 			"name": "Launch Tests",
 			"type": "extensionHost",
 			"request": "launch",

--- a/package.json
+++ b/package.json
@@ -506,7 +506,7 @@
           "enum": [
             "Standard",
             "LightWeight",
-            "HighPerformance"
+            "Hybrid"
           ],
           "enumDescriptions": [
             "Provides full features such as intellisense, refactoring, building, Maven/Gradle support etc.",
@@ -514,7 +514,7 @@
             "Provides full features with better responsiveness. It starts a standard language server and a secondary syntax server. The syntax server provides syntax features until the standard server is ready."
           ],
           "description": "The launch mode for the Java extension",
-          "default": "HighPerformance",
+          "default": "Hybrid",
           "scope": "window"
         }
       }

--- a/package.json
+++ b/package.json
@@ -500,6 +500,22 @@
           "default": [],
           "description": "Java Execution Environments -> Runtimes.",
           "scope": "machine"
+        },
+        "java.server.launchMode": {
+          "type": "string",
+          "enum": [
+            "Standard",
+            "LightWeight",
+            "HighPerformance"
+          ],
+          "enumDescriptions": [
+            "Provides full features such as intellisense, refactoring, building, Maven/Gradle support etc.",
+            "Starts a syntax server with lower start-up cost. Only provides syntax features such as outline, navigation, javadoc, syntax errors.",
+            "Provides full features with better responsiveness. It starts a standard language server and a secondary syntax server. The syntax server provides syntax features until the standard server is ready."
+          ],
+          "description": "The launch mode for the Java extension",
+          "default": "HighPerformance",
+          "scope": "window"
         }
       }
     },

--- a/src/hoverAction.ts
+++ b/src/hoverAction.ts
@@ -4,20 +4,19 @@ import { commands, ExtensionContext, HoverProvider, languages, CancellationToken
 import { LanguageClient, TextDocumentPositionParams, HoverRequest } from "vscode-languageclient";
 import { Commands as javaCommands } from "./commands";
 import { FindLinks } from "./protocol";
-import { registerHoverCommand, provideHoverCommandFn } from "./extension.api";
+import { provideHoverCommandFn } from "./extension.api";
 import { logger } from "./log";
 
-export function registerClientHoverProvider(languageClient: LanguageClient, context: ExtensionContext): registerHoverCommand {
+export function createClientHoverProvider(languageClient: LanguageClient, context: ExtensionContext): JavaHoverProvider {
     const hoverProvider: JavaHoverProvider = new JavaHoverProvider(languageClient);
     hoverProvider.registerHoverCommand(async (params: TextDocumentPositionParams, token: CancellationToken) => {
         return await provideHoverCommand(languageClient, params, token);
     });
-    context.subscriptions.push(languages.registerHoverProvider('java', hoverProvider));
     context.subscriptions.push(commands.registerCommand(javaCommands.NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND, (location: any) => {
         navigateToSuperImplementation(languageClient, location);
     }));
 
-    return hoverProvider.registerHoverCommand;
+    return hoverProvider;
 }
 
 async function provideHoverCommand(languageClient: LanguageClient, params: TextDocumentPositionParams, token: CancellationToken): Promise<Command[] | undefined> {

--- a/src/providerDispatcher.ts
+++ b/src/providerDispatcher.ts
@@ -1,0 +1,106 @@
+'use strict';
+
+import { LanguageClient, DocumentSymbolRequest, SymbolInformation as clientSymbolInformation, DocumentSymbol as clientDocumentSymbol, HoverRequest } from "vscode-languageclient";
+import { ExtensionContext, languages, DocumentSymbolProvider, TextDocument, CancellationToken, SymbolInformation, ProviderResult, DocumentSymbol, TextDocumentContentProvider, workspace, Uri, Event, HoverProvider, Position, Hover } from "vscode";
+import { SyntaxLanguageClient } from "./syntaxLanguageClient";
+import { ClassFileContentsRequest } from "./protocol";
+import { provideHoverCommandFn } from "./extension.api";
+import { createClientHoverProvider } from "./hoverAction";
+
+export interface ProviderOptions {
+	standardClient: LanguageClient;
+	syntaxClient?: SyntaxLanguageClient;
+	contentProviderEvent: Event<Uri>;
+}
+
+export interface ProviderHandle {
+	handles: any[];
+}
+
+export function registerClientProviders(context: ExtensionContext, options: ProviderOptions): ProviderHandle {
+	const hoverProvider = new ClientHoverProvider(options, context);
+	context.subscriptions.push(languages.registerHoverProvider('java', hoverProvider));
+
+	const symbolProvider = createDocumentSymbolProvider(options);
+	context.subscriptions.push(languages.registerDocumentSymbolProvider('java', symbolProvider));
+
+	const jdtProvider = createJDTContentProvider(options);
+	context.subscriptions.push(workspace.registerTextDocumentContentProvider('jdt', jdtProvider));
+	return {
+		handles: [hoverProvider, symbolProvider, jdtProvider]
+	};
+}
+
+export class ClientHoverProvider implements HoverProvider {
+	private delegateProvider;
+
+	constructor(private options: ProviderOptions, context: ExtensionContext) {
+		if (options.standardClient) {
+			this.delegateProvider = createClientHoverProvider(options.standardClient, context);
+		}
+	}
+
+	async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover> {
+		if (this.options.syntaxClient && this.options.syntaxClient.isAlive()) {
+			const languageClient: LanguageClient = this.options.syntaxClient.getClient();
+			await languageClient.onReady();
+			const params = {
+				textDocument: languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document),
+				position: languageClient.code2ProtocolConverter.asPosition(position)
+			};
+			const hoverResponse = await languageClient.sendRequest(HoverRequest.type, params);
+			return languageClient.protocol2CodeConverter.asHover(hoverResponse);
+		} else if (this.delegateProvider) {
+			return this.delegateProvider.provideHover(document, position, token);
+		}
+	}
+
+	registerHoverCommand(callback: provideHoverCommandFn) {
+		if (this.delegateProvider) {
+			this.delegateProvider.registerHoverCommand(callback);
+		}
+	}
+}
+
+function createJDTContentProvider(options: ProviderOptions): TextDocumentContentProvider {
+	return <TextDocumentContentProvider>{
+		onDidChange: options.contentProviderEvent,
+		provideTextDocumentContent: async (uri: Uri, token: CancellationToken): Promise<string> => {
+			let languageClient: LanguageClient = options.standardClient;
+			if (options.syntaxClient && options.syntaxClient.isAlive() && uri.fragment === "syntaxserver") {
+				languageClient = options.syntaxClient.getClient();
+			}
+
+			await languageClient.onReady();
+			return languageClient.sendRequest(ClassFileContentsRequest.type, { uri: uri.toString() }, token).then((v: string): string => {
+				return v || '';
+			});
+		}
+	};
+}
+
+function createDocumentSymbolProvider(options: ProviderOptions): DocumentSymbolProvider {
+	return <DocumentSymbolProvider>{
+		provideDocumentSymbols: async (document: TextDocument, token: CancellationToken): Promise<SymbolInformation[] | DocumentSymbol[]> => {
+			let languageClient: LanguageClient = options.standardClient;
+			if (options.syntaxClient && options.syntaxClient.isAlive()) {
+				languageClient = options.syntaxClient.getClient();
+			}
+
+			await languageClient.onReady();
+			const params = {
+				textDocument: languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document),
+			};
+			const symbolResponse = await languageClient.sendRequest(DocumentSymbolRequest.type, params);
+			if (!symbolResponse || !symbolResponse.length) {
+				return [];
+			}
+
+			if ((<any>symbolResponse[0]).containerName) {
+				return languageClient.protocol2CodeConverter.asSymbolInformations(<clientSymbolInformation[]>symbolResponse);
+			}
+
+			return languageClient.protocol2CodeConverter.asDocumentSymbols(<clientDocumentSymbol[]>symbolResponse);
+		}
+	};
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -101,7 +101,8 @@ function excludeProjectSettingsFilesForWorkspace(workspaceUri: Uri) {
 function hasJavaConfigChanged(oldConfig: WorkspaceConfiguration, newConfig: WorkspaceConfiguration) {
 	return hasConfigKeyChanged('home', oldConfig, newConfig)
 		|| hasConfigKeyChanged('jdt.ls.vmargs', oldConfig, newConfig)
-		|| hasConfigKeyChanged('progressReports.enabled', oldConfig, newConfig);
+		|| hasConfigKeyChanged('progressReports.enabled', oldConfig, newConfig)
+		|| hasConfigKeyChanged('server.launchMode', oldConfig, newConfig);
 }
 
 function hasConfigKeyChanged(key, oldConfig, newConfig) {
@@ -191,4 +192,15 @@ export function getJavaagentFlag(vmargs) {
 		}
 	}
 	return agentFlag;
+}
+
+export enum ServerMode {
+	STANDARD = 'Standard',
+	LIGHTWEIGHT = 'LightWeight',
+	HIGHPERFORMANCE = 'HighPerformance'
+}
+
+export function getJavaServerMode(): ServerMode {
+	return workspace.getConfiguration().get('java.server.launchMode')
+		|| ServerMode.HIGHPERFORMANCE;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -197,10 +197,10 @@ export function getJavaagentFlag(vmargs) {
 export enum ServerMode {
 	STANDARD = 'Standard',
 	LIGHTWEIGHT = 'LightWeight',
-	HIGHPERFORMANCE = 'HighPerformance'
+	HYBRID = 'Hybrid'
 }
 
 export function getJavaServerMode(): ServerMode {
 	return workspace.getConfiguration().get('java.server.launchMode')
-		|| ServerMode.HIGHPERFORMANCE;
+		|| ServerMode.HYBRID;
 }

--- a/src/syntaxLanguageClient.ts
+++ b/src/syntaxLanguageClient.ts
@@ -1,0 +1,72 @@
+import * as net from "net";
+import { LanguageClientOptions, StreamInfo, LanguageClient, ServerOptions, DidChangeConfigurationNotification } from "vscode-languageclient";
+import { OutputInfoCollector, ClientErrorHandler, getJavaConfig } from "./extension";
+import { logger } from "./log";
+
+const extensionName = "Language Support for Java (Syntax Server)";
+
+export class SyntaxLanguageClient {
+	private languageClient: LanguageClient;
+	private stopping: boolean = false;
+
+	public initialize(requirements, clientOptions: LanguageClientOptions, serverOptions?: ServerOptions) {
+		const newClientOptions: LanguageClientOptions = Object.assign({}, clientOptions, {
+			middleware: {
+				workspace: {
+					didChangeConfiguration: () => {
+						this.languageClient.sendNotification(DidChangeConfigurationNotification.type, {
+							settings: {
+								java: getJavaConfig(requirements.java_home),
+							}
+						});
+					}
+				}
+			},
+			errorHandler: new ClientErrorHandler(extensionName),
+			initializationFailedHandler: error => {
+				logger.error(`Failed to initialize ${extensionName} due to ${error && error.toString()}`);
+				return true;
+			},
+			outputChannel: new OutputInfoCollector(extensionName),
+			outputChannelName: extensionName
+		});
+
+		const lsPort = process.env['SYNTAXLS_CLIENT_PORT'];
+		if (!serverOptions && lsPort) {
+			serverOptions = () => {
+				const socket = net.connect(lsPort);
+				const result: StreamInfo = {
+					writer: socket,
+					reader: socket
+				};
+				return Promise.resolve(result);
+			};
+		}
+
+		if (serverOptions) {
+			this.languageClient = new LanguageClient('java', extensionName, serverOptions, newClientOptions);
+		}
+	}
+
+	public start(): void {
+		if (this.languageClient) {
+			this.languageClient.start();
+		}
+	}
+
+	public stop() {
+		this.stopping = true;
+		if (this.languageClient) {
+			this.languageClient.stop();
+			this.languageClient = null;
+		}
+	}
+
+	public isAlive(): boolean {
+		return !!this.languageClient && !this.stopping;
+	}
+
+	public getClient(): LanguageClient {
+		return this.languageClient;
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It requires https://github.com/eclipse/eclipse.jdt.ls/pull/1386

This PR exposes a new user setting `java.server.launchMode` to control whether to enable syntax language server, below is the accepted values:
- Standard
Provides full features such as intellisense, refactoring, building, Maven/Gradle support etc.
- LightWeight
Starts a syntax server with lower start-up cost. Only provides syntax features such as outline, navigation, javadoc, syntax errors. The lightweight mode won't load thirdparty extensions, such as java test runner, java debugger, etc.
 - Hybrid
Provides full features with better responsiveness. It starts a standard language server and a secondary syntax server. The syntax server provides syntax features until the standard server is ready. And the syntax server will be shutdown automatically after the standard server is fully ready.

