### PR TITLE
Improve 'launching from source' detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,9 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"env": {
+				"DEBUG_VSCODE_JAVA":"true"
+			},
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
@@ -23,7 +26,8 @@
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
 			"env": {
-				"SERVER_PORT": "3333"
+				"SERVER_PORT": "3333",
+				"DEBUG_VSCODE_JAVA":"true"
 			},
 			"preLaunchTask": "npm: watch"
 		},
@@ -37,7 +41,8 @@
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
 			"env": {
-				"JDTLS_CLIENT_PORT": "5036"
+				"JDTLS_CLIENT_PORT": "5036",
+				"DEBUG_VSCODE_JAVA":"true"
 			},
 			"preLaunchTask": "npm: watch"
 		},
@@ -51,7 +56,8 @@
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
 			"env": {
-				"SYNTAXLS_CLIENT_PORT": "5037"
+				"SYNTAXLS_CLIENT_PORT": "5037",
+				"DEBUG_VSCODE_JAVA":"true"
 			},
 			"preLaunchTask": "npm: watch"
 		},
@@ -66,7 +72,8 @@
 			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
 			"env": {
 				"JDTLS_CLIENT_PORT": "5036",
-				"SYNTAXLS_CLIENT_PORT": "5037"
+				"SYNTAXLS_CLIENT_PORT": "5037",
+				"DEBUG_VSCODE_JAVA":"true"
 			},
 			"preLaunchTask": "npm: watch"
 		},

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -117,7 +117,8 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 		configDir = isSyntaxServer ? 'config_ss_linux' : 'config_linux';
 	}
 	params.push('-configuration');
-	if (DEBUG) { // Dev Mode: keep the config.ini in the installation location
+	if (startedFromSources()) { // Dev Mode: keep the config.ini in the installation location
+		console.log(`Starting jdt.ls ${isSyntaxServer?'(syntax)' : '(standard)'} from vscode-java sources`);
 		params.push(path.resolve(__dirname, '../server', configDir));
 	} else {
 		params.push(resolveConfiguration(context, configDir));
@@ -160,6 +161,10 @@ function resolveConfiguration(context, configDir) {
 function startedInDebugMode(): boolean {
 	const args = (process as any).execArgv as string[];
 	return hasDebugFlag(args);
+}
+
+function startedFromSources(): boolean {
+	return process.env['DEBUG_VSCODE_JAVA'] === 'true';
 }
 
 // exported for tests


### PR DESCRIPTION
In some circumstances, when launching vscode in debug mode (to debug a different extension),
vscode-java would behave as if it was itself being launched. Various combination of launches 
might end up with vscode-java copying the server config files to the global storage area, when 
it shouldn't.

This PR ensures server config management is strictly driven by debugging vscode-java from 
sources or not.
 
﻿Signed-off-by: Fred Bricon <fbricon@gmail.com>
