### PR TITLE
Refactor semanticTokenProvider.ts

### DIFF
--- a/src/semanticTokenProvider.ts
+++ b/src/semanticTokenProvider.ts
@@ -1,90 +1,111 @@
 import * as vscode from 'vscode';
 import { Commands } from './commands';
-import { getJavaConfiguration } from './utils';
+import { getJavaConfiguration, waitForDocumentChangesToEnd } from './utils';
 
-const semanticHighlightingKey = 'java.semanticHighlighting.enabled';
+export function registerSemanticTokensProvider(context: vscode.ExtensionContext): void {
+	if (!vscode.languages.registerDocumentSemanticTokensProvider) { // in case Theia doesn't support this API
+		return;
+	}
 
-export function registerSemanticTokensProvider(context: vscode.ExtensionContext) {
-    if (!vscode.languages.registerDocumentSemanticTokensProvider) { // in case Theia doesn't support this API
-        return;
-    }
+	context.subscriptions.push(semanticTokensProvider);
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e) => {
+		if (e.affectsConfiguration('java.semanticHighlighting.enabled')) {
+			if (isSemanticHighlightingEnabled()) {
+				semanticTokensProvider.enable();
+			}
+			else {
+				semanticTokensProvider.disable();
+			}
+		}
+	}));
 
-    if (isSemanticHighlightingEnabled()) {
-        getSemanticTokensLegend().then(legend => {
-            const documentSelector = [
-                { scheme: 'file', language: 'java' },
-                { scheme: 'jdt', language: 'java' }
-            ];
-            const semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(documentSelector, semanticTokensProvider, legend);
-            context.subscriptions.push(semanticTokensProviderDisposable);
-            onceSemanticTokenEnabledChange(context, semanticTokensProviderDisposable);
-        });
-    } else {
-        onceSemanticTokenEnabledChange(context, undefined);
-    }
-}
-
-class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
-    async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens> {
-        const versionBeforeRequest: number = document.version;
-        const response = <any> await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.PROVIDE_SEMANTIC_TOKENS, document.uri.toString());
-        const versionAfterRequest: number = document.version;
-
-        if (versionBeforeRequest !== versionAfterRequest) {
-            await waitForDocumentChangesToEnd(document);
-            throw new Error("busy");
-        }
-        if (token.isCancellationRequested) {
-            return undefined;
-        }
-        if (!response || !response.data) {
-            return undefined;
-        }
-        return new vscode.SemanticTokens(new Uint32Array(response.data), response.resultId);
-    }
-}
-
-function waitForDocumentChangesToEnd(document: vscode.TextDocument): Promise<void> {
-    let version = document.version;
-    return new Promise((resolve) => {
-        const iv = setInterval(() => {
-            if (document.version === version) {
-                clearInterval(iv);
-                resolve();
-            }
-            version = document.version;
-        }, 400);
-    });
-}
-
-const semanticTokensProvider = new SemanticTokensProvider();
-
-async function getSemanticTokensLegend(): Promise<vscode.SemanticTokensLegend | undefined> {
-    const response = await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_SEMANTIC_TOKENS_LEGEND) as vscode.SemanticTokensLegend;
-    if (response && response.tokenModifiers !== undefined && response.tokenTypes !== undefined) {
-        return new vscode.SemanticTokensLegend(response.tokenTypes, response.tokenModifiers);
-    }
-    return undefined;
-}
-
-function onceSemanticTokenEnabledChange(context: vscode.ExtensionContext, registeredDisposable?: vscode.Disposable) {
-    const configChangeListener = vscode.workspace.onDidChangeConfiguration(e => {
-        configChangeListener.dispose();
-        if (e.affectsConfiguration(semanticHighlightingKey)) {
-            if (isSemanticHighlightingEnabled()) {
-                // turn on
-                registerSemanticTokensProvider(context);
-            } else if (registeredDisposable) {
-                // turn off
-                registeredDisposable.dispose();
-            }
-            onceSemanticTokenEnabledChange(context);
-        }
-    });
+	if (isSemanticHighlightingEnabled()) {
+		semanticTokensProvider.enable();
+	}
 }
 
 function isSemanticHighlightingEnabled(): boolean {
-    const config = getJavaConfiguration();
-    const section = 'semanticHighlighting.enabled';
-    return config.get(section);
+	const config = getJavaConfiguration();
+	const section = 'semanticHighlighting.enabled';
+	return config.get(section);
 }
