### PR TITLE
Do not show hint when standard server is already activated

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -320,6 +320,9 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 }
 
 function startStandardServer(context: ExtensionContext, requirements: requirements.RequirementsData, clientOptions: LanguageClientOptions, workspacePath: string, resolve: (value?: ExtensionAPI | PromiseLike<ExtensionAPI>) => void) {
+	if (standardClient.getClientStatus() !== ClientStatus.Uninitialized) {
+		return;
+	}
 	standardClient.initialize(context, requirements, clientOptions, workspacePath, jdtEventEmitter, resolve);
 	standardClient.start();
 	serverStatusBarProvider.showStandardStatus();
@@ -355,14 +358,10 @@ async function promptUserForStandardServer(config: WorkspaceConfiguration): Prom
 			return true;
 		case "Later":
 		default:
-			const standardClientStatus: ClientStatus = standardClient.getClientStatus();
-			if (standardClientStatus !== ClientStatus.Uninitialized) {
-				return false;
-			}
 			const importHintSection: string = "project.importHint";
 			const dontShowAgain: string = "Don't Show Again";
 			const showHint: boolean = config.get(importHintSection);
-			if (showHint) {
+			if (showHint && standardClient.getClientStatus() === ClientStatus.Uninitialized) {
 				const showRocketEmoji: boolean = process.platform === "win32" || process.platform === "darwin";
 				const message: string = `Java Language Server is running in LightWeight mode. Click the ${showRocketEmoji ? '🚀' : 'Rocket'} icon in the status bar if you want to import the projects later.`;
 				window.showInformationMessage(message, dontShowAgain)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,7 +248,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 			/**
 			 * Command to switch the server mode. Currently it only supports switch from lightweight to standard.
-			 * @param force: just for test purpose.
+			 * @param force force to switch server mode without asking
 			 */
 			commands.registerCommand(Commands.SWITCH_SERVER_MODE, async (switchTo: ServerMode, force: boolean = false) => {
 				const clientStatus: ClientStatus = standardClient.getClientStatus();
@@ -355,6 +355,10 @@ async function promptUserForStandardServer(config: WorkspaceConfiguration): Prom
 			return true;
 		case "Later":
 		default:
+			const standardClientStatus: ClientStatus = standardClient.getClientStatus();
+			if (standardClientStatus !== ClientStatus.Uninitialized) {
+				return false;
+			}
 			const importHintSection: string = "project.importHint";
 			const dontShowAgain: string = "Don't Show Again";
 			const showHint: boolean = config.get(importHintSection);

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -24,12 +24,10 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public showStandardStatus(): void {
-		if (this.statusBarItem.text === StatusIcon.LightWeight) {
-			this.statusBarItem.text = StatusIcon.Busy;
-			this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-			this.statusBarItem.tooltip = "";
-			this.statusBarItem.show();
-		}
+		this.statusBarItem.text = StatusIcon.Busy;
+		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
+		this.statusBarItem.tooltip = "";
+		this.statusBarItem.show();
 	}
 
 	public updateText(text: string): void {

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -13,7 +13,7 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public showLightWeightStatus(): void {
-		this.statusBarItem.text = "$(rocket)";
+		this.statusBarItem.text = StatusIcon.LightWeight;
 		this.statusBarItem.command = {
 			title: "Switch to Standard mode",
 			command: Commands.SWITCH_SERVER_MODE,
@@ -24,10 +24,12 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public showStandardStatus(): void {
-		this.statusBarItem.text = "$(sync~spin)";
-		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-		this.statusBarItem.tooltip = "";
-		this.statusBarItem.show();
+		if (this.statusBarItem.text === StatusIcon.LightWeight) {
+			this.statusBarItem.text = StatusIcon.Busy;
+			this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
+			this.statusBarItem.tooltip = "";
+			this.statusBarItem.show();
+		}
 	}
 
 	public updateText(text: string): void {
@@ -35,15 +37,15 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public setBusy(): void {
-		this.statusBarItem.text = '$(sync~spin)';
+		this.statusBarItem.text = StatusIcon.Busy;
 	}
 
 	public setError(): void {
-		this.statusBarItem.text = '$(thumbsdown)';
+		this.statusBarItem.text = StatusIcon.Error;
 	}
 
 	public setReady(): void {
-		this.statusBarItem.text = '$(thumbsup)';
+		this.statusBarItem.text = StatusIcon.Ready;
 	}
 
 	public updateTooltip(tooltip: string): void {
@@ -53,6 +55,13 @@ class ServerStatusBarProvider implements Disposable {
 	public dispose(): void {
 		this.statusBarItem.dispose();
 	}
+}
+
+enum StatusIcon {
+	LightWeight = "$(rocket)",
+	Busy = "$(sync~spin)",
+	Ready = "$(thumbsup)",
+	Error = "$(thumbsdown)"
 }
 
 export const serverStatusBarProvider: ServerStatusBarProvider = new ServerStatusBarProvider();


### PR DESCRIPTION
This change is to avoid showing the import hint dialog if the standard server is already activated. Following steps shows how to reproduce the issue without this change:

- Open a fresh workspace
- Ignore the message box that asks to import the projects in workspace
- Click the rocket icon in status bar to switch the server mode
- Now, click the buttons(later/close) in the message box that asks to import.

> Note: There is no API to get the handler of the message box in VS Code. Thus we cannot dispose it when some certain conditions are met. But at least what we can do here is to avoid showing the hint message box if the standard server is already started.

Signed-off-by: Sheng Chen <sheche@microsoft.com>