### PR TITLE
Show a more detailed message about Java 11 requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
             "null"
           ],
           "default": null,
-          "description": "Specifies the folder path to the JDK (8 or more recent) used to launch the Java Language Server.\nOn Windows, backslashes must be escaped, i.e.\n\"java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"",
+          "description": "Specifies the folder path to the JDK (11 or more recent) used to launch the Java Language Server.\nOn Windows, backslashes must be escaped, i.e.\n\"java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk11.0_8\"",
           "scope": "window"
         },
         "java.jdt.ls.vmargs": {

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -86,7 +86,7 @@ function checkJavaVersion(javaHome: string): Promise<number> {
         cp.execFile(javaBin, ['-version'], {}, (error, stdout, stderr) => {
             const javaVersion = parseMajorVersion(stderr);
             if (javaVersion < 11) {
-                openJDKDownload(reject, 'Java 11 or more recent is required to run. Please download and install a recent JDK');
+                openJDKDownload(reject, 'Java 11 or more recent is required to run the Java extension. Please download and install a recent JDK. You can still compile your projects with older JDKs by configuring [`java.configuration.runtimes`](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)');
             }
             resolve(javaVersion);
         });


### PR DESCRIPTION
Make it more obvious to users they can still use older JDKs to compile their projects:

<img width="460" alt="Screen Shot 2020-08-31 at 6 20 05 PM" src="https://user-images.githubusercontent.com/148698/91742687-ebbf9d00-ebb6-11ea-8a3a-032d54963e0d.png">

The link opens https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes