### PR TITLE
Give more information in the language level status bar item

### DIFF
--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -149,7 +149,7 @@ class RuntimeStatusBarProvider implements Disposable {
 		}
 
 		this.statusBarItem.text = this.getJavaRuntimeFromVersion(projectInfo.sourceLevel);
-		this.statusBarItem.tooltip = `Language Level: ${this.statusBarItem.text}${projectInfo.vmInstallPath ? ` <${projectInfo.vmInstallPath}>` : ""}`;
+		this.statusBarItem.tooltip = projectInfo.vmInstallPath ? `Language Level: ${this.statusBarItem.text} <${projectInfo.vmInstallPath}>` : "Configure Java Runtime";
 		this.statusBarItem.show();
 	}
 

--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -149,7 +149,7 @@ class RuntimeStatusBarProvider implements Disposable {
 		}
 
 		this.statusBarItem.text = this.getJavaRuntimeFromVersion(projectInfo.sourceLevel);
-		this.statusBarItem.tooltip = projectInfo.vmInstallPath ? projectInfo.vmInstallPath : "Configure Java Runtime";
+		this.statusBarItem.tooltip = `Language Level: ${this.statusBarItem.text}${projectInfo.vmInstallPath ? ` <${projectInfo.vmInstallPath}>` : ""}`;
 		this.statusBarItem.show();
 	}
 


### PR DESCRIPTION
Received some users' questions that they misunderstand the status bar item to the current JDK's version. Actually it represents the language level. This PR gives more information in the hover message:

![WeChat Screenshot_20200701125355](https://user-images.githubusercontent.com/6193897/86206004-f2716a00-bb9d-11ea-992d-49af687aaddf.png)


Signed-off-by: Sheng Chen <sheche@microsoft.com>