### PR TITLE
Show Java source level in the status bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,7 +453,7 @@
         },
         "java.configuration.runtimes": {
           "type": "array",
-          "description": "Map Java Execution Environments to local JDKs",
+          "description": "Map Java Execution Environments to local JDKs.",
           "items": {
             "type": "object",
             "default": {},
@@ -476,19 +476,19 @@
                   "JavaSE-13",
                   "JavaSE-14"
                 ],
-                "description": "Java Execution Environment name. Must be unique"
+                "description": "Java Execution Environment name. Must be unique."
               },
               "path": {
                 "type": "string",
-                "description": "JDK path.\nOn Windows, backslashes must be escaped, i.e.\n\"path\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\""
+                "description": "JDK path.\nOn Windows, backslashes must be escaped, i.e.\n\"path\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"."
               },
               "sources": {
                 "type": "string",
-                "description": "JDK sources."
+                "description": "JDK sources path."
               },
               "javadoc": {
                 "type": "string",
-                "description": "JDK javadoc."
+                "description": "JDK javadoc path."
               },
               "default": {
                 "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -453,7 +453,7 @@
         },
         "java.configuration.runtimes": {
           "type": "array",
-          "label": "Map Java Execution Environments to local JDKs",
+          "description": "Map Java Execution Environments to local JDKs",
           "items": {
             "type": "object",
             "default": {},
@@ -476,29 +476,28 @@
                   "JavaSE-13",
                   "JavaSE-14"
                 ],
-                "label": "Java Execution Environment name. Must be unique"
+                "description": "Java Execution Environment name. Must be unique"
               },
               "path": {
                 "type": "string",
-                "label": "JDK path.\nOn Windows, backslashes must be escaped, i.e.\n\"path\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\""
+                "description": "JDK path.\nOn Windows, backslashes must be escaped, i.e.\n\"path\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\""
               },
               "sources": {
                 "type": "string",
-                "label": "JDK sources."
+                "description": "JDK sources."
               },
               "javadoc": {
                 "type": "string",
-                "label": "JDK javadoc."
+                "description": "JDK javadoc."
               },
               "default": {
                 "type": "boolean",
-                "label": "Is default runtime? Only one runtime can be default."
+                "description": "Is default runtime? Only one runtime can be default."
               }
             },
             "additionalProperties": false
           },
           "default": [],
