### PR TITLE
Add Go to Super Implementation to context menu and command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -671,6 +671,11 @@
         "command": "java.show.server.task.status",
         "title": "Show Build Job Status",
         "category": "Java"
+      },
+      {
+        "command": "java.action.navigateToSuperImplementation",
+        "title": "Go to Super Implementation",
+        "category": "Java"
       }
     ],
     "keybindings": [
@@ -718,6 +723,11 @@
           "command": "java.projectConfiguration.update",
           "when": "resourceFilename =~ /(.*\\.gradle)|(pom.xml)$/",
           "group": "1_javaactions"
+        },
+        {
+          "command": "java.action.navigateToSuperImplementation",
+          "when": "javaLSReady && editorTextFocus && editorLangId == java",
+          "group": "navigation@90"
         }
       ],
       "commandPalette": [
@@ -728,6 +738,10 @@
         {
           "command": "java.project.import",
           "when": "javaLSReady"
+        },
+        {
+          "command": "java.action.navigateToSuperImplementation",
+          "when": "javaLSReady && editorLangId == java"
         },
         {
           "command": "java.workspace.compile",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,6 +30,11 @@ export namespace Commands {
     export const SHOW_REFERENCES = 'editor.action.showReferences';
 
     /**
+     * Go to editor location
+     */
+    export const GOTO_LOCATION = 'editor.action.goToLocations';
+
+    /**
      * Update project configuration
      */
     export const CONFIGURATION_UPDATE = 'java.projectConfiguration.update';

--- a/test/lightweight-mode-suite/publicApi.test.ts
+++ b/test/lightweight-mode-suite/publicApi.test.ts
@@ -54,7 +54,7 @@ suite('Public APIs - LightWeight', () => {
 				continue;
 			}
 			symbolDetected = true;
-			assert.equal((symbol as DocumentSymbol).children.length, 3);
+			assert.equal((symbol as DocumentSymbol).children.length, 4);
 		}
 		if (!symbolDetected) {
 			assert.fail('Failed to get document symbols');

--- a/test/resources/projects/maven/salut/src/main/java/java/Foo3.java
+++ b/test/resources/projects/maven/salut/src/main/java/java/Foo3.java
@@ -18,4 +18,9 @@ public class Foo3 {
 		System.out.println(this.properties);
 		System.out.println(util);
 	}
+
+	@Override
+	public String toString() {
+		return "Foo3 [properties=" + properties + "]";
+	}
 }

--- a/test/standard-mode-suite/gotoSuperImplementation.test.ts
+++ b/test/standard-mode-suite/gotoSuperImplementation.test.ts
@@ -1,0 +1,30 @@
+'use strict';
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { Uri, extensions, commands, TextDocument, workspace, window, Selection, Position } from 'vscode';
+import { Commands } from '../../src/commands';
+
+const projectFsPath: string = path.join(__dirname, '..', '..', '..', 'test', 'resources', 'projects', 'maven', 'salut');
+const fileFsPath: string = path.join(projectFsPath, 'src', 'main', 'java', 'java', 'Foo3.java');
+
+// tslint:disable: only-arrow-functions
+suite('Goto Super Implementation', () => {
+
+	suiteSetup(async function() {
+		await extensions.getExtension('redhat.java').activate();
+	});
+
+	test('go to super implementation should work', async function () {
+		const document: TextDocument = await workspace.openTextDocument(Uri.file(path.join(fileFsPath)));
+		await window.showTextDocument(document);
+		window.activeTextEditor.selection = new Selection(
+			new Position(22, 18),
+			new Position(22, 18),
+		);
+
+		await commands.executeCommand(Commands.NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND);
+
+		assert.equal(path.basename(window.activeTextEditor.document.fileName), "Object.class");
+	});
+});

--- a/test/standard-mode-suite/publicApi.test.ts
+++ b/test/standard-mode-suite/publicApi.test.ts
@@ -58,7 +58,7 @@ suite('Public APIs - Standard', () => {
 				continue;
 			}
 			symbolDetected = true;
-			assert.equal((symbol as DocumentSymbol).children.length, 3);
+			assert.equal((symbol as DocumentSymbol).children.length, 4);
 		}
 		if (!symbolDetected) {
 			assert.fail('Failed to get document symbols');


### PR DESCRIPTION
![demo](https://user-images.githubusercontent.com/6193897/79424914-826a3380-7ff3-11ea-850c-c360df608e8e.gif)

Note: so far, if the selected element has no super implementation, we are not able to show the editor message. This need VS Code to support such API. See: https://github.com/microsoft/vscode/issues/95308

Signed-off-by: Sheng Chen <sheche@microsoft.com>