### PR TITLE
Declare semantic token types for annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,18 @@
   ],
   "main": "./dist/extension",
   "contributes": {
+    "semanticTokenTypes": [
+      {
+        "id": "annotation",
+        "superType": "type",
+        "description": "Style for annotations."
+      },
+      {
+        "id": "annotationMember",
+        "superType": "function",
+        "description": "Style for annotation members."
+      }
+    ],
     "languages": [
       {
         "id": "java",


### PR DESCRIPTION
This is a partial implementation of #1537 , in order to fix token colorization for annotations whilst not causing conflicts with the default token types.