### PR TITLE
Support inferSeletion when extract to field

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						generateConstructorsPromptSupport: true,
 						generateDelegateMethodsPromptSupport: true,
 						advancedExtractRefactoringSupport: true,
-						inferSelectionSupport: ["extractMethod", "extractVariable"],
+						inferSelectionSupport: ["extractMethod", "extractVariable", "extractField"],
 						moveRefactoringSupport: true,
 						clientHoverProvider: true,
 						clientDocumentSymbolProvider: true,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -333,6 +333,7 @@ export interface SelectionInfo {
     name: string;
     length: number;
     offset: number;
+    params?: string[];
 }
 
 export interface InferSelectionParams {


### PR DESCRIPTION
Requires eclipse/eclipse.jdt.ls#1619

Add the capability for the client to infer expressions if there is no selection range when extract to field.
![extractField](https://user-images.githubusercontent.com/45906942/100432014-f44f4300-30d3-11eb-9aeb-4d1e506a3734.gif)

Signed-off-by: Shi Chen chenshi@microsoft.com