### PR TITLE
Support semantic tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ New in 0.60.0:
 * `java.sources.organizeImports.staticStarThreshold`: Specifies the number of static imports added before a star-import declaration is used, default is 99.
 * `java.semanticHighlighting.enabled`: Enable/disable the [semantic highlighting](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview). Defaults to `true`.
 
+Semantic Highlighting
+===============
+[Semantic Highlighting](https://code.visualstudio.com/updates/v1_43#_typescript-semantic-highlighting) is a new feature enabled since VS Code 1.43. Color themes can now write [rules](https://code.visualstudio.com/updates/v1_44#_theme-support-for-semantic-tokens) to color semantic tokens reported by this extension. If current color theme does not provide any, you can define your own rules in user settings, e.g.
+```json
+"editor.tokenColorCustomizationsExperimental": {
+    "variable":{
+        "foreground": "#9CDCFE" // change color for tokens of type 'variable'
+    },
+    "*.static":{
+        "fontStyle": "italic" // all tokens with modifier 'static' should be of italic style
+    },
+    "*.final":{
+        "fontStyle": "bold" // all tokens with modifier 'final' should be of bold style
+    }
+}
+```
+
+More details in [Semantic Highlighting Wiki Page (Token Styling)](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview#token-styling).
+
 Troubleshooting
 ===============
 1. Check the status of the language tools on the lower right corner (marked with A on image below).

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ The following settings are supported:
 
   Default launch mode is `Hybrid`. Legacy mode is `Standard`
 
-  New in 0.60.0:
+New in 0.60.0:
 * `java.sources.organizeImports.starThreshold`: Specifies the number of imports added before a star-import declaration is used, default is 99.
 * `java.sources.organizeImports.staticStarThreshold`: Specifies the number of static imports added before a star-import declaration is used, default is 99.
+* `java.semanticHighlighting.enabled`: Enable/disable the [semantic highlighting](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview). Defaults to `true`.
 
 Troubleshooting
 ===============

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
-      "integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
+      "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
       "dev": true
     },
     "@types/winston": {
@@ -714,9 +714,9 @@
       }
     },
     "base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -890,14 +890,13 @@
       }
     },
     "buffer": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-      "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
       "dev": true,
       "requires": {
-        "base64-js": "0.0.8",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -1444,7 +1443,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -1494,9 +1493,9 @@
       "dev": true
     },
     "decompress": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "dev": true,
       "requires": {
         "decompress-tar": "^4.0.0",
@@ -1725,7 +1724,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -2694,9 +2693,9 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             }
@@ -3733,7 +3732,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -4088,7 +4087,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -4527,9 +4526,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }
@@ -4555,7 +4554,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -4677,7 +4676,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -4934,7 +4933,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -5565,7 +5564,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -6474,13 +6473,13 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
-      "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.0.tgz",
+      "integrity": "sha512-kVx7CDAsdBSWVf404Mw7oI9i09w5/mTT/Ruk+RWa64PLYKvsAucLLFHvQtnvjeADM4ZizxrvG5SHnF4Te4T2Cg==",
       "dev": true,
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "unc-path-regex": {
@@ -7208,7 +7207,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "preview": true,
   "enableProposedApi": false,
   "engines": {
-    "vscode": "^1.41.0"
+    "vscode": "^1.44.0"
   },
   "repository": {
     "type": "git",
@@ -526,7 +526,12 @@
         "java.sources.organizeImports.staticStarThreshold": {
           "type": "integer",
           "description": "Specifies the number of static imports added before a star-import declaration is used.",
-          "default": 99,
+          "default": 99
+        },
+        "java.semanticHighlighting.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the semantic highlighting.",
           "scope": "window"
         }
       }
@@ -693,7 +698,7 @@
     "@types/lodash.findindex": "^4.6.6",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.51",
-    "@types/vscode": "^1.41.0",
+    "@types/vscode": "^1.44.0",
     "@types/winston": "^2.4.4",
     "gulp": "^4.0.0",
     "gulp-decompress": "2.0.1",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -184,4 +184,12 @@ export namespace Commands {
      * Check the input file is a test file or not
      */
     export const IS_TEST_FILE = 'java.project.isTestFile';
+    /**
+     * Temporary command for Semantic Highlighting. To remove when LSP v3.16 is ready.
+     */
+    export const PROVIDE_SEMANTIC_TOKENS = 'java.project.provideSemanticTokens';
+    /**
+     * Temporary command to fetch Semantic Tokens Legend. To remove when LSP v3.16 is ready.
+     */
+    export const GET_SEMANTIC_TOKENS_LEGEND = 'java.project.getSemanticTokensLegend';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { serverStatus, ServerStatusKind } from './serverStatus';
 import { SyntaxLanguageClient } from './syntaxLanguageClient';
 import { registerClientProviders, ClientHoverProvider } from './providerDispatcher';
 import * as fileEventHandler from './fileEventHandler';
+import { registerSemanticTokensProvider } from './semanticTokenProvider';
 
 let languageClient: LanguageClient;
 const syntaxClient: SyntaxLanguageClient = new SyntaxLanguageClient();
@@ -517,6 +518,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_WORKSPACE, () => cleanWorkspace(workspacePath)));
 
 			context.subscriptions.push(onConfigurationChange(languageClient, context));
