### PR TITLE
Filter 'sun.*' packages out of completion type results.

### DIFF
--- a/package.json
+++ b/package.json
@@ -379,7 +379,8 @@
           "description": "Defines the type filters. All types whose fully qualified name matches the selected filter strings will be ignored in content assist or quick fix proposals and when organizing imports. For example 'java.awt.*' will hide all types from the awt packages.",
           "default": [
             "java.awt.*",
-            "com.sun.*"
+            "com.sun.*",
+            "sun.*"
           ],
           "scope": "window"
         },


### PR DESCRIPTION
- Fixes eclipse/eclipse.jdt.ls#1613

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>