### PR TITLE
Show VM install location on hover

### DIFF
--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -10,7 +10,9 @@ export type registerHoverCommand = (callback: provideHoverCommandFn) => void;
 /**
  * Gets the project settings.
  * @param uri Uri of the file that needs to be queried. Accepted uris are: source file, class file and project root path.
- * @param OptionKeys the settings we want to query, for example: ["org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source"]
+ * @param OptionKeys the settings we want to query, for example: ["org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source"].
+ *                   Besides the options defined in JavaCore, the following keys can also be used:
+ *                   - "org.eclipse.jdt.ls.vm.location": Get the location of the VM assigned to build the given Java project
  * @returns An object with all the optionKeys.
  * @throws Will throw errors if the Uri does not belong to any project.
  */

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -12,7 +12,7 @@ export type registerHoverCommand = (callback: provideHoverCommandFn) => void;
  * @param uri Uri of the file that needs to be queried. Accepted uris are: source file, class file and project root path.
  * @param OptionKeys the settings we want to query, for example: ["org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source"].
  *                   Besides the options defined in JavaCore, the following keys can also be used:
- *                   - "org.eclipse.jdt.ls.vm.location": Get the location of the VM assigned to build the given Java project
+ *                   - "org.eclipse.jdt.ls.core.vm.location": Get the location of the VM assigned to build the given Java project
  * @returns An object with all the optionKeys.
  * @throws Will throw errors if the Uri does not belong to any project.
  */


### PR DESCRIPTION
requires: https://github.com/eclipse/eclipse.jdt.ls/pull/1454

Show the VM's installation path when the mouse hovers on the status bar item.

This could better telling the user: what's the source level and what's the JDK used now.

<img width="449" alt="Screen Shot 2020-05-26 at 1 32 00 PM" src="https://user-images.githubusercontent.com/6193897/82863671-56789100-9f55-11ea-9a1a-e008efe0befc.png">


Signed-off-by: Sheng Chen <sheche@microsoft.com>