### PR TITLE
Fix jdk detection: cover symlink folder on Linux

### DIFF
--- a/src/findJavaRuntimes.ts
+++ b/src/findJavaRuntimes.ts
@@ -244,7 +244,6 @@ export async function verifyJavaHome(raw: string, javaFilename: string): Promise
     const targetJavaFile = await findLinkedFile(path.resolve(dir, "bin", javaFilename));
     const proposed = path.dirname(path.dirname(targetJavaFile));
     if (await fse.pathExists(proposed)
-        && (await fse.lstat(proposed)).isDirectory()
         && await fse.pathExists(path.resolve(proposed, "bin", javaFilename))
     ) {
         return proposed;


### PR DESCRIPTION
On Linux it's common that a JDK homedir is a symlink, and symlink fails `isDirectory()` test.

See https://github.com/redhat-developer/vscode-java/pull/1701#issuecomment-730062422