-          "description": "Java Execution Environments -> Runtimes.",
           "scope": "machine"
         },
         "java.server.launchMode": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -185,6 +185,10 @@ export namespace Commands {
      */
     export const IS_TEST_FILE = 'java.project.isTestFile';
     /**
+     * Get all java projects root path in URI format
+     */
+    export const GET_ALL_JAVA_PROJECTS = 'java.project.getAll';
+    /**
      * Temporary command for Semantic Highlighting. To remove when LSP v3.16 is ready.
      */
     export const PROVIDE_SEMANTIC_TOKENS = 'java.project.provideSemanticTokens';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -287,7 +287,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						switch (report.type) {
 							case 'ServiceReady':
 								syntaxClient.stop();
-								runtimeStatusBarProvider.initialize(onDidClasspathUpdate);
+								runtimeStatusBarProvider.initialize(onDidClasspathUpdate, context.storagePath);
 								break;
 							case 'Started':
 								serverStatus.updateServerStatus(ServerStatusKind.Ready);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import { SyntaxLanguageClient } from './syntaxLanguageClient';
 import { registerClientProviders, ClientHoverProvider } from './providerDispatcher';
 import * as fileEventHandler from './fileEventHandler';
 import { registerSemanticTokensProvider } from './semanticTokenProvider';
+import { runtimeStatusBarProvider } from './runtimeStatusBarProvider';
 
 let languageClient: LanguageClient;
 const syntaxClient: SyntaxLanguageClient = new SyntaxLanguageClient();
@@ -286,6 +287,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						switch (report.type) {
 							case 'ServiceReady':
 								syntaxClient.stop();
+								runtimeStatusBarProvider.initialize(onDidClasspathUpdate);
 								break;
 							case 'Started':
 								serverStatus.updateServerStatus(ServerStatusKind.Ready);

--- a/src/javaRuntime.ts
+++ b/src/javaRuntime.ts
@@ -1,0 +1,9 @@
+'use strict';
+
+export function getJavaRuntimeFromVersion(ver: string) {
+    if (ver === "1.5") {
+        return "J2SE-1.5";
+    }
+
+    return `JavaSE-${ver}`;
+}

--- a/src/javaRuntime.ts
+++ b/src/javaRuntime.ts
@@ -1,9 +1,0 @@
-'use strict';
-
-export function getJavaRuntimeFromVersion(ver: string) {
-    if (ver === "1.5") {
-        return "J2SE-1.5";
-    }
-
-    return `JavaSE-${ver}`;
-}

--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -9,7 +9,7 @@ class RuntimeStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
 	private javaProjects: Map<string, IProjectInfo>;
 	private fileProjectMapping: Map<string, string>;
-	private storagePath: string;
+	private storagePath: string | undefined;
 	private disposables: Disposable[];
 
 	constructor() {
@@ -18,9 +18,12 @@ class RuntimeStatusBarProvider implements Disposable {
 		this.disposables = [];
 	}
 
-	public async initialize(onClasspathUpdate: Event<Uri>, storagePath: string): Promise<void> {
+	public async initialize(onClasspathUpdate: Event<Uri>, storagePath?: string): Promise<void> {
 		// ignore the hash part to make it compatible in debug mode.
-		this.storagePath = Uri.file(path.join(storagePath, "..", "..")).fsPath;
+		if (storagePath) {
+			this.storagePath = Uri.file(path.join(storagePath, "..", "..")).fsPath;
+		}
+
 		this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 0);
 		let projectUriStrings: string[];
 		try {
@@ -144,7 +147,9 @@ class RuntimeStatusBarProvider implements Disposable {
 	}
 
 	private isDefaultProjectPath(fsPath: string) {
-		return fsPath.startsWith(this.storagePath) && fsPath.indexOf("jdt.ls-java-project") > -1;
+		// this.storagePath === undefined indicates that it's in standalone file mode
+		return !this.storagePath ||
+			fsPath.startsWith(this.storagePath) && fsPath.indexOf("jdt.ls-java-project") > -1;
 	}
 
 	private getJavaRuntimeFromVersion(ver: string) {

--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -1,0 +1,142 @@
+'use strict';
+
+import { StatusBarItem, window, StatusBarAlignment, TextEditor, Uri, commands, Event, FileSystemProvider } from "vscode";
+import { Commands } from "./commands";
+import { Disposable } from "vscode-languageclient";
+import * as path from "path";
+import { getJavaRuntimeFromVersion } from "./javaRuntime";
+
+class RuntimeStatusBarProvider implements Disposable {
+	private statusBarItem: StatusBarItem;
+	private javaProjects: Map<string, IProjectInfo>;
+	private fileProjectMapping: Map<string, string>;
+	private disposables: Disposable[];
+
+	constructor() {
+		this.javaProjects = new Map<string, IProjectInfo>();
+		this.fileProjectMapping = new Map<string, string>();
+		this.disposables = [];
+	}
+
+	public async initialize(onClasspathUpdate: Event<Uri>): Promise<void> {
+		this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 0);
+		let projectUriStrings: string[];
+		try {
+			projectUriStrings = await commands.executeCommand<string[]>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_ALL_JAVA_PROJECTS);
+		} catch (e) {
+			return;
+		}
+
+		for (const uri of projectUriStrings) {
+			this.javaProjects.set(Uri.parse(uri).fsPath, undefined);
+		}
+
+		this.statusBarItem.command = {
+			title: "Configure Java Runtime",
+			command: "workbench.action.openSettings",
+			arguments: ["java.configuration.runtimes"],
+		};
+		this.statusBarItem.tooltip = "Configure Java Runtime";
+
+		this.disposables.push(window.onDidChangeActiveTextEditor((textEditor) => {
+			this.updateItem(textEditor);
+		}));
+
+		onClasspathUpdate(async (e) => {
+			for (const projectPath of this.javaProjects.keys()) {
+				if (path.relative(projectPath, e.fsPath) === '') {
+					this.javaProjects.set(projectPath, undefined);
+					await this.updateItem(window.activeTextEditor);
+					return;
+				}
+			}
+		});
+
+		await this.updateItem(window.activeTextEditor);
+	}
+
+	public dispose(): void {
+		this.statusBarItem.dispose();
+		for (const disposable of this.disposables) {
+			disposable.dispose();
+		}
+	}
+
+	private findBelongingProject(uri: Uri): string {
+		if (this.fileProjectMapping.has(uri.fsPath)) {
+			return this.fileProjectMapping.get(uri.fsPath);
+		}
+
+		let belongingProjectPath: string;
+		for (const projectPath of this.javaProjects.keys()) {
+			if (uri.fsPath.startsWith(projectPath)) {
+				if (!belongingProjectPath) {
+					belongingProjectPath = projectPath;
+					continue;
+				}
+
+				if (projectPath.length > belongingProjectPath.length) {
+					belongingProjectPath = projectPath;
+				}
+			}
+		}
+
+		if (belongingProjectPath) {
+			this.fileProjectMapping.set(uri.fsPath, belongingProjectPath);
+		}
+
+		return belongingProjectPath;
+	}
+
+	private async getProjectInfo(projectPath: string): Promise<IProjectInfo> {
+		if (this.javaProjects.get(projectPath)) {
+			return this.javaProjects.get(projectPath);
+		}
+
+		try {
+			const settings: {} = await commands.executeCommand<{}>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_PROJECT_SETTINGS, Uri.file(projectPath).toString(), ["org.eclipse.jdt.core.compiler.source"]);
+			const sourceLevel: string = settings["org.eclipse.jdt.core.compiler.source"];
+			if (!sourceLevel) {
+				return undefined;
+			}
+
+			const projectInfo: IProjectInfo = { sourceLevel };
+			this.javaProjects.set(projectPath, projectInfo);
+			return projectInfo;
+
+		} catch (e) {
+			// do nothing
+		}
+
+		return undefined;
+	}
+
+	private async updateItem(textEditor: TextEditor): Promise<void> {
+		if (!textEditor || path.extname(textEditor.document.fileName) !== ".java") {
+			this.statusBarItem.hide();
+			return;
+		}
+
+		const uri: Uri = textEditor.document.uri;
+		const projectPath: string = this.findBelongingProject(uri);
+		if (!projectPath) {
+			this.statusBarItem.hide();
+			return;
+		}
+
+		const projectInfo: IProjectInfo = await this.getProjectInfo(projectPath);
+		if (!projectInfo) {
+			this.statusBarItem.hide();
+			return;
+		}
+
+		this.statusBarItem.text = getJavaRuntimeFromVersion(projectInfo.sourceLevel);
+		this.statusBarItem.show();
+	}
+}
+
+interface IProjectInfo {
+	sourceLevel: string;
+}
+
+export const runtimeStatusBarProvider: RuntimeStatusBarProvider = new RuntimeStatusBarProvider();


### PR DESCRIPTION
requires: https://github.com/eclipse/eclipse.jdt.ls/pull/1447

![Kapture 2020-05-19 at 14 38 57](https://user-images.githubusercontent.com/6193897/82294546-e7dd8580-99e0-11ea-856d-817577de3c51.gif)

1. The status bar item will only show up when current active editor is `.java` file
2. The status bar item is used to show the project's source level
3. In the future the status bar item might be used as an entry to expose more commands

requires https://github.com/eclipse/eclipse.jdt.ls/pull/1447

Signed-off-by: Sheng Chen <sheche@microsoft.com>