### PR TITLE
Document 'Hybrid' serverMode value in api

### DIFF
--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -98,6 +98,7 @@ export interface ExtensionAPI {
 	/**
 	 * Indicates the current active mode for Java Language Server. Possible modes are:
 	 * - "Standard"
+	 * - "Hybrid"
 	 * - "LightWeight"
 	 */
 	serverMode: ServerMode;


### PR DESCRIPTION
Found it confusing that the `serverMode` api could return any of the server mode types defined in the `ServerMode ` enum, but the extension api docs only mention Standard and Lightweight. 

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>