### PR TITLE
Fix debug mode detection

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -158,9 +158,15 @@ function resolveConfiguration(context, configDir) {
 }
 
 function startedInDebugMode(): boolean {
-	const args = (process as any).execArgv;
+	const args = (process as any).execArgv as string[];
+	return hasDebugFlag(args);
+}
+
+// exported for tests
+export function hasDebugFlag(args: string[]): boolean {
 	if (args) {
-		return args.some((arg) => /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg) || /^--inspect-brk=?/.test(arg));
+		// See https://nodejs.org/en/docs/guides/debugging-getting-started/
+		return args.some( arg => /^--inspect/.test(arg) || /^--debug/.test(arg));
 	}
 	return false;
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -125,4 +125,15 @@ suite('Java Language Extension', () => {
 		assert.equal(requirements.parseMajorVersion('version "9.0.1"'), 9);
 		assert.equal(requirements.parseMajorVersion('version "10-ea"'), 10);
 	});
+
+	test('should detect debug flag', () => {
+		assert(!java.hasDebugFlag(['debug', '-debug']));
+		assert(java.hasDebugFlag(['foo', '--inspect']));
+		assert(java.hasDebugFlag(['foo', '--inspect=127.0.0.1:1234']));
+		assert(java.hasDebugFlag(['foo', '--inspect-brk']));
+		assert(java.hasDebugFlag(['foo', '--inspect-brk=127.0.0.1:1234']));
+		// deprecated flags
+		assert(java.hasDebugFlag(['foo', '--debug=1234']));
+		assert(java.hasDebugFlag(['foo', '--debug-brk=1234']));
+	});
 });


### PR DESCRIPTION
It was no longer possible to start a remote Java debugger on jdt.ls,
because the debug flags used to start the hosted vscode extension have changed.