### PR TITLE
always exclude project settings files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The following settings are supported:
 * `java.trace.server` : Traces the communication between VS Code and the Java language server.
 * `java.configuration.updateBuildConfiguration` : Specifies how modifications on build files update the Java classpath/configuration. Supported values are `disabled` (nothing happens), `interactive` (asks about updating on every modification), `automatic` (updating is automatically triggered).
 * `java.configuration.maven.userSettings` : Path to Maven's user settings.xml.
-* `java.configuration.checkProjectSettingsExclusions`: Checks if the extension-generated project settings files (`.project`, `.classpath`, `.factorypath`, `.settings/`) should be excluded from the file explorer. Defaults to `true`.
+* `java.configuration.checkProjectSettingsExclusions`: Controls whether to exclude extension-generated project settings files (`.project`, `.classpath`, `.factorypath`, `.settings/`) from the file explorer. Defaults to `true`.
 * `java.referencesCodeLens.enabled` : Enable/disable the references code lenses.
 * `java.implementationsCodeLens.enabled` : Enable/disable the implementations code lenses.
 * `java.signatureHelp.enabled` : Enable/disable signature help support (triggered on `(`).

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
         "java.configuration.checkProjectSettingsExclusions": {
           "type": "boolean",
           "default": true,
-          "description": "Checks if the extension-generated project settings files (.project, .classpath, .factorypath, .settings/) should be excluded from the file explorer.",
+          "description": "Controls whether to exclude extension-generated project settings files (.project, .classpath, .factorypath, .settings/) from the file explorer.",
           "scope": "window"
         },
         "java.configuration.updateBuildConfiguration": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -56,8 +56,9 @@ export function excludeProjectSettingsFiles() {
 }
 
 function excludeProjectSettingsFilesForWorkspace(workspaceUri: Uri) {
-	const excudedConfig = getJavaConfiguration().get(EXCLUDE_FILE_CONFIG);
-	if (excudedConfig) {
+	const javaConfig = getJavaConfiguration();
+	const checkExclusionConfig = javaConfig.get(EXCLUDE_FILE_CONFIG);
+	if (checkExclusionConfig) {
 		const config = workspace.getConfiguration('files', workspaceUri);
 		const excludedValue: Object = config.get('exclude');
 		const needExcludeFiles: string[] = [];
@@ -71,30 +72,21 @@ function excludeProjectSettingsFilesForWorkspace(workspaceUri: Uri) {
 		}
 		if (needUpdate) {
 			const excludedInspectedValue = config.inspect('exclude');
-			const items = [changeItem.workspace, changeItem.never];
-			// Workspace file.exclude is undefined
-			if (!excludedInspectedValue.workspaceValue) {
-				items.unshift(changeItem.global);
-			}
-
-			window.showInformationMessage(`Do you want to exclude the ${env.appName} Java project settings files (.classpath, .project, .settings, .factorypath) from the file explorer?`, ...items).then((result) => {
-				if (result === changeItem.global) {
-					excludedInspectedValue.globalValue = excludedInspectedValue.globalValue || {};
-					for (const hiddenFile of needExcludeFiles) {
-						excludedInspectedValue.globalValue[hiddenFile] = true;
-					}
-					config.update('exclude', excludedInspectedValue.globalValue, ConfigurationTarget.Global);
-				} if (result === changeItem.workspace) {
-					excludedInspectedValue.workspaceValue = excludedInspectedValue.workspaceValue || {};
-					for (const hiddenFile of needExcludeFiles) {
-						excludedInspectedValue.workspaceValue[hiddenFile] = true;
-					}
-					config.update('exclude', excludedInspectedValue.workspaceValue, ConfigurationTarget.Workspace);
-				} else if (result === changeItem.never) {
-					const storeInWorkspace = getJavaConfiguration().inspect(EXCLUDE_FILE_CONFIG).workspaceValue;
-					getJavaConfiguration().update(EXCLUDE_FILE_CONFIG, false, storeInWorkspace ? ConfigurationTarget.Workspace : ConfigurationTarget.Global);
+			const checkExclusionInWorkspace = javaConfig.inspect(EXCLUDE_FILE_CONFIG).workspaceValue;
+			if (checkExclusionInWorkspace) {
+				excludedInspectedValue.workspaceValue = excludedInspectedValue.workspaceValue || {};
+				for (const hiddenFile of needExcludeFiles) {
+					excludedInspectedValue.workspaceValue[hiddenFile] = true;
 				}
-			});
+				config.update('exclude', excludedInspectedValue.workspaceValue, ConfigurationTarget.Workspace);
+			} else {
+				// by default save to global settings
+				excludedInspectedValue.globalValue = excludedInspectedValue.globalValue || {};
+				for (const hiddenFile of needExcludeFiles) {
+					excludedInspectedValue.globalValue[hiddenFile] = true;
+				}
+				config.update('exclude', excludedInspectedValue.globalValue, ConfigurationTarget.Global);
+			}
 		}
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -74,18 +74,18 @@ function excludeProjectSettingsFilesForWorkspace(workspaceUri: Uri) {
 			const excludedInspectedValue = config.inspect('exclude');
 			const checkExclusionInWorkspace = javaConfig.inspect(EXCLUDE_FILE_CONFIG).workspaceValue;
 			if (checkExclusionInWorkspace) {
-				excludedInspectedValue.workspaceValue = excludedInspectedValue.workspaceValue || {};
+				const workspaceValue = excludedInspectedValue.workspaceValue || {};
 				for (const hiddenFile of needExcludeFiles) {
-					excludedInspectedValue.workspaceValue[hiddenFile] = true;
+					workspaceValue[hiddenFile] = true;
 				}
-				config.update('exclude', excludedInspectedValue.workspaceValue, ConfigurationTarget.Workspace);
+				config.update('exclude', workspaceValue, ConfigurationTarget.Workspace);
 			} else {
 				// by default save to global settings
-				excludedInspectedValue.globalValue = excludedInspectedValue.globalValue || {};
+				const globalValue = excludedInspectedValue.globalValue = excludedInspectedValue.globalValue || {};
 				for (const hiddenFile of needExcludeFiles) {
-					excludedInspectedValue.globalValue[hiddenFile] = true;
+					globalValue[hiddenFile] = true;
 				}
-				config.update('exclude', excludedInspectedValue.globalValue, ConfigurationTarget.Global);
+				config.update('exclude', globalValue, ConfigurationTarget.Global);
 			}
 		}
 	}


### PR DESCRIPTION
To reduce pop-ups, this PR exclude project settings files (.project, .settings, etc) from vscode's explorer by default. 