### PR TITLE
Ignore /node_modules/ when webpack is watching sources

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,9 @@ const path = require('path');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
+	watchOptions:{
+		ignored: /node_modules/
+	},
     target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
     node: {
         __dirname: false,


### PR DESCRIPTION
Without that option, webpack --watch was taking 25% of my Mac's CPU.
With that option. CPU usage is down to 1%