### PR TITLE
bugfix: Emit Hybrid mode if both language server is running

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -270,9 +270,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				}
 
 				if (choice === "Yes") {
-					// Before standard server is ready, we are in hybrid.
-					apiManager.getApiInstance().serverMode = ServerMode.HYBRID;
-					apiManager.fireDidServerModeChange(ServerMode.HYBRID);
 					startStandardServer(context, requirements, clientOptions, workspacePath, resolve);
 				}
 			});
@@ -321,6 +318,11 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 function startStandardServer(context: ExtensionContext, requirements: requirements.RequirementsData, clientOptions: LanguageClientOptions, workspacePath: string, resolve: (value?: ExtensionAPI | PromiseLike<ExtensionAPI>) => void) {
 	if (standardClient.getClientStatus() !== ClientStatus.Uninitialized) {
 		return;
+	}
+	if (apiManager.getApiInstance().serverMode === ServerMode.LIGHTWEIGHT) {
+		// Before standard server is ready, we are in hybrid.
+		apiManager.getApiInstance().serverMode = ServerMode.HYBRID;
+		apiManager.fireDidServerModeChange(ServerMode.HYBRID);
 	}
 	standardClient.initialize(context, requirements, clientOptions, workspacePath, jdtEventEmitter, resolve);
 	standardClient.start();


### PR DESCRIPTION
fix an issue found in #1571.

The `hybrid` should be emitted when Lightweight server is ready and standard server is going to start.

So I moved the emit action into the function which starts the standard server, and only emit the event if the current server mode is lightweight.