### PR TITLE
Request semantic tokens for class files

### DIFF
--- a/src/semanticTokenProvider.ts
+++ b/src/semanticTokenProvider.ts
@@ -21,7 +21,11 @@ export function registerSemanticTokensProvider(context: vscode.ExtensionContext)
     }
     if (isSemanticHighlightingEnabled()) {
         getSemanticTokensLegend().then(legend => {
-            const semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider({ scheme: 'file', language: 'java' }, semanticTokensProvider, legend);
+            const documentSelector = [
+                { scheme: 'file', language: 'java' },
+                { scheme: 'jdt', language: 'java' }
+            ];
+            const semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(documentSelector, semanticTokensProvider, legend);
             context.subscriptions.push(semanticTokensProviderDisposable);
             onceSemanticTokenEnabledChange(context, semanticTokensProviderDisposable);
         });


### PR DESCRIPTION
Fixes #1538
Requires eclipse/eclipse.jdt.ls#1511

This is a very simple change to the semantic tokens provider to make it request semantic tokens not only for source files, but also for class files in libraries, using the `jdt://...` protocol.