### PR TITLE
Emit event when projects are imported

### DIFF
--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -79,5 +79,10 @@ export interface ExtensionAPI {
 	 *   2. The Uri points to the project root path.
 	 */
 	readonly onDidClasspathUpdate: Event<Uri>;
+	/**
+	 * An event fires on projects imported.
+	 * The Uris in the array point to the project root path.
+	 */
+	readonly onDidProjectsImport: Event<Uri[]>;
 	readonly goToDefinition: goToDefinitionCommand;
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -55,6 +55,11 @@ export enum FeatureStatus {
     automatic = 2,
 }
 
+export enum EventType {
+    ClasspathUpdated = 100,
+    ProjectsImported = 200,
+}
+
 export enum CompileWorkspaceStatus {
     FAILED = 0,
     SUCCEED = 1,
@@ -84,6 +89,11 @@ export interface ActionableMessage {
 	commands?: Command[];
 }
 
+export interface EventNotification {
+    eventType: EventType;
+    data?: any;
+}
+
 export namespace StatusNotification {
 	export const type = new NotificationType<StatusReport, void >('language/status');
 }
@@ -102,6 +112,10 @@ export namespace ProjectConfigurationUpdateRequest {
 
 export namespace ActionableNotification {
     export const type = new NotificationType<ActionableMessage, void>('language/actionableNotification');
+}
+
+export namespace EventNotification {
+    export const type = new NotificationType<EventNotification, void>('language/eventNotification');
 }
 
 export namespace CompileWorkspaceRequest {

--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -18,7 +18,7 @@ class RuntimeStatusBarProvider implements Disposable {
 		this.disposables = [];
 	}
 
-	public async initialize(onClasspathUpdate: Event<Uri>, storagePath?: string): Promise<void> {
+	public async initialize(onClasspathUpdate: Event<Uri>, onProjectsImport: Event<Uri[]>, storagePath?: string): Promise<void> {
 		// ignore the hash part to make it compatible in debug mode.
 		if (storagePath) {
 			this.storagePath = Uri.file(path.join(storagePath, "..", "..")).fsPath;
@@ -46,7 +46,14 @@ class RuntimeStatusBarProvider implements Disposable {
 			this.updateItem(textEditor);
 		}));
 
-		onClasspathUpdate(async (e) => {
+		onProjectsImport(async (uris: Uri[]) => {
+			for (const uri of uris) {
+				this.javaProjects.set(uri.fsPath, this.javaProjects.get(uri.fsPath));
+			}
+			await this.updateItem(window.activeTextEditor);
+		});
+
+		onClasspathUpdate(async (e: Uri) => {
 			for (const projectPath of this.javaProjects.keys()) {
 				if (path.relative(projectPath, e.fsPath) === '') {
 					this.javaProjects.set(projectPath, undefined);

--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -46,14 +46,14 @@ class RuntimeStatusBarProvider implements Disposable {
 			this.updateItem(textEditor);
 		}));
 
-		onProjectsImport(async (uris: Uri[]) => {
+		this.disposables.push(onProjectsImport(async (uris: Uri[]) => {
 			for (const uri of uris) {
 				this.javaProjects.set(uri.fsPath, this.javaProjects.get(uri.fsPath));
 			}
 			await this.updateItem(window.activeTextEditor);
-		});
+		}));
 
-		onClasspathUpdate(async (e: Uri) => {
+		this.disposables.push(onClasspathUpdate(async (e: Uri) => {
 			for (const projectPath of this.javaProjects.keys()) {
 				if (path.relative(projectPath, e.fsPath) === '') {
 					this.javaProjects.set(projectPath, undefined);
@@ -61,7 +61,7 @@ class RuntimeStatusBarProvider implements Disposable {
 					return;
 				}
 			}
-		});
+		}));
 
 		await this.updateItem(window.activeTextEditor);
 	}


### PR DESCRIPTION
require: https://github.com/eclipse/eclipse.jdt.ls/pull/1456

Since now we can increasingly import the projects, adding a new event in the public API to notify the project importing happens.

Some usages of this API:

- Refresh the project cache for the client side status bar
- Refresh the test source paths cache in Java Test Runner

Signed-off-by: Sheng Chen <sheche@microsoft.com>