### PR TITLE
Declare semantic tokens in contribution points

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,108 @@
   ],
   "main": "./dist/extension",
   "contributes": {
+    "semanticTokenTypes": [
+      {
+        "id": "namespace",
+        "description": "Style for packages."
+      },
+      {
+        "id": "type",
+        "description": "Style for types."
+      },
+      {
+        "id": "class",
+        "superType": "type",
+        "description": "Style for classes."
+      },
+      {
+        "id": "interface",
+        "superType": "type",
+        "description": "Style for interfaces."
+      },
+      {
+        "id": "enum",
+        "superType": "type",
+        "description": "Style for enums."
+      },
+      {
+        "id": "annotation",
+        "superType": "type",
+        "description": "Style for annotations."
+      },
+      {
+        "id": "typeParameter",
+        "superType": "type",
+        "description": "Style for type parameters."
+      },
+      {
+        "id": "member",
+        "description": "Style for members."
+      },
+      {
+        "id": "function",
+        "superType": "member",
+        "description": "Style for methods."
+      },
+      {
+        "id": "annotationMember",
+        "superType": "function",
+        "description": "Style for annotation members."
+      },
+      {
+        "id": "property",
+        "superType": "member",
+        "description": "Style for fields."
+      },
+      {
+        "id": "enumMember",
+        "superType": "property",
+        "description": "Style for enum members."
+      },
+      {
+        "id": "variable",
+        "description": "Style for variables."
+      },
+      {
+        "id": "parameter",
+        "superType": "variable",
+        "description": "Style for parameters."
+      }
+    ],
+    "semanticTokenModifiers": [
+      {
+        "id": "static",
+        "description": "Style for symbols that are static."
+      },
+      {
+        "id": "readonly",
+        "description": "Style for symbols that are final."
+      },
+      {
+        "id": "deprecated",
+        "description": "Style for symbols that are deprecated."
+      },
+      {
+        "id": "public",
+        "description": "Style for symbols that are public"
+      },
+      {
+        "id": "private",
+        "description": "Style for symbols that are private."
+      },
+      {
+        "id": "protected",
+        "description": "Style for symbols that are protected"
+      },
+      {
+        "id": "abstract",
+        "description": "Style for symbols that are abstract"
+      },
+      {
+        "id": "declaration",
+        "description": "Style for symbols that are declarations."
+      }
+    ],
     "languages": [
       {
         "id": "java",


### PR DESCRIPTION
Relates to eclipse/eclipse.jdt.ls#1501

This PR ensures backwards compatibility for the "old" semantic token types and enables more flexible styling of semantic tokens by declaring their supertypes in the `semanticTokenTypes` contribution point. For example, with the changes to the semantic highlighting I made in eclipse/eclipse.jdt.ls#1501, styling `type` will yield no results, since the language server now gives more specific tokens like `class`, `interface` and `enum`. By adding a supertype of `type` to these three tokens, they can still be styled with the "old" `type` token type.

Here is a more detailed view of the type hierarchy I have declared for the new semantic token types in eclipse/eclipse.jdt.ls#1501:
- `namespace`
- `type`
  - `class`
  - `interface`
  - `enum`
  - `annotation`
  - `typeParameter`
- `member`
  - `function`
    - `annotationMember`
  - `property`
    - `enumMember`
- `variable`
  - `parameter`

This hierarchy should probably be documented in the semantic highlighting wiki page, but I will leave that up to someone else, since I don't know if or how I can contribute to the wiki.