### PR TITLE
fallback to search /usr/lib/jvm for jdks on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  * bug fix - Quarkus: generated sources are not accessible. See [#1675](https://github.com/redhat-developer/vscode-java/issues/1675)
  * bug fix - Error in every java file after updating to macOS Big Sur. See [#1700](https://github.com/redhat-developer/vscode-java/issues/1700).
  * bug fix - Fix jdk detection: cover symlink folder on Linux. See [#1704](https://github.com/redhat-developer/vscode-java/pull/1704).
+ * bug fix - Fix jdk detection: cover common JDK installation places on Linux. See [#1706](https://github.com/redhat-developer/vscode-java/pull/1706).
  * other - Improve tracing capability of m2e through m2e.logback.configuration.. See [JLS#1589](https://github.com/eclipse/eclipse.jdt.ls/pull/1589).
  * other - Infer expressions if there is no selection range when extracting method. See [#1680](https://github.com/redhat-developer/vscode-java/pull/1680).
 

--- a/src/findJavaRuntimes.ts
+++ b/src/findJavaRuntimes.ts
@@ -10,6 +10,7 @@ const expandHomeDir = require("expand-home-dir");
 const WinReg = require("winreg-utf8");
 const isWindows: boolean = process.platform.indexOf("win") === 0;
 const isMac: boolean = process.platform.indexOf("darwin") === 0;
+const isLinux: boolean = process.platform.indexOf("linux") === 0;
 const JAVAC_FILENAME = "javac" + (isWindows ? ".exe" : "");
 const JAVA_FILENAME = "java" + (isWindows ? ".exe" : "");
 
@@ -232,6 +233,24 @@ async function fromCommonPlaces(): Promise<string[]> {
                 if (javaHome) {
                     ret.push(javaHome);
                 }
+            }
+        }
+    }
+
+    // common place for Linux
+    if (isLinux) {
+        const jvmStore = "/usr/lib/jvm";
+        let jvms: string[] = [];
+        try {
+            jvms = await fse.readdir(jvmStore);
+        } catch (error) {
+            // ignore
+        }
+        for (const jvm of jvms) {
+            const proposed = path.join(jvmStore, jvm);
+            const javaHome = await verifyJavaHome(proposed, JAVAC_FILENAME);
+            if (javaHome) {
+                ret.push(javaHome);
             }
         }
     }


### PR DESCRIPTION
a follow-up of https://github.com/redhat-developer/vscode-java/pull/1701#issuecomment-730107692

Linux users still have #1621 , and this PR can fix that.