+
+			// temporary implementation Semantic Highlighting before it is part of LSP
+			registerSemanticTokensProvider(context);
 		});
 	});
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -475,6 +475,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						});
 					}
 					excludeProjectSettingsFiles();
+
+					// temporary implementation Semantic Highlighting before it is part of LSP
+					registerSemanticTokensProvider(context);
 				});
 			}
 
@@ -519,8 +522,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 			context.subscriptions.push(onConfigurationChange(languageClient, context));
 
-			// temporary implementation Semantic Highlighting before it is part of LSP
-			registerSemanticTokensProvider(context);
 		});
 	});
 }

--- a/src/semanticTokenProvider.ts
+++ b/src/semanticTokenProvider.ts
@@ -3,7 +3,11 @@ import { Commands } from './commands';
 import { getJavaConfiguration } from './utils';
 
 export function registerSemanticTokensProvider(context: vscode.ExtensionContext) {
-	if (isSemanticHTokensEnabled()) {
+	if (!vscode.languages.registerDocumentSemanticTokensProvider) { // in case Theia doesn't support this API
+		return;
+	}
+
+	if (isSemanticHighlightingEnabled()) {
 		getSemanticTokensLegend().then(legend => {
 			const semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider({ scheme: 'file', language: 'java' }, semanticTokensProvider, legend);
 			context.subscriptions.push(semanticTokensProviderDisposable);
@@ -38,7 +42,7 @@ function onceSemanticTokenEnabledChange(context: vscode.ExtensionContext, regist
 	const configChangeListener = vscode.workspace.onDidChangeConfiguration(e => {
 		configChangeListener.dispose();
 		if (e.affectsConfiguration('java.semanticHighlighting.enabled')) {
-			if (isSemanticHTokensEnabled()) {
+			if (isSemanticHighlightingEnabled()) {
 				// turn on
 				registerSemanticTokensProvider(context);
 			} else if (registeredDisposable) {
@@ -50,7 +54,7 @@ function onceSemanticTokenEnabledChange(context: vscode.ExtensionContext, regist
 	});
 }
 
-function isSemanticHTokensEnabled(): boolean {
+function isSemanticHighlightingEnabled(): boolean {
 	const config = getJavaConfiguration();
 	const section = 'semanticHighlighting.enabled';
 	return config.get(section);

--- a/src/semanticTokenProvider.ts
+++ b/src/semanticTokenProvider.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { Commands } from './commands';
+import { getJavaConfiguration } from './utils';
+
+export function registerSemanticTokensProvider(context: vscode.ExtensionContext) {
+	if (isSemanticHTokensEnabled()) {
+		getSemanticTokensLegend().then(legend => {
+			const semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider({ scheme: 'file', language: 'java' }, semanticTokensProvider, legend);
+			context.subscriptions.push(semanticTokensProviderDisposable);
+			onceSemanticTokenEnabledChange(context, semanticTokensProviderDisposable);
+		});
+	} else {
+		onceSemanticTokenEnabledChange(context, undefined);
+	}
+}
+
+class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+    async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens> {
+        const response = await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.PROVIDE_SEMANTIC_TOKENS, document.uri.toString());
+        if (token.isCancellationRequested) {
+            return undefined;
+        }
+        return response as vscode.SemanticTokens;
+    }
+}
+
+const semanticTokensProvider = new SemanticTokensProvider();
+
+async function getSemanticTokensLegend(): Promise<vscode.SemanticTokensLegend | undefined> {
+    const response = await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_SEMANTIC_TOKENS_LEGEND) as vscode.SemanticTokensLegend;
+    if (response && response.tokenModifiers !== undefined && response.tokenTypes !== undefined) {
+        return new vscode.SemanticTokensLegend(response.tokenTypes, response.tokenModifiers);
+    }
+    return undefined;
+}
+
+function onceSemanticTokenEnabledChange(context: vscode.ExtensionContext, registeredDisposable?: vscode.Disposable) {
+	const configChangeListener = vscode.workspace.onDidChangeConfiguration(e => {
+		configChangeListener.dispose();
+		if (e.affectsConfiguration('java.semanticHighlighting.enabled')) {
+			if (isSemanticHTokensEnabled()) {
+				// turn on
+				registerSemanticTokensProvider(context);
+			} else if (registeredDisposable) {
+				// turn off
+				registeredDisposable.dispose();
+			}
+			onceSemanticTokenEnabledChange(context);
+		}
+	});
+}
+
+function isSemanticHTokensEnabled(): boolean {
+	const config = getJavaConfiguration();
+	const section = 'semanticHighlighting.enabled';
+	return config.get(section);
+}


### PR DESCRIPTION
depends on https://github.com/eclipse/eclipse.jdt.ls/pull/1408

To enable [Semantic Highlighting](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview), this PR registers a semantic tokens provider, which actually forward the request to the language server via a delegate command. After semantic highlighting becomes part of LSP, the provider and related delegate commands should be removed, and LS should respond directly to corresponding LSP requests