### PR TITLE
bugfix: Click 'Always' has no response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.64.1 (July 8th, 2020)
+* bug fix - No response when clicking 'Always' on import. See [#1513](https://github.com/redhat-developer/vscode-java/pull/1513).
+
 ## 0.64.0 (July 7th, 2020)
  * enhancement - Give more information in the language level status bar item. See [#1508](https://github.com/redhat-developer/vscode-java/pull/1508).
  * enhancement - Register the semantic token provider after standard server is ready. See [#1505](https://github.com/redhat-developer/vscode-java/pull/1505).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "java",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Red Hat",
   "icon": "icons/icon128.png",
   "license": "EPL-2.0",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "publisher": "redhat",
   "bugs": "https://github.com/redhat-developer/vscode-java/issues",
   "preview": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -349,7 +349,7 @@ async function promptUserForStandardServer(config: WorkspaceConfiguration): Prom
 	const choice: string = await window.showInformationMessage("The workspace contains Java projects, would you like to import them?", "Yes", "Always", "Later");
 	switch (choice) {
 		case "Always":
-			await config.update("project.importOnFirstTimeStartup", "automatic");
+			await config.update("project.importOnFirstTimeStartup", "automatic", ConfigurationTarget.Global);
 			return true;
 		case "Yes":
 			return true;


### PR DESCRIPTION
If not specify `ConfigurationTarget.Global`, VS Code will try to save it to workspace setting then fail.

Signed-off-by: Sheng Chen <sheche@microsoft.com>