### PR TITLE
Declare semantic token type for modifier keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,28 @@
         "id": "annotationMember",
         "superType": "function",
         "description": "Style for annotation members."
+      },
+      {
+        "id": "modifier",
+        "superType": "keyword",
+        "description": "Style for modifier keywords."
+      }
+    ],
+    "semanticTokenScopes": [
+      {
+        "language": "java",
+        "scopes": {
+          "annotation": [
+            "storage.type.annotation.java"
+          ],
+          "annotationMember": [
+            "entity.name.annotationMember.java",
+            "constant.other.key.java"
+          ],
+          "modifier": [
+            "storage.modifier.java"
+          ]
+        }
       }
     ],
     "languages": [


### PR DESCRIPTION
Part of eclipse/eclipse.jdt.ls#1539.

Declares semantic token type for `modifierKeyword`, and supertypes it to `keyword`. Also adds [scope mapping](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#semantic-token-scope-map) for the custom token types, since that was missing. The scope mapping is required in order for the default themes to look correct with the new `modifierKeyword`, and also means that themes still using TextMate scopes can style modifier keywords, annotations and annotation members.