### PR TITLE
Use java:serverMode to avoid conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -741,11 +741,11 @@
         },
         {
           "command": "java.show.server.task.status",
-          "when": "serverMode != LightWeight"
+          "when": "java:serverMode != LightWeight"
         },
         {
           "command": "java.server.mode.switch",
-          "when": "serverMode == LightWeight"
+          "when": "java:serverMode == LightWeight"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,8 +135,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			const syntaxServerWorkspacePath = path.resolve(storagePath + '/ss_ws');
 
 			const serverMode = getJavaServerMode();
-			// TODO: deptecated this in the future, use 'java:serverMode' instead
-			commands.executeCommand('setContext', 'serverMode', serverMode);
 			commands.executeCommand('setContext', 'java:serverMode', serverMode);
 			const isDebugModeByClientPort = !!process.env['SYNTAXLS_CLIENT_PORT'] || !!process.env['JDTLS_CLIENT_PORT'];
 			const requireSyntaxServer = (serverMode !== ServerMode.STANDARD) && (!isDebugModeByClientPort || !!process.env['SYNTAXLS_CLIENT_PORT']);
@@ -280,8 +278,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 					snippetProvider.setActivation(false);
 					fileEventHandler.setServerStatus(true);
 					runtimeStatusBarProvider.initialize(context.storagePath);
-					// TODO: deptecated this in the future, use 'java:serverMode' instead
-					commands.executeCommand('setContext', 'serverMode', event);
 					commands.executeCommand('setContext', 'java:serverMode', serverMode);
 				}
 			});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -278,7 +278,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 					snippetProvider.setActivation(false);
 					fileEventHandler.setServerStatus(true);
 					runtimeStatusBarProvider.initialize(context.storagePath);
-					commands.executeCommand('setContext', 'java:serverMode', serverMode);
+					commands.executeCommand('setContext', 'java:serverMode', event);
 				}
 			});
 		});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,7 +135,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			const syntaxServerWorkspacePath = path.resolve(storagePath + '/ss_ws');
 
 			const serverMode = getJavaServerMode();
+			// TODO: deptecated this in the future, use 'java:serverMode' instead
 			commands.executeCommand('setContext', 'serverMode', serverMode);
+			commands.executeCommand('setContext', 'java:serverMode', serverMode);
 			const isDebugModeByClientPort = !!process.env['SYNTAXLS_CLIENT_PORT'] || !!process.env['JDTLS_CLIENT_PORT'];
 			const requireSyntaxServer = (serverMode !== ServerMode.STANDARD) && (!isDebugModeByClientPort || !!process.env['SYNTAXLS_CLIENT_PORT']);
 			const requireStandardServer = (serverMode !== ServerMode.LIGHTWEIGHT) && (!isDebugModeByClientPort || !!process.env['JDTLS_CLIENT_PORT']);
@@ -278,7 +280,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 					snippetProvider.setActivation(false);
 					fileEventHandler.setServerStatus(true);
 					runtimeStatusBarProvider.initialize(context.storagePath);
+					// TODO: deptecated this in the future, use 'java:serverMode' instead
 					commands.executeCommand('setContext', 'serverMode', event);
+					commands.executeCommand('setContext', 'java:serverMode', serverMode);
 				}
 			});
 		});


### PR DESCRIPTION
Since the context value is shared between all the extensions. Other extensions can leverage this value in the when clause in the package.json.

It would be better to call it `java:serverMode` to avoid conflicts.

Signed-off-by: Sheng Chen <sheche@microsoft.com>