### PR TITLE
Auto fill file contents when new a Java file

### DIFF
--- a/src/buildpath.ts
+++ b/src/buildpath.ts
@@ -15,7 +15,7 @@ interface SourcePath {
     projectType: string;
 }
 
-interface ListCommandResult extends Result {
+export interface ListCommandResult extends Result {
     data?: SourcePath[];
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { SnippetCompletionProvider } from './snippetCompletionProvider';
 import { serverTasks } from './serverTasks';
 import { serverTaskPresenter } from './serverTaskPresenter';
 import { serverStatus, ServerStatusKind } from './serverStatus';
+import * as fileEventHandler from './fileEventHandler';
 
 let languageClient: LanguageClient;
 const jdtEventEmitter = new EventEmitter<Uri>();
@@ -275,6 +276,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								onDidClasspathUpdate
 							});
 							snippetProvider.setActivation(false);
+							fileEventHandler.setServerStatus(true);
 							break;
 						case 'Error':
 							serverStatus.updateServerStatus(ServerStatusKind.Error);
@@ -289,6 +291,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 								isTestFile,
 								onDidClasspathUpdate
 							});
+							fileEventHandler.setServerStatus(true);
 							break;
 						case 'Starting':
 						case 'Message':
@@ -467,6 +470,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 					window.showErrorMessage(`Failed to delete ${workspacePath}: ${error}`);
 				}
 			}
+
+			fileEventHandler.registerFileEventHandlers(languageClient, context);
 
 			languageClient.start();
 			// Register commands here to make it available even when the language client fails

--- a/src/fileEventHandler.ts
+++ b/src/fileEventHandler.ts
@@ -8,16 +8,16 @@ import { Commands } from './commands';
 
 let serverReady: boolean = false;
 
