### PR TITLE
Declare semantic token modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,36 @@
         "description": "Style for modifier keywords."
       }
     ],
+    "semanticTokenModifiers": [
+      {
+        "id": "public",
+        "description": "Style for symbols with the public access modifier."
+      },
+      {
+        "id": "private",
+        "description": "Style for symbols with the private access modifier."
+      },
+      {
+        "id": "protected",
+        "description": "Style for symbols with the protected access modifier."
+      },
+      {
+        "id": "native",
+        "description": "Style for symbols with the native modifier."
+      },
+      {
+        "id": "generic",
+        "description": "Style for symbols that are generic (have type parameters)."
+      },
+      {
+        "id": "typeArgument",
+        "description": "Style for symbols that are type arguments for a generic symbol."
+      },
+      {
+        "id": "importDeclaration",
+        "description": "Style for symbols that are part of an import declaration."
+      }
+    ],
     "semanticTokenScopes": [
       {
         "language": "java",
@@ -65,6 +95,9 @@
           ],
           "modifier": [
             "storage.modifier.java"
+          ],
+          "keyword.documentation": [
+            "keyword.other.documentation.javadoc.java"
           ]
         }
       }


### PR DESCRIPTION
Declares new semantic token types* for eclipse/eclipse.jdt.ls#1641, and adds scope mapping for them so that themes using TextMate rules won't break. I also added all the custom modifiers provided by jdt.ls to the contribution point, which means that theme authors can now get intellisense for those modifiers when editing `color-theme.json` files or the `editor.semanticTokenColorCustomizations` setting.

*after [discussion with Eskibear](https://github.com/eclipse/eclipse.jdt.ls/pull/1641#issuecomment-763603693), I decided not to add any new token types yet. However, scope mapping for Javadoc tags is still required to prevent them from being styled as generic control keywords (regressing the default themes).