### PR TITLE
return semantic tokens as Uint32Array

### DIFF
--- a/src/semanticTokenProvider.ts
+++ b/src/semanticTokenProvider.ts
@@ -32,11 +32,14 @@ export function registerSemanticTokensProvider(context: vscode.ExtensionContext)
 
 class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
     async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens> {
-        const response = await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.PROVIDE_SEMANTIC_TOKENS, document.uri.toString());
+        const response = <any> await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.PROVIDE_SEMANTIC_TOKENS, document.uri.toString());
         if (token.isCancellationRequested) {
             return undefined;
         }
-        return response as vscode.SemanticTokens;
+        if (!response || !response.data) {
+            return undefined;
+        }
+        return new vscode.SemanticTokens(new Uint32Array(response.data), response.resultId);
     }
 }
 


### PR DESCRIPTION
currently it's returned as `number[]`, causing random failures of semantic highlighting.

See [vscode's API]( https://github.com/microsoft/vscode/blob/bd0efff9e3f36d6b3e1045cee9887003af8034d7/src/vs/vscode.d.ts#L3242) and https://github.com/microsoft/vscode/issues/96664#issuecomment-623311367

