### PR TITLE
Infer expressions if there is no selection range when extracting method

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,6 +174,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						generateConstructorsPromptSupport: true,
 						generateDelegateMethodsPromptSupport: true,
 						advancedExtractRefactoringSupport: true,
+						inferSelectionSupport: ["extractMethod"],
 						moveRefactoringSupport: true,
 						clientHoverProvider: true,
 						clientDocumentSymbolProvider: true,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -332,17 +332,16 @@ export namespace GetRefactorEditRequest {
 export interface InferSelection {
     name: string;
     length: number;
-    startPosition: number;
+    offset: number;
 }
 
-export interface GetInferSelectionParams {
+export interface InferSelectionParams {
     command: string;
     context: CodeActionParams;
-    options: FormattingOptions;
 }
 
-export namespace GetInferSelectionRequest {
-    export const type = new RequestType<GetInferSelectionParams, InferSelection[], void, void>('java/getInferSelection');
+export namespace InferSelectionRequest {
+    export const type = new RequestType<InferSelectionParams, InferSelection[], void, void>('java/inferSelection');
 }
 
 export interface PackageNode {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -329,6 +329,22 @@ export namespace GetRefactorEditRequest {
     export const type = new RequestType<GetRefactorEditParams, RefactorWorkspaceEdit, void, void>('java/getRefactorEdit');
 }
 
+export interface InferSelection {
+    name: string;
+    length: number;
+    startPosition: number;
+}
+
+export interface GetInferSelectionParams {
+    command: string;
+    context: CodeActionParams;
+    options: FormattingOptions;
+}
+
+export namespace GetInferSelectionRequest {
+    export const type = new RequestType<GetInferSelectionParams, InferSelection[], void, void>('java/getInferSelection');
+}
+
 export interface PackageNode {
     displayName: string;
     uri: string;

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -329,7 +329,7 @@ export namespace GetRefactorEditRequest {
     export const type = new RequestType<GetRefactorEditParams, RefactorWorkspaceEdit, void, void>('java/getRefactorEdit');
 }
 
-export interface InferSelection {
+export interface SelectionInfo {
     name: string;
     length: number;
     offset: number;
@@ -341,7 +341,7 @@ export interface InferSelectionParams {
 }
 
 export namespace InferSelectionRequest {
-    export const type = new RequestType<InferSelectionParams, InferSelection[], void, void>('java/inferSelection');
+    export const type = new RequestType<InferSelectionParams, SelectionInfo[], void, void>('java/inferSelection');
 }
 
 export interface PackageNode {

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { commands, ExtensionContext, Position, QuickPickItem, TextDocument, Uri, window, workspace } from 'vscode';
 import { FormattingOptions, LanguageClient, WorkspaceEdit, CreateFile, RenameFile, DeleteFile, TextDocumentEdit, CodeActionParams, SymbolInformation } from 'vscode-languageclient';
 import { Commands as javaCommands } from './commands';
-import { GetRefactorEditRequest, MoveRequest, RefactorWorkspaceEdit, RenamePosition, GetMoveDestinationsRequest, SearchSymbols, InferSelection, GetInferSelectionRequest } from './protocol';
+import { GetRefactorEditRequest, MoveRequest, RefactorWorkspaceEdit, RenamePosition, GetMoveDestinationsRequest, SearchSymbols, InferSelection, InferSelectionRequest } from './protocol';
 
 export function registerCommands(languageClient: LanguageClient, context: ExtensionContext) {
     registerApplyRefactorCommand(languageClient, context);
@@ -75,17 +75,16 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
                     return;
                 }
                 if (params.range.start.character === params.range.end.character && params.range.start.line === params.range.end.line) {
-                    const expressions: InferSelection[] = await languageClient.sendRequest(GetInferSelectionRequest.type, {
+                    const expressions: InferSelection[] = await languageClient.sendRequest(InferSelectionRequest.type, {
                         command: command,
                         context: params,
-                        options: formattingOptions,
                     });
                     const options: IExpressionItem[] = [];
                     for (const expression of expressions) {
                         const extractMethodItem: IExpressionItem = {
                             label: expression.name,
                             length: expression.length,
-                            startPosition: expression.startPosition,
+                            offset: expression.offset,
                         };
                         options.push(extractMethodItem);
                     }
@@ -103,7 +102,7 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
                     const resultExpression: InferSelection = {
                         name: resultItem.label,
                         length: resultItem.length,
-                        startPosition: resultItem.startPosition,
+                        offset: resultItem.offset,
                     };
                     commandArguments.push(resultExpression);
                 }
@@ -136,7 +135,7 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
 interface IExpressionItem extends QuickPickItem {
 	label: string;
 	length: number;
-	startPosition: number;
+	offset: number;
 }
 
 async function applyRefactorEdit(languageClient: LanguageClient, refactorEdit: RefactorWorkspaceEdit) {

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -2,7 +2,7 @@
 
 import { existsSync } from 'fs';
 import * as path from 'path';
-import { commands, ExtensionContext, Position, TextDocument, Uri, window, workspace } from 'vscode';
+import { commands, ExtensionContext, Position, QuickPickItem, TextDocument, Uri, window, workspace } from 'vscode';
 import { FormattingOptions, LanguageClient, WorkspaceEdit, CreateFile, RenameFile, DeleteFile, TextDocumentEdit, CodeActionParams, SymbolInformation } from 'vscode-languageclient';
 import { Commands as javaCommands } from './commands';
 import { GetRefactorEditRequest, MoveRequest, RefactorWorkspaceEdit, RenamePosition, GetMoveDestinationsRequest, SearchSymbols } from './protocol';
@@ -70,6 +70,30 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
 
                     commandArguments.push(initializeIn);
                 }
+            } else if (command === 'extractMethod') {
+                if (commandInfo && Array.isArray(commandInfo)) {
+                    const options: IExpressionItem[] = [];
+                    for (const command of commandInfo) {
+                        const extractMethodItem: IExpressionItem = {
+                            label: command.name,
+                            length: command.length,
+                            startPosition: command.startPosition,
+                        };
+                        options.push(extractMethodItem);
+                    }
+                    let resultItem: IExpressionItem;
+                    if (options.length === 1) {
+                        resultItem = options[0];
+                    } else if (options.length > 1) {
+                        resultItem = await window.showQuickPick<IExpressionItem>(options, {
+                            placeHolder: "Choose the expression to extract",
+                        });
+                    }
+                    if (!resultItem) {
+                        return;
+                    }
+                    commandArguments.push(resultItem);
+                }
             }
 
             const result: RefactorWorkspaceEdit = await languageClient.sendRequest(GetRefactorEditRequest.type, {
@@ -94,6 +118,12 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
             await moveType(languageClient, params, commandInfo);
         }
     }));
+}
+
+interface IExpressionItem extends QuickPickItem {
+	label: string;
+	length: number;
+	startPosition: number;
 }
 
 async function applyRefactorEdit(languageClient: LanguageClient, refactorEdit: RefactorWorkspaceEdit) {

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { commands, ExtensionContext, Position, QuickPickItem, TextDocument, Uri, window, workspace } from 'vscode';
 import { FormattingOptions, LanguageClient, WorkspaceEdit, CreateFile, RenameFile, DeleteFile, TextDocumentEdit, CodeActionParams, SymbolInformation } from 'vscode-languageclient';
 import { Commands as javaCommands } from './commands';
-import { GetRefactorEditRequest, MoveRequest, RefactorWorkspaceEdit, RenamePosition, GetMoveDestinationsRequest, SearchSymbols, InferSelection, InferSelectionRequest } from './protocol';
+import { GetRefactorEditRequest, MoveRequest, RefactorWorkspaceEdit, RenamePosition, GetMoveDestinationsRequest, SearchSymbols, SelectionInfo, InferSelectionRequest } from './protocol';
 
 export function registerCommands(languageClient: LanguageClient, context: ExtensionContext) {
     registerApplyRefactorCommand(languageClient, context);
@@ -75,7 +75,7 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
                     return;
                 }
                 if (params.range.start.character === params.range.end.character && params.range.start.line === params.range.end.line) {
-                    const expressions: InferSelection[] = await languageClient.sendRequest(InferSelectionRequest.type, {
+                    const expressions: SelectionInfo[] = await languageClient.sendRequest(InferSelectionRequest.type, {
                         command: command,
                         context: params,
                     });
@@ -99,7 +99,7 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
                     if (!resultItem) {
                         return;
                     }
-                    const resultExpression: InferSelection = {
+                    const resultExpression: SelectionInfo = {
                         name: resultItem.label,
                         length: resultItem.length,
                         offset: resultItem.offset,


### PR DESCRIPTION
Requires eclipse/eclipse.jdt.ls#1585

Will infer different expressions if there is no selection range when extracting method.
![extract](https://user-images.githubusercontent.com/45906942/97411936-da3b0d00-193b-11eb-84e8-5f2ad99233df.gif)

Signed-off-by: Shi Chen <chenshi@microsoft.com>