### PR TITLE
Adjust the setting's scope to enhance security

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
           "type": "string",
           "default": null,
           "description": "Arguments to pass to Gradle.",
-          "scope": "window"
+          "scope": "machine"
         },
         "java.import.gradle.jvmArguments": {
           "type": "string",


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

The settings that allows you to specify an executable to perform some operation on startup should only be defined in the user settings, and not at workspace scope.