### PR TITLE
Expose the 'java.import.gradle.java.home' preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The following settings are supported:
 * `java.project.importOnFirstTimeStartup`: Specifies whether to import the Java projects, when opening the folder in Hybrid mode for the first time. Supported values are `disabled` (never imports), `interactive` (asks to import or not), `automatic` (always imports). Default to `interactive`.
 * `java.project.importHint`: Enable/disable the server-mode switch information, when Java projects import is skipped on startup. Defaults to `true`.
 
+New in 0.65.0:
+* `java.import.gradle.java.home`: Specifies the location to the JVM used to run the Gradle daemon.
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) is controlled by the `java.semanticHighlighting.enabled` preference. When enabled, it fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience different small issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing.

--- a/package.json
+++ b/package.json
@@ -163,6 +163,12 @@
           "description": "Use Gradle from the specified local installation directory or GRADLE_HOME if the Gradle wrapper is missing or disabled and no 'java.import.gradle.version' is specified.",
           "scope": "window"
         },
+        "java.import.gradle.java.home": {
+          "type": "string",
+          "default": null,
+          "description": "The location to the JVM used to run the Gradle daemon.",
+          "scope": "machine"
+        },
         "java.import.gradle.offline.enabled": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
Fixes #1536 
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/1512

Requires gradle <4.7. See https://github.com/gradle/gradle/issues/4503

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>