### PR TITLE
Support inferSeletion when extract to variable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						generateConstructorsPromptSupport: true,
 						generateDelegateMethodsPromptSupport: true,
 						advancedExtractRefactoringSupport: true,
-						inferSelectionSupport: ["extractMethod"],
+						inferSelectionSupport: ["extractMethod", "extractVariable"],
 						moveRefactoringSupport: true,
 						clientHoverProvider: true,
 						clientDocumentSymbolProvider: true,

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -70,7 +70,10 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
 
                     commandArguments.push(initializeIn);
                 }
-            } else if (command === 'extractMethod') {
+            } else if (command === 'extractMethod'
+                || command === 'extractVariableAllOccurrence'
+                || command === 'extractVariable'
+                || command === 'extractConstant') {
                 if (!params || !params.range) {
                     return;
                 }
@@ -81,12 +84,12 @@ function registerApplyRefactorCommand(languageClient: LanguageClient, context: E
                     });
                     const options: IExpressionItem[] = [];
                     for (const expression of expressions) {
-                        const extractMethodItem: IExpressionItem = {
+                        const extractItem: IExpressionItem = {
                             label: expression.name,
                             length: expression.length,
                             offset: expression.offset,
                         };
-                        options.push(extractMethodItem);
+                        options.push(extractItem);
                     }
                     let resultItem: IExpressionItem;
                     if (options.length === 1) {


### PR DESCRIPTION
Requires eclipse/eclipse.jdt.ls#1615

Add the capability for the client to infer expressions if there is no selection range when extract to variable.
![extractVariable](https://user-images.githubusercontent.com/45906942/100428784-5bb6c400-30cf-11eb-9728-e4b9dd2210f0.gif)

Signed-off-by: Shi Chen <chenshi@microsoft.com>