### PR TITLE
Report errors when configuring a wrong runtime path

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,7 +500,8 @@
               },
               "path": {
                 "type": "string",
-                "description": "JDK path.\nOn Windows, backslashes must be escaped, i.e.\n\"path\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"."
+                "pattern": ".*(?<!\\/bin|\\/bin\\/|\\\\bin|\\\\bin\\\\)$",
+                "description": "JDK home path. Should be the JDK installation directory, not the Java bin path.\n On Windows, backslashes must be escaped, i.e.\n\"path\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"."
               },
               "sources": {
                 "type": "string",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -218,4 +218,6 @@ export namespace Commands {
     export const LEARN_MORE_ABOUT_REFACTORING = '_java.learnMoreAboutRefactorings';
 
     export const TEMPLATE_VARIABLES = '_java.templateVariables';
+
+    export const RUNTIME_VALIDATION_OPEN = 'java.runtimeValidation.open';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,9 +113,6 @@ export class OutputInfoCollector implements OutputChannel {
 }
 
 export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
-	context.subscriptions.push(commands.registerCommand(Commands.RUNTIME_VALIDATION_OPEN, () => {
-		commands.executeCommand("workbench.action.openSettings", "java.configuration.runtimes");
-	}));
 	context.subscriptions.push(markdownPreviewProvider);
 	context.subscriptions.push(commands.registerCommand(Commands.TEMPLATE_VARIABLES, async () => {
 		markdownPreviewProvider.show(context.asAbsolutePath(path.join('document', `${Commands.TEMPLATE_VARIABLES}.md`)), 'Predefined Variables', "", context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,6 +113,9 @@ export class OutputInfoCollector implements OutputChannel {
 }
 
 export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
+	context.subscriptions.push(commands.registerCommand(Commands.RUNTIME_VALIDATION_OPEN, () => {
+		commands.executeCommand("workbench.action.openSettings", "java.configuration.runtimes");
+	}));
 	context.subscriptions.push(markdownPreviewProvider);
 	context.subscriptions.push(commands.registerCommand(Commands.TEMPLATE_VARIABLES, async () => {
 		markdownPreviewProvider.show(context.asAbsolutePath(path.join('document', `${Commands.TEMPLATE_VARIABLES}.md`)), 'Predefined Variables', "", context);
@@ -179,7 +182,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						clientDocumentSymbolProvider: true,
 						gradleChecksumWrapperPromptSupport: true,
 						resolveAdditionalTextEditsSupport: true,
-						advancedIntroduceParameterRefactoringSupport: true
+						advancedIntroduceParameterRefactoringSupport: true,
+						actionableRuntimeNotificationSupport: true
 					},
 					triggerFiles,
 				},

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -44,6 +44,10 @@ export class StandardLanguageClient {
 			commands.executeCommand(Commands.SHOW_SERVER_TASK_STATUS);
 		}
 
+		context.subscriptions.push(commands.registerCommand(Commands.RUNTIME_VALIDATION_OPEN, () => {
+			commands.executeCommand("workbench.action.openSettings", "java.configuration.runtimes");
+		}));
+
 		serverStatus.initialize();
 		serverStatus.onServerStatusChanged(status => {
 			if (status === ServerStatusKind.Busy) {

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -64,7 +64,8 @@ suite('Java Language Extension - Standard', () => {
 				Commands.SHOW_JAVA_REFERENCES,
 				Commands.SHOW_SERVER_TASK_STATUS,
 				Commands.SWITCH_SERVER_MODE,
-				Commands.UPDATE_SOURCE_ATTACHMENT
+				Commands.UPDATE_SOURCE_ATTACHMENT,
+				Commands.RUNTIME_VALIDATION_OPEN
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It requires https://github.com/eclipse/eclipse.jdt.ls/pull/1550
Fix #1614, Fix #1568, Fix #1481

It will validate the `java.configuration.runtimes` settings in both cases below. Meanwhile provide a regular pattern to check whether the path contains bin.
- The Java extension is activated.
- `java.configuration.runtimes` settings are changed.