### PR TITLE
Added goToDefinition call to extension API

### DIFF
--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -1,4 +1,5 @@
 import { getDocumentSymbolsCommand } from './documentSymbols';
+import { goToDefinitionCommand } from './goToDefinition';
 import { RequirementsData } from './requirements';
 import { TextDocumentPositionParams } from 'vscode-languageclient';
 import { CancellationToken, Command, ProviderResult, Uri, Event } from 'vscode';
@@ -56,7 +57,7 @@ export type ClasspathResult = {
  */
 export type isTestFileCommand = (uri: string) => Promise<boolean>;
 
-export const ExtensionApiVersion = '0.4';
+export const ExtensionApiVersion = '0.5';
 
 export interface ExtensionAPI {
 	readonly apiVersion: string;
@@ -77,4 +78,5 @@ export interface ExtensionAPI {
 	 *   3. The Uri points to the project root path.
 	 */
 	readonly onDidClasspathUpdate: Event<Uri>;
+	readonly goToDefinition: goToDefinitionCommand;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, LanguageCl
 import { onExtensionChange, collectJavaExtensions } from './plugin';
 import { prepareExecutable, awaitServerConnection } from './javaServerStarter';
 import { getDocumentSymbolsCommand, getDocumentSymbolsProvider } from './documentSymbols';
+import { goToDefinitionCommand, goToDefinitionProvider } from './goToDefinition';
 import * as requirements from './requirements';
 import { Commands } from './commands';
 import {
@@ -260,6 +261,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				languageClient = new LanguageClient('java', extensionName, serverOptions, clientOptions);
 				languageClient.registerProposedFeatures();
 				const getDocumentSymbols: getDocumentSymbolsCommand = getDocumentSymbolsProvider(languageClient);
+				const goToDefinition: goToDefinitionCommand = goToDefinitionProvider(languageClient);
 
 				const snippetProvider: SnippetCompletionProvider = new SnippetCompletionProvider();
 				context.subscriptions.push(languages.registerCompletionItemProvider({ scheme: 'file', language: 'java' }, snippetProvider));
@@ -297,7 +299,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 									getProjectSettings,
 									getClasspaths,
 									isTestFile,
-									onDidClasspathUpdate
+									onDidClasspathUpdate,
+									goToDefinition: goToDefinition
 								});
 								snippetProvider.setActivation(false);
 								fileEventHandler.setServerStatus(true);
@@ -313,7 +316,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 									getProjectSettings,
 									getClasspaths,
 									isTestFile,
-									onDidClasspathUpdate
+									onDidClasspathUpdate,
+									goToDefinition: goToDefinition
 								});
 								fileEventHandler.setServerStatus(true);
 								break;

--- a/src/goToDefinition.ts
+++ b/src/goToDefinition.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import {
+	CancellationToken,
+	Location,
+	LocationLink,
+	DefinitionParams,
+	DefinitionRequest,
+	LanguageClient,
+} from 'vscode-languageclient';
+
+type GoToDefinitionResponse = Location | Location[] | LocationLink[] | null;
+
+export type goToDefinitionCommand = (params: DefinitionParams, token?: CancellationToken) => Promise<GoToDefinitionResponse>;
+
+export function goToDefinitionProvider(languageClient: LanguageClient): goToDefinitionCommand {
+    return async (params: DefinitionParams, token?: CancellationToken): Promise<GoToDefinitionResponse> => {
+        if (token !== undefined) {
+            return languageClient.sendRequest(DefinitionRequest.type, params, token);
+        }
+        return languageClient.sendRequest(DefinitionRequest.type, params);
+    };
+}


### PR DESCRIPTION
For this enhancement: https://github.com/redhat-developer/vscode-java/issues/1416

At Alibaba we are working on a VSCode extension and in it we need finding a method's defination in Java files. Your extension has everything we need, but there just wasn't a way to call the language server you are using from outside the extension. 

This PR add function gotoDefinitionSymbols to the extension API, which can then be called by other extensions. This function performs textDocument/definition call to the language server and return a promise with the result.

If you have any questions just ask, or if this PR has incorrect style etc. then I can fix that, no problem.

Signed-off-by: kaihang.xkh <kaihang.xkh@alibaba-inc.com>