### PR TITLE
Disabling Java language server programmatically

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,7 +140,10 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			const serverMode = getJavaServerMode();
 			commands.executeCommand('setContext', 'java:serverMode', serverMode);
 			const isDebugModeByClientPort = !!process.env['SYNTAXLS_CLIENT_PORT'] || !!process.env['JDTLS_CLIENT_PORT'];
-			const requireSyntaxServer = (serverMode !== ServerMode.STANDARD) && (!isDebugModeByClientPort || !!process.env['SYNTAXLS_CLIENT_PORT']);
+			let requireSyntaxServer = (serverMode !== ServerMode.STANDARD) && (!isDebugModeByClientPort || !!process.env['SYNTAXLS_CLIENT_PORT']);
+			if (serverMode === ServerMode.DISABLED) {
+				requireSyntaxServer = false;
+			}
 			let requireStandardServer = (serverMode !== ServerMode.LIGHTWEIGHT) && (!isDebugModeByClientPort || !!process.env['JDTLS_CLIENT_PORT']);
 
 			// Options to control the language client

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -198,7 +198,8 @@ export function getJavaagentFlag(vmargs) {
 export enum ServerMode {
 	STANDARD = 'Standard',
 	LIGHTWEIGHT = 'LightWeight',
-	HYBRID = 'Hybrid'
+	HYBRID = 'Hybrid',
+	DISABLED = 'Disabled'
 }
 
 export function getJavaServerMode(): ServerMode {


### PR DESCRIPTION
Hi. I understand that my request isn't common. I tried to solve the problem in different ways, but at the end it seems easiest to report a PR and together think about options to solve the situation. Please accept my apology to begin with and bear with me.

The [Apache NetBeans](http://netbeans.apache.org) community is working on a [VSCode extension](https://github.com/apache/netbeans/blob/master/java/java.lsp.server/vscode/README.md) based on NetBeans implementation of [Java Language Server](https://github.com/apache/netbeans/tree/master/java/java.lsp.server). While trying to productize it a question about **co-existence** with your extension has come up. I did testing on Maven project when having both systems on:
* the Apache NetBeans one
* your one together with Java Extension Pack

The situation isn't that bad. Both extensions work, do what is expected, just, when asking for completion hints in the editor, they are often duplicated. 

![obrazek](https://user-images.githubusercontent.com/26887752/92597206-58b5ef80-f2a7-11ea-883b-70e6517e634e.png)

That's the most visible problem. To solve it I was thinking of detecting that your extension is installed (that's what I can do) and asking the user to: 
* Disable NetBeans Java Language Server (that's what I can easily do)
* Disable RedHat Java Language Server 
* Configure Manually (would show the installed extensions)
* Keep running

The problem with "Configure Manually" is that there are other extensions that depend on yours and one has to disable them all in correct order. That's tedious.

The problem with "Disable RedHat Java Language Server" is that there doesn't seem to be a way to programmatically disable another extension in VSCode API. However I noticed various modes your language server may run in and I got an idea: let's add a `Disabled` mode and use that API to disable your server when user chooses to "Disable RedHat Java Language Server":
```ts
workspace.getConfiguration().update('java.server.launchMode', 'Disabled', false)
```
Early experiments show the "configuration API" works if the setting is applied soon enough. A better API is needed to `stop()` your `LanguageClient` when it is running. Would you be so kind and support a way to disable your language server?

I am aware of absurdity of my request. Asking you to disable your own code feels weird. However I haven't found other programmatic way of solving the duplication of code completion items. All I can promise is to provide similar API in the Apache NetBeans extension for you to disable our language server.

In any case, thanks in advance for all your help!