### PR TITLE
improve java version checking

### DIFF
--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -80,34 +80,75 @@ function checkJavaRuntime(context: ExtensionContext): Promise<string> {
     });
 }
 
-function checkJavaVersion(javaHome: string): Promise<number> {
+async function checkJavaVersion(javaHome: string): Promise<number> {
+    let javaVersion = await checkVersionInReleaseFile(javaHome);
+    if (!javaVersion) {
+        javaVersion = await checkVersionByCLI(javaHome);
+    }
+    return new Promise<number>((resolve, reject) => {
+        if (javaVersion < 11) {
+            openJDKDownload(reject, 'Java 11 or more recent is required to run the Java extension. Please download and install a recent JDK. You can still compile your projects with older JDKs by configuring [`java.configuration.runtimes`](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)');
+        }
+        return resolve(javaVersion);
+    });
+}
+
+/**
+ * Get version by checking file JAVA_HOME/release
+ */
+async function checkVersionInReleaseFile(javaHome: string): Promise<number> {
+    if (!javaHome) {
+        return 0;
+    }
+    const releaseFile = path.join(javaHome, "release");
+    if (!await fse.pathExists(releaseFile)) {
+        return 0;
+    }
+
+    try {
+        const content = await fse.readFile(releaseFile);
+        const regexp = /^JAVA_VERSION="(.*)"/gm;
+        const match = regexp.exec(content.toString());
+        if (!match) {
+            return 0;
+        }
+        const majorVersion = parseMajorVersion(match[1]);
+        return majorVersion;
+    } catch (error) {
+        // ignore
+    }
+    return 0;
+}
+
+/**
+ * Get version by parsing `JAVA_HOME/bin/java -version`
+ */
+function checkVersionByCLI(javaHome: string): Promise<number> {
     return new Promise((resolve, reject) => {
         const javaBin = path.join(javaHome, "bin", JAVA_FILENAME);
         cp.execFile(javaBin, ['-version'], {}, (error, stdout, stderr) => {
-            const javaVersion = parseMajorVersion(stderr);
-            if (javaVersion < 11) {
-                openJDKDownload(reject, 'Java 11 or more recent is required to run the Java extension. Please download and install a recent JDK. You can still compile your projects with older JDKs by configuring [`java.configuration.runtimes`](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)');
+            const regexp = /version "(.*)"/g;
+            const match = regexp.exec(stderr);
+            if (!match) {
+                return resolve(0);
             }
+            const javaVersion = parseMajorVersion(match[1]);
             resolve(javaVersion);
         });
     });
 }
 
-export function parseMajorVersion(content: string): number {
-    let regexp = /version "(.*)"/g;
-    let match = regexp.exec(content);
-    if (!match) {
+export function parseMajorVersion(version: string): number {
+    if (!version) {
         return 0;
     }
-    let version = match[1];
     // Ignore '1.' prefix for legacy Java versions
     if (version.startsWith('1.')) {
         version = version.substring(2);
     }
-
     // look into the interesting bits now
-    regexp = /\d+/g;
-    match = regexp.exec(version);
+    const regexp = /\d+/g;
+    const match = regexp.exec(version);
     let javaVersion = 0;
     if (match) {
         javaVersion = parseInt(match[0]);

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -120,6 +120,7 @@ suite('Java Language Extension - Standard', () => {
 	test('should parse Java version', () => {
 		// Test boundaries
 		assert.equal(requirements.parseMajorVersion(null), 0);
+		assert.equal(requirements.parseMajorVersion(undefined), 0);
 		assert.equal(requirements.parseMajorVersion(''), 0);
 		assert.equal(requirements.parseMajorVersion('foo'), 0);
 		assert.equal(requirements.parseMajorVersion('version'), 0);
@@ -127,11 +128,11 @@ suite('Java Language Extension - Standard', () => {
 		assert.equal(requirements.parseMajorVersion('version "NaN"'), 0);
 
 		// Test the real stuff
-		assert.equal(requirements.parseMajorVersion('version "1.7"'), 7);
-		assert.equal(requirements.parseMajorVersion('version "1.8.0_151"'), 8);
-		assert.equal(requirements.parseMajorVersion('version "9"'), 9);
-		assert.equal(requirements.parseMajorVersion('version "9.0.1"'), 9);
-		assert.equal(requirements.parseMajorVersion('version "10-ea"'), 10);
+		assert.equal(requirements.parseMajorVersion('1.7'), 7);
+		assert.equal(requirements.parseMajorVersion('1.8.0_151'), 8);
+		assert.equal(requirements.parseMajorVersion('9'), 9);
+		assert.equal(requirements.parseMajorVersion('9.0.1'), 9);
+		assert.equal(requirements.parseMajorVersion('10-ea'), 10);
 	});
 
 	test('should detect debug flag', () => {


### PR DESCRIPTION
This PR does no harm but improves the coverage, fixing corner cases like #1331 .

Now it first reads `<javahome>/release` file for the version if it exists, and fallbacks to execute `java -version` and parse output.
Sample `release` file:
```
$> cat `java_home -v 12`/release
BUILD_TYPE="commercial"
IMPLEMENTOR="Oracle Corporation"
JAVA_VERSION="12.0.2"
JAVA_VERSION_DATE="2019-07-16"
MODULES="java.base java.compiler java.datatransfer java.xml java.prefs java.desktop java.instrument java.logging java.management java.security.sasl java.naming java.rmi java.management.rmi java.net.http java.scripting java.security.jgss java.transaction.xa java.sql java.sql.rowset java.xml.crypto java.se java.smartcardio jdk.accessibility jdk.internal.vm.ci jdk.management jdk.unsupported jdk.internal.vm.compiler jdk.aot jdk.internal.jvmstat jdk.attach jdk.charsets jdk.compiler jdk.crypto.ec jdk.crypto.cryptoki jdk.dynalink jdk.internal.ed jdk.editpad jdk.hotspot.agent jdk.httpserver jdk.internal.le jdk.internal.opt jdk.internal.vm.compiler.management jdk.jartool jdk.javadoc jdk.jcmd jdk.management.agent jdk.jconsole jdk.jdeps jdk.jdwp.agent jdk.jdi jdk.jfr jdk.jlink jdk.jshell jdk.jsobject jdk.jstatd jdk.localedata jdk.management.jfr jdk.naming.dns jdk.naming.rmi jdk.net jdk.pack jdk.rmic jdk.scripting.nashorn jdk.scripting.nashorn.shell jdk.sctp jdk.security.auth jdk.security.jgss jdk.unsupported.desktop jdk.xml.dom jdk.zipfs"
OS_ARCH="x86_64"
OS_NAME="Darwin"
SOURCE=".:hg:e4535ae60a23 open:hg:f3ba5ebee368"
```