### PR TITLE
Refactor package name from file explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ The following settings are supported:
 * `java.semanticHighlighting.enabled`: Enable/disable [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) for Java files. Defaults to `false`.
 * `java.requirements.JDK11Warning`: Enable/disable a warning about the impending requirement of Java 11. Defaults to `true`.
 
+New in 0.61.0:
+* `java.refactor.renameFromFileExplorer`: Specifies whether to update imports and package declarations when renaming files from File Explorer. Defaults to `prompt`.
+  - `never`: Don't enable refactoring for rename operations on File Explorer.
+  - `autoApply`: Always automatically update the imports and package declarations.
+  - `preview`: Always preview the changes before applying.
+  - `prompt`: Ask user to confirm whether to bypass refactor preview.
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) is controlled by the `java.semanticHighlighting.enabled` preference. When enabled, it fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience different small issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing.

--- a/package.json
+++ b/package.json
@@ -544,16 +544,18 @@
           "type": "string",
           "enum": [
             "Never",
-            "AutoApply",
-            "PreviewBeforeApply"
+            "AlwaysAutoApply",
+            "AlwaysPreview",
+            "Prompt"
           ],
           "enumDescriptions": [
             "Don't enable refactoring for rename operations on File Explorer.",
             "Always automatically update the imports and package declarations.",
-            "Always preview the changes before applying."
+            "Always preview the changes before applying.",
+            "Ask user to confirm whether to bypass refactor preview."
           ],
           "description": "Specifies whether to update imports and package declarations when renaming files from File Explorer.",
-          "default": "PreviewBeforeApply",
+          "default": "Prompt",
           "scope": "window"
         }
       }

--- a/package.json
+++ b/package.json
@@ -543,10 +543,10 @@
         "java.refactor.renameFromFileExplorer": {
           "type": "string",
           "enum": [
-            "Never",
-            "AlwaysAutoApply",
-            "AlwaysPreview",
-            "Prompt"
+            "never",
+            "autoApply",
+            "preview",
+            "prompt"
           ],
           "enumDescriptions": [
             "Don't enable refactoring for rename operations on File Explorer.",
@@ -555,7 +555,7 @@
             "Ask user to confirm whether to bypass refactor preview."
           ],
           "description": "Specifies whether to update imports and package declarations when renaming files from File Explorer.",
-          "default": "Prompt",
+          "default": "prompt",
           "scope": "window"
         }
       }

--- a/package.json
+++ b/package.json
@@ -539,6 +539,22 @@
           "description": "Enable/disable a warning about the impending requirement of Java 11.",
           "default": true,
           "scope": "window"
+        },
+        "java.refactor.renameFromFileExplorer": {
+          "type": "string",
+          "enum": [
+            "Never",
+            "AutoApply",
+            "PreviewBeforeApply"
+          ],
+          "enumDescriptions": [
+            "Don't enable refactoring for rename operations on File Explorer.",
+            "Always automatically update the imports and package declarations.",
+            "Always preview the changes before applying."
+          ],
+          "description": "Specifies whether to update imports and package declarations when renaming files from File Explorer.",
+          "default": "PreviewBeforeApply",
+          "scope": "window"
         }
       }
     },

--- a/src/fileEventHandler.ts
+++ b/src/fileEventHandler.ts
@@ -179,7 +179,6 @@ async function handleRenameFiles(e: FileRenameEvent, client: LanguageClient) {
 
         if (edit) {
             askForConfirmation();
-            await new Promise((resolve) =>setTimeout(resolve, 400)); // wait for the document lifecycle events to be synced to the server.
             const codeEdit = asPreviewWorkspaceEdit(edit, client.protocol2CodeConverter, isPreviewRenameRefactoring(), "Rename updates", e.files);
             workspace.applyEdit(codeEdit);
         }

--- a/src/fileEventHandler.ts
+++ b/src/fileEventHandler.ts
@@ -231,6 +231,11 @@ function askForConfirmation() {
 
             if (answer === "Refactor automatically") {
                 workspace.getConfiguration().update(PREFERENCE_KEY, Preference.AlwaysAutoApply, ConfigurationTarget.Global);
+                try {
+                    commands.executeCommand("refactorPreview.apply");
+                } catch (error) {
+                    console.error(error);
+                }
             } else if (answer === "Always preview changes") {
                 workspace.getConfiguration().update(PREFERENCE_KEY, Preference.AlwaysPreview, ConfigurationTarget.Global);
             }

--- a/src/fileEventHandler.ts
+++ b/src/fileEventHandler.ts
@@ -14,10 +14,10 @@ let pendingEditPromise: Promise<LsWorkspaceEdit>;
 
 const PREFERENCE_KEY = "java.refactor.renameFromFileExplorer";
 const enum Preference {
-    Never = "Never",
-    AlwaysAutoApply = "AlwaysAutoApply",
-    AlwaysPreview = "AlwaysPreview",
-    Prompt = "Prompt"
+    Never = "never",
+    AlwaysAutoApply = "autoApply",
+    AlwaysPreview = "preview",
+    Prompt = "prompt"
 }
 
 export function setServerStatus(ready: boolean) {
@@ -223,18 +223,18 @@ async function handleRenameFiles(e: FileRenameEvent, client: LanguageClient) {
 
 function askForConfirmation() {
     if (needsConfirmRenameRefactoring()) {
-        window.showInformationMessage("Do you want to always preview the changes for rename refactoring?",
-            "Yes", "No").then(async (answer) => {
-                if (!answer) {
-                    return;
-                }
+        window.showInformationMessage("Do you want to automatically apply refactoring when renaming?",
+            "Refactor automatically", "Always preview changes").then(async (answer) => {
+            if (!answer) {
+                return;
+            }
 
-                if (answer === "Yes") {
-                    workspace.getConfiguration().update(PREFERENCE_KEY, Preference.AlwaysPreview, ConfigurationTarget.Global);
-                } else if (answer === "No") {
-                    workspace.getConfiguration().update(PREFERENCE_KEY, Preference.AlwaysAutoApply, ConfigurationTarget.Global);
-                }
-            });
+            if (answer === "Refactor automatically") {
+                workspace.getConfiguration().update(PREFERENCE_KEY, Preference.AlwaysAutoApply, ConfigurationTarget.Global);
+            } else if (answer === "Always preview changes") {
+                workspace.getConfiguration().update(PREFERENCE_KEY, Preference.AlwaysPreview, ConfigurationTarget.Global);
+            }
+        });
     }
 }
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -376,3 +376,7 @@ export interface FileRenameParams {
 export namespace DidRenameFiles {
     export const type = new RequestType<FileRenameParams, WorkspaceEdit, void, void>('java/didRenameFiles');
 }
+
+export namespace WillRenameFiles {
+    export const type = new RequestType<FileRenameParams, WorkspaceEdit, void, void>('java/willRenameFiles');
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix #823

This PR requires https://github.com/eclipse/eclipse.jdt.ls/pull/1414, it will rename the files and subpackages when renaming the package.

Rename package:
![renamePackage](https://user-images.githubusercontent.com/14052197/79823240-da26e700-83c5-11ea-8ed4-5058edf66310.gif)

Rename subpackages:
![renameSubPackage](https://user-images.githubusercontent.com/14052197/79823258-e8750300-83c5-11ea-8c0d-87c456ef84c3.gif)
