### PR TITLE
Add cache for markdown provider

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -35,6 +35,11 @@ export namespace Commands {
     export const GOTO_LOCATION = 'editor.action.goToLocations';
 
     /**
+     * Render markdown string to html string
+     */
+    export const MARKDOWN_API_RENDER = 'markdown.api.render';
+
+    /**
      * Update project configuration
      */
     export const CONFIGURATION_UPDATE = 'java.projectConfiguration.update';


### PR DESCRIPTION
This PR is to fix a bug for the markdown preview.

When using the API `markdown.api.render` to render the same markdown string to html more than once. The `id` field in the rendered result will be appended `-1`, `-2`, ...

Which means, if users opens the document more than once in the same session, he cannot navigate from TOC.

So a cache is introduced here. This will also boost the loading time since the render process will be skipped if the cache hits.

Signed-off-by: Sheng Chen <sheche@microsoft.com>