-export function setServerStatus(onReady: boolean) {
-    serverReady = onReady;
+export function setServerStatus(ready: boolean) {
+    serverReady = ready;
 }
 
 export function registerFileEventHandlers(client: LanguageClient, context: ExtensionContext, ) {
-    context.subscriptions.push(workspace.onDidCreateFiles(didCreateFiles));
+    context.subscriptions.push(workspace.onDidCreateFiles(handleNewJavaFiles));
 }
 
-async function didCreateFiles(e: FileCreateEvent) {
-    const emptyFiles: string[] = [];
+async function handleNewJavaFiles(e: FileCreateEvent) {
+    const emptyFiles: Uri[] = [];
     const textDocuments: TextDocument[] = [];
     for (const uri of e.files) {
         if (!uri.fsPath || !uri.fsPath.endsWith(".java")) {
@@ -29,7 +29,7 @@ async function didCreateFiles(e: FileCreateEvent) {
             continue;
         }
 
-        emptyFiles.push(uri.fsPath);
+        emptyFiles.push(uri);
         textDocuments.push(textDocument);
     }
 
@@ -46,19 +46,20 @@ async function didCreateFiles(e: FileCreateEvent) {
     }
 
     for (let i = 0; i < emptyFiles.length; i++) {
+        const packageName = resolvePackageName(sourcePaths, emptyFiles[i].fsPath);
+        const typeName: string = resolveTypeName(textDocuments[i].fileName);
         const snippets: string[] = [];
-        const packageName = resolvePackageName(sourcePaths, emptyFiles[i]);
         if (packageName) {
             snippets.push(`package ${packageName};`);
         }
-
-        const typeName: string = resolveTypeName(textDocuments[i].fileName);
-        snippets.push(...[
-            "",
-            `public \${1|class,interface,enum|} ${typeName} {`,
-            "",
-            "}"
-        ]);
+        snippets.push("");
+        if (!serverReady || await isVersionLessThan(emptyFiles[i].toString(), 14)) {
+            snippets.push(`public \${1|class,interface,enum|} ${typeName} {`);
+        } else {
+            snippets.push(`public \${1|class ${typeName},interface ${typeName},enum ${typeName},record ${typeName}()|} {`);
+        }
+        snippets.push("");
+        snippets.push("}");
         const textEditor = await window.showTextDocument(textDocuments[i]);
         textEditor.insertSnippet(new SnippetString(snippets.join("\n")));
     }
@@ -88,4 +89,33 @@ function resolvePackageName(sourcePaths: string[], filePath: string): string {
 function isPrefix(parentPath: string, filePath: string): boolean {
     const relative = path.relative(parentPath, filePath);
     return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+const COMPLIANCE = "org.eclipse.jdt.core.compiler.compliance";
+async function isVersionLessThan(fileUri: string, targetVersion: number): Promise<boolean> {
+    let projectSettings = {};
+    try {
+        projectSettings = await commands.executeCommand<Object>(
+            Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_PROJECT_SETTINGS, fileUri, [ COMPLIANCE ]);
+    } catch (err) {
+        // do nothing.
+    }
+
+    let javaVersion = 0;
+    let complianceVersion = projectSettings[COMPLIANCE];
+    if (complianceVersion) {
+        // Ignore '1.' prefix for legacy Java versions
+        if (complianceVersion.startsWith('1.')) {
+            complianceVersion = complianceVersion.substring(2);
+        }
+
+        // look into the interesting bits now
+        const regexp = /\d+/g;
+        const match = regexp.exec(complianceVersion);
+        if (match) {
+            javaVersion = parseInt(match[0]);
+        }
+    }
+
+    return javaVersion < targetVersion;
 }

--- a/src/fileEventHandler.ts
+++ b/src/fileEventHandler.ts
@@ -1,0 +1,91 @@
+'use strict';
+
+import * as path from 'path';
+import { workspace, FileCreateEvent, ExtensionContext, FileRenameEvent, window, TextDocument, SnippetString, commands, Uri } from 'vscode';
+import { LanguageClient } from 'vscode-languageclient';
+import { ListCommandResult } from './buildpath';
+import { Commands } from './commands';
+
+let serverReady: boolean = false;
+
+export function setServerStatus(onReady: boolean) {
+    serverReady = onReady;
+}
+
+export function registerFileEventHandlers(client: LanguageClient, context: ExtensionContext, ) {
+    context.subscriptions.push(workspace.onDidCreateFiles(didCreateFiles));
+}
+
+async function didCreateFiles(e: FileCreateEvent) {
+    const emptyFiles: string[] = [];
+    const textDocuments: TextDocument[] = [];
+    for (const uri of e.files) {
+        if (!uri.fsPath || !uri.fsPath.endsWith(".java")) {
+            continue;
+        }
+
+        const textDocument = await workspace.openTextDocument(uri);
+        if (textDocument.getText()) { // ignore the non-empty files
+            continue;
+        }
+
+        emptyFiles.push(uri.fsPath);
+        textDocuments.push(textDocument);
+    }
+
+    if (!emptyFiles.length) {
+        return;
+    }
+
+    let sourcePaths: string[] = [];
+    if (serverReady) {
+        const result: ListCommandResult = await commands.executeCommand<ListCommandResult>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.LIST_SOURCEPATHS);
+        if (result && result.data && result.data.length) {
+            sourcePaths = result.data.map((sourcePath) => sourcePath.path).sort((a, b) => b.length - a.length);
+        }
+    }
+
+    for (let i = 0; i < emptyFiles.length; i++) {
+        const snippets: string[] = [];
+        const packageName = resolvePackageName(sourcePaths, emptyFiles[i]);
+        if (packageName) {
+            snippets.push(`package ${packageName};`);
+        }
+
+        const typeName: string = resolveTypeName(textDocuments[i].fileName);
+        snippets.push(...[
+            "",
+            `public \${1|class,interface,enum|} ${typeName} {`,
+            "",
+            "}"
+        ]);
+        const textEditor = await window.showTextDocument(textDocuments[i]);
+        textEditor.insertSnippet(new SnippetString(snippets.join("\n")));
+    }
+}
+
+function resolveTypeName(filePath: string): string {
+    const fileName: string = path.basename(filePath);
+    const extName: string = path.extname(fileName);
+    return fileName.substring(0, fileName.length - extName.length);
+}
+
+function resolvePackageName(sourcePaths: string[], filePath: string): string {
+    if (!sourcePaths || !sourcePaths.length) {
+        return "";
+    }
+
+    for (const sourcePath of sourcePaths) {
+        if (isPrefix(sourcePath, filePath)) {
+            const relative = path.relative(sourcePath, path.dirname(filePath));
+            return relative.replace(/[\/\\]/g, ".");
+        }
+    }
+
+    return "";
+}
+
+function isPrefix(parentPath: string, filePath: string): boolean {
+    const relative = path.relative(parentPath, filePath);
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix #1222

- If the language server is not initialized yet, new file will only generate the class structure.
- If the language server is ready, then resolve the package name and populate both the package statement and class contents.
- If the new file is not belonged to any known source paths, then leave the package as default.

![newfile](https://user-images.githubusercontent.com/14052197/77510070-e4c68d00-6ea8-11ea-8a47-6064506d96d9.gif)