+
+class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider, vscode.Disposable {
+
+	private disposable?: vscode.Disposable;
+	private tokensChangedEmitter?: vscode.EventEmitter<void>;
+	private shouldClearTokens: boolean = false;
+
+	public get onDidChangeSemanticTokens(): vscode.Event<void> {
+		return this.tokensChangedEmitter?.event;
+	}
+
+	public async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens> {
+		if (this.shouldClearTokens) {
+			// We can return early here to skip the request, but just to be
+			// safe we should also check this case after requesting tokens,
+			// in case the provider was disbled during the request itself.
+			this.disable(true);
+			return undefined;
+		}
+
+		const versionBeforeRequest: number = document.version;
+		const response = <any> await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.PROVIDE_SEMANTIC_TOKENS, document.uri.toString());
+		const versionAfterRequest: number = document.version;
+
+		if (this.shouldClearTokens) {
+			this.disable(true);
+			return undefined;
+		}
+		if (versionBeforeRequest !== versionAfterRequest) {
+			await waitForDocumentChangesToEnd(document);
+			throw new Error("busy");
+		}
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+		if (!response || !response.data) {
+			return undefined;
+		}
+		return new vscode.SemanticTokens(new Uint32Array(response.data), response.resultId);
+	}
+
+	public async enable(): Promise<void> {
+		this.shouldClearTokens = false;
+		this.tokensChangedEmitter = new vscode.EventEmitter();
+		this.disposable = vscode.languages.registerDocumentSemanticTokensProvider(
+			[
+				{ language: 'java', scheme: 'file' },
+				{ language: 'java', scheme: 'jdt' }
+			],
+			this,
+			await this.getSemanticTokensLegend()
+		);
+	}
+
+	public disable(tokensAreCleared?: boolean): void {
+		if (tokensAreCleared) {
+			this.disposable?.dispose();
+			this.tokensChangedEmitter?.dispose();
+		}
+		else {
+			this.shouldClearTokens = true;
+			this.tokensChangedEmitter?.fire();
+		}
+	}
+
+	public dispose(): void {
+		this.disable();
+	}
+
+	private async getSemanticTokensLegend(): Promise<vscode.SemanticTokensLegend | undefined> {
+		const response = await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_SEMANTIC_TOKENS_LEGEND) as vscode.SemanticTokensLegend;
+		if (response && response.tokenModifiers !== undefined && response.tokenTypes !== undefined) {
+			return new vscode.SemanticTokensLegend(response.tokenTypes, response.tokenModifiers);
+		}
+		return undefined;
+	}
+
+}
+
+const semanticTokensProvider = new SemanticTokensProvider();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { workspace, WorkspaceConfiguration } from 'vscode';
+import { workspace, WorkspaceConfiguration, TextDocument } from 'vscode';
 
 export function getJavaConfiguration(): WorkspaceConfiguration {
 	return workspace.getConfiguration('java');
@@ -111,4 +111,17 @@ function parseToStringGlob(patterns: string[]): string {
 	}
 
 	return `{${patterns.join(",")}}`;
+}
+
+export async function waitForDocumentChangesToEnd(document: TextDocument): Promise<void> {
+	let version = document.version;
+	return new Promise((resolve) => {
+		const iv = setInterval(() => {
+			if (document.version === version) {
+				clearInterval(iv);
+				resolve();
+			}
+			version = document.version;
+		}, 400);
+	});
 }


### PR DESCRIPTION
Fixes #1678 

I don't think there's any way to do this without implementing `onDidChangeSemanticTokens`, as that seems to be the only way to force a refresh of semantic tokens. Part of #1678 was caused by `onceSemanticTokenEnabledChange` not registering itself after a change to a setting other than `java.semanticHighlighting.enabled`, so I refactored that code as well.

While I was at it, I decided to change the indentation to tabs as per the `.editorconfig`, and move `waitForDocumentChangesToEnd` to utils.ts, since it feels like more of a utility than something specific to the semantic tokens provider. It might have other use cases, such as fixing #1633, although I haven't looked closely at that particular case.