### PR TITLE
Prompt to enable Semantic Hightlighting on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,31 +154,18 @@ The following settings are supported:
   - `Hybrid`: Provides full features with better responsiveness. It starts a standard language server and a secondary syntax server. The syntax server provides syntax features until the standard server is ready. And the syntax server will be shutdown automatically after the standard server is fully ready.
 
   Default launch mode is `Hybrid`. Legacy mode is `Standard`
-
-New in 0.60.0:
 * `java.sources.organizeImports.starThreshold`: Specifies the number of imports added before a star-import declaration is used, default is 99.
 * `java.sources.organizeImports.staticStarThreshold`: Specifies the number of static imports added before a star-import declaration is used, default is 99.
-* `java.semanticHighlighting.enabled`: Enable/disable the [semantic highlighting](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview). Defaults to `false`.
-`java.requirements.JDK11Warning`: Enable/disable a warning about the impending requirement of Java 11. Defaults to `true`.
+* `java.semanticHighlighting.enabled`: Enable/disable [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) for Java files. Defaults to `false`.
+* `java.requirements.JDK11Warning`: Enable/disable a warning about the impending requirement of Java 11. Defaults to `true`.
 
 Semantic Highlighting
 ===============
-[Semantic Highlighting](https://code.visualstudio.com/updates/v1_43#_typescript-semantic-highlighting) is a new feature enabled since VS Code 1.43. Color themes can now write [rules](https://code.visualstudio.com/updates/v1_44#_theme-support-for-semantic-tokens) to color semantic tokens reported by this extension. If current color theme does not provide any, you can define your own rules in user settings, e.g.
-```json
-"editor.tokenColorCustomizationsExperimental": {
-    "variable":{
-        "foreground": "#9CDCFE" // change color for tokens of type 'variable'
-    },
-    "*.static":{
-        "fontStyle": "italic" // all tokens with modifier 'static' should be of italic style
-    },
-    "*.final":{
-        "fontStyle": "bold" // all tokens with modifier 'final' should be of bold style
-    }
-}
-```
-Disabled by default, as it's still experimental, it can be enabled with `"java.semanticHighlighting.enabled":true` in settings.json.
-More details in [Semantic Highlighting Wiki Page (Token Styling)](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview#token-styling).
+[Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) is controlled by the `java.semanticHighlighting.enabled` preference. When enabled, it fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience different small issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing.
+
+You will be prompted to enable or disable it on startup:
+
+![](https://user-images.githubusercontent.com/148698/80595049-65d2f000-8a24-11ea-8d9c-19b05b9cac15.png)
 
 Troubleshooting
 ===============

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,16 @@ export function getJavaConfiguration(): WorkspaceConfiguration {
 	return workspace.getConfiguration('java');
 }
 
+export function isPreferenceOverridden(section: string): boolean {
+	const config = workspace.getConfiguration();
+	return config.inspect(section).workspaceFolderValue !== undefined ||
+			config.inspect(section).workspaceFolderLanguageValue !== undefined ||
+			config.inspect(section).workspaceValue !== undefined ||
+			config.inspect(section).workspaceLanguageValue !== undefined ||
+			config.inspect(section).globalValue !== undefined ||
+			config.inspect(section).globalLanguageValue !== undefined;
+}
+
 export function deleteDirectory(dir) {
 	if (fs.existsSync(dir)) {
 		fs.readdirSync(dir).forEach((child) => {


### PR DESCRIPTION
Display this prompt when the `java.semanticHighlighting.enabled` preference has not be set explicitely:

![](https://user-images.githubusercontent.com/148698/80595049-65d2f000-8a24-11ea-8d9c-19b05b9cac15.png)

Message links to https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting