### PR TITLE
Support Type Hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ The following settings are supported:
 * `java.configuration.maven.globalSettings` : Path to Maven's global settings.xml.
 * `java.eclipse.downloadSources` : Enable/disable download of Maven source artifacts for Eclipse projects.
 * `java.recommendations.dependency.analytics.show` : Show the recommended Dependency Analytics extension.
-* `java.typeHierarchy.lazyLoad` : Enable/disable lazy loading the content in type hierarchy. Lazy loading could save a lot of loading time but every type should be expanded manually to load its content.
 
 New in 0.77.0:
 * `java.references.includeDecompiledSources` : Include the decompiled sources when finding references. Default to true.
 * `java.project.sourcePaths`: Relative paths to the workspace where stores the source files. `Only` effective in the `WORKSPACE` scope. The setting will `NOT` affect Maven or Gradle project.
+* `java.typeHierarchy.lazyLoad` : Enable/disable lazy loading the content in type hierarchy. Lazy loading could save a lot of loading time but every type should be expanded manually to load its content.
 
 Semantic Highlighting
 ===============

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The following settings are supported:
 * `java.configuration.maven.globalSettings` : Path to Maven's global settings.xml.
 * `java.eclipse.downloadSources` : Enable/disable download of Maven source artifacts for Eclipse projects.
 * `java.recommendations.dependency.analytics.show` : Show the recommended Dependency Analytics extension.
+* `java.typeHierarchy.lazyLoad` : Enable/disable lazy loading the content in type hierarchy. Lazy loading could save a lot of loading time but every type should be expanded manually to load its content.
 
 New in 0.77.0:
 * `java.references.includeDecompiledSources` : Include the decompiled sources when finding references. Default to true.

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
-      "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
+      "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
       "dev": true
     },
     "@types/winreg": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "preview": true,
   "enableProposedApi": false,
   "engines": {
-    "vscode": "^1.47.0"
+    "vscode": "^1.53.2"
   },
   "repository": {
     "type": "git",
@@ -747,6 +747,12 @@
           "default": true,
           "description": "Include the decompiled sources when finding references.",
           "scope": "window"
+        },
+        "java.typeHierarchy.lazyLoad": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable/disable lazy loading the content in type hierarchy. Lazy loading could save a lot of loading time but every type should be expanded manually to load its content.",
+          "scope": "window"
         }
       }
     },
@@ -830,6 +836,37 @@
         "command": "java.action.navigateToSuperImplementation",
         "title": "Go to Super Implementation",
         "category": "Java"
+      },
+      {
+        "command": "java.action.showTypeHierarchy",
+        "title": "Show Type Hierarchy",
+        "category": "Java"
+      },
+      {
+        "command": "java.action.showClassHierarchy",
+        "title": "Show Class Hierarchy",
+        "icon": "$(type-hierarchy)",
+        "enablement": "typeHierarchyDirection != both && typeHierarchySymbolKind != 10",
+        "category": "Java"
+      },
+      {
+        "command": "java.action.showSupertypeHierarchy",
+        "title": "Show Supertype Hierarchy",
+        "icon": "$(type-hierarchy-super)",
+        "enablement": "typeHierarchyDirection != parents",
+        "category": "Java"
+      },
+      {
+        "command": "java.action.showSubtypeHierarchy",
+        "title": "Show Subtype Hierarchy",
+        "icon": "$(type-hierarchy-sub)",
+        "enablement": "typeHierarchyDirection != children",
+        "category": "Java"
+      },
+      {
+        "command": "java.action.changeBaseType",
+        "title": "Base on this Type",
+        "category": "Java"
       }
     ],
     "keybindings": [
@@ -882,6 +919,11 @@
           "command": "java.action.navigateToSuperImplementation",
           "when": "javaLSReady && editorTextFocus && editorLangId == java",
           "group": "navigation@90"
+        },
+        {
+          "command": "java.action.showTypeHierarchy",
+          "when": "javaLSReady && editorTextFocus && editorLangId == java",
+          "group": "0_navigation@3"
         }
       ],
       "commandPalette": [
@@ -906,6 +948,26 @@
           "when": "javaLSReady"
         },
         {
+          "command": "java.action.showTypeHierarchy",
+          "when": "javaLSReady && editorIsOpen"
+        },
+        {
+          "command": "java.action.showClassHierarchy",
+          "when": "false"
+        },
+        {
+          "command": "java.action.showSubtypeHierarchy",
+          "when": "false"
+        },
+        {
+          "command": "java.action.showSupertypeHierarchy",
+          "when": "false"
+        },
+        {
+          "command": "java.action.changeBaseType",
+          "when": "false"
+        },
+        {
           "command": "java.project.updateSourceAttachment",
           "when": "false"
         },
@@ -924,6 +986,30 @@
         {
           "command": "java.server.mode.switch",
           "when": "java:serverMode == LightWeight"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "java.action.showClassHierarchy",
+          "group": "navigation@-1",
+          "when": "view == references-view.tree && reference-list.hasResult && reference-list.source == javaTypeHierarchy && typeHierarchySymbolKind != 10"
+        },
+        {
+          "command": "java.action.showSupertypeHierarchy",
+          "group": "navigation@0",
+          "when": "view == references-view.tree && reference-list.hasResult && reference-list.source == javaTypeHierarchy"
+        },
+        {
+          "command": "java.action.showSubtypeHierarchy",
+          "group": "navigation@1",
+          "when": "view == references-view.tree && reference-list.hasResult && reference-list.source == javaTypeHierarchy"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "java.action.changeBaseType",
+          "group": "1",
+          "when": "view == references-view.tree && reference-list.hasResult && reference-list.source == javaTypeHierarchy && viewItem != 'false'"
         }
       ]
     }
@@ -949,7 +1035,7 @@
     "@types/lodash.findindex": "^4.6.6",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.51",
-    "@types/vscode": "^1.47.0",
+    "@types/vscode": "^1.53.0",
     "@types/winreg": "^1.2.30",
     "@types/winston": "^2.4.4",
     "gulp": "^4.0.2",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -183,6 +183,34 @@ export namespace Commands {
      */
     export const NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND = 'java.action.navigateToSuperImplementation';
     /**
+     * Open Type Hierarchy of given Selection.
+     */
+    export const SHOW_TYPE_HIERARCHY = 'java.action.showTypeHierarchy';
+    /**
+     * Show SuperType Hierarchy of given Selection.
+     */
+    export const SHOW_SUPERTYPE_HIERARCHY = 'java.action.showSupertypeHierarchy';
+    /**
+     * Show SubType Hierarchy of given Selection.
+     */
+    export const SHOW_SUBTYPE_HIERARCHY = 'java.action.showSubtypeHierarchy';
+    /**
+     * Show Type Hierarchy of given Selection.
+     */
+    export const SHOW_CLASS_HIERARCHY = 'java.action.showClassHierarchy';
+    /**
+     * Change the base type of Type Hierarchy.
+     */
+    export const CHANGE_BASE_TYPE = 'java.action.changeBaseType';
+    /**
+     * Open the given TypeHierarchy Item.
+     */
+    export const OPEN_TYPE_HIERARCHY = 'java.navigate.openTypeHierarchy';
+    /**
+     * Resolve the given TypeHierarchy Item.
+     */
+    export const RESOLVE_TYPE_HIERARCHY = 'java.navigate.resolveTypeHierarchy';
+    /**
      * Show server task status
      */
     export const SHOW_SERVER_TASK_STATUS = 'java.show.server.task.status';

--- a/src/typeHierarchy/model.ts
+++ b/src/typeHierarchy/model.ts
@@ -1,0 +1,258 @@
+import * as vscode from "vscode";
+import { TypeHierarchyDirection, TypeHierarchyItem } from "./protocol";
+import { SymbolItemNavigation, SymbolTreeInput, SymbolTreeModel } from "./references-view";
+import { getActiveLanguageClient } from "../extension";
+import { LanguageClient } from "vscode-languageclient";
+import { getRootItem, resolveTypeHierarchy, typeHierarchyDirectionToContextString } from "./util";
+import { CancellationToken, commands, workspace } from "vscode";
+
+export class TypeHierarchyTreeInput implements SymbolTreeInput<TypeHierarchyItem> {
+	readonly contextValue: string = "javaTypeHierarchy";
+	readonly title: string;
+	readonly baseItem: TypeHierarchyItem;
+	private client: LanguageClient;
+	private rootItem: TypeHierarchyItem;
+
+	constructor(readonly location: vscode.Location, readonly direction: TypeHierarchyDirection, readonly token: CancellationToken, item: TypeHierarchyItem) {
+		this.baseItem = item;
+		switch (direction) {
+			case TypeHierarchyDirection.Both:
+				this.title = "Class Hierarchy";
+				break;
+			case TypeHierarchyDirection.Parents:
+				this.title = "Supertype Hierarchy";
+				break;
+			case TypeHierarchyDirection.Children:
+				this.title = "Subtype Hierarchy";
+				break;
+			default:
+				return;
+		}
+	}
+
+	async resolve(): Promise<SymbolTreeModel<TypeHierarchyItem>> {
+		if (!this.client) {
+			this.client = await getActiveLanguageClient();
+		}
+		// workaround: await a second to make sure the success of reveal operation on baseItem, see: https://github.com/microsoft/vscode/issues/114989
+		await new Promise<void>((resolve) => setTimeout(() => {
+			resolve();
+		}, 1000));
+
+		this.rootItem = (this.direction === TypeHierarchyDirection.Both) ? await getRootItem(this.client, this.baseItem, this.token) : this.baseItem;
+		const model: TypeHierarchyModel = new TypeHierarchyModel(this.rootItem, this.direction, this.baseItem);
+		const provider = new TypeHierarchyTreeDataProvider(model, this.client, this.token);
+		const treeModel: SymbolTreeModel<TypeHierarchyItem> = {
+			provider: provider,
+			message: undefined,
+			navigation: model,
+			dispose() {
+				provider.dispose();
+			}
+		};
+		commands.executeCommand('setContext', 'typeHierarchyDirection', typeHierarchyDirectionToContextString(this.direction));
+		commands.executeCommand('setContext', 'typeHierarchySymbolKind', this.baseItem.kind);
+		return treeModel;
+	}
+
+	with(location: vscode.Location): TypeHierarchyTreeInput {
+		return new TypeHierarchyTreeInput(location, this.direction, this.token, this.baseItem);
+	}
+}
+
+export class TypeHierarchyModel implements SymbolItemNavigation<TypeHierarchyItem> {
+	public readonly onDidChange = new vscode.EventEmitter<TypeHierarchyModel>();
+	public readonly onDidChangeEvent = this.onDidChange.event;
+
+	constructor(private rootItem: TypeHierarchyItem, private direction: TypeHierarchyDirection, private baseItem: TypeHierarchyItem) { }
+
+	public getBaseItem(): TypeHierarchyItem {
+		return this.baseItem;
+	}
+
+	public getDirection(): TypeHierarchyDirection {
+		return this.direction;
+	}
+
+	public getRootItem(): TypeHierarchyItem {
+		return this.rootItem;
+	}
+
+	location(item: TypeHierarchyItem) {
+		return new vscode.Location(vscode.Uri.file(item.uri), item.range);
+	}
+
+	nearest(uri: vscode.Uri, _position: vscode.Position): TypeHierarchyItem | undefined {
+		return this.baseItem;
+	}
+
+	next(from: TypeHierarchyItem): TypeHierarchyItem {
+		return from;
+	}
+
+	previous(from: TypeHierarchyItem): TypeHierarchyItem {
+		return from;
+	}
+}
+
+class TypeHierarchyTreeDataProvider implements vscode.TreeDataProvider<TypeHierarchyItem> {
+	private readonly _emitter: vscode.EventEmitter<TypeHierarchyItem> = new vscode.EventEmitter<TypeHierarchyItem>();
+	private readonly _modelListener: vscode.Disposable;
+	private lazyLoad: boolean;
+	public readonly onDidChangeTreeData: vscode.Event<TypeHierarchyItem> = this._emitter.event;
+
+	constructor(readonly model: TypeHierarchyModel, readonly client: LanguageClient, readonly token: CancellationToken) {
+		this._modelListener = model.onDidChangeEvent(e => this._emitter.fire(e instanceof TypeHierarchyItem ? e : undefined));
+		this.lazyLoad = workspace.getConfiguration().get("java.typeHierarchy.lazyLoad");
+	}
+
+	dispose(): void {
+		this._emitter.dispose();
+		this._modelListener.dispose();
+	}
+
+	async getTreeItem(element: TypeHierarchyItem): Promise<vscode.TreeItem> {
+		if (!element) {
+			return undefined;
+		}
+		const treeItem: vscode.TreeItem = (element === this.model.getBaseItem()) ? new vscode.TreeItem({ label: element.name, highlights: [[0, element.name.length]] }) : new vscode.TreeItem(element.name);
+		treeItem.contextValue = (element === this.model.getBaseItem() || !element.uri) ? "false" : "true";
+		treeItem.description = element.detail;
+		treeItem.iconPath = TypeHierarchyTreeDataProvider.getThemeIcon(element.kind);
+		treeItem.command = (element.uri) ? {
+			command: 'vscode.open',
+			title: 'Open Type Definition Location',
+			arguments: [
+				vscode.Uri.parse(element.uri), <vscode.TextDocumentShowOptions>{ selection: element.selectionRange }
+			]
+		} : undefined;
+		// workaround: set a specific id to refresh the collapsible state for treeItems, see: https://github.com/microsoft/vscode/issues/114614#issuecomment-763428052
+		treeItem.id = `${element.data}${Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)}`;
+		if (element.expand) {
+			treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+		} else if (this.model.getDirection() === TypeHierarchyDirection.Children || this.model.getDirection() === TypeHierarchyDirection.Both) {
+			// For an unresolved baseItem, will make it collapsed to show it early. It will be automatically expanded by model.nearest()
+			if (element === this.model.getBaseItem()) {
+				if (!element.children) {
+					treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+				} else if (element.children.length === 0) {
+					treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
+				} else {
+					treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+				}
+			} else {
+				if (!element.children) {
+					if (this.lazyLoad) {
+						treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+						return treeItem;
+					}
+					const resolvedItem = await resolveTypeHierarchy(this.client, element, this.model.getDirection(), this.token);
+					if (!resolvedItem) {
+						return undefined;
+					}
+					element.children = resolvedItem.children;
+				}
+				treeItem.collapsibleState = (element.children.length === 0) ? vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Collapsed;
+			}
+		} else if (this.model.getDirection() === TypeHierarchyDirection.Parents) {
+			if (element === this.model.getBaseItem()) {
+				if (!element.parents) {
+					treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+				} else if (element.parents.length === 0) {
+					treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
+				} else {
+					treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+				}
+			} else {
+				if (!element.parents) {
+					if (this.lazyLoad) {
+						treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+						return treeItem;
+					}
+					const resolvedItem = await resolveTypeHierarchy(this.client, element, this.model.getDirection(), this.token);
+					if (!resolvedItem) {
+						return undefined;
+					}
+					element.parents = resolvedItem.parents;
+				}
+				treeItem.collapsibleState = (element.parents.length === 0) ? vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Collapsed;
+			}
+		}
+		return treeItem;
+	}
+
+	async getChildren(element?: TypeHierarchyItem | undefined): Promise<TypeHierarchyItem[]> {
+		if (!element) {
+			return [this.model.getRootItem()];
+		}
+		if (this.model.getDirection() === TypeHierarchyDirection.Children || this.model.getDirection() === TypeHierarchyDirection.Both) {
+			if (!element.children) {
+				if (TypeHierarchyTreeDataProvider.isWhiteListType(element)) {
+					return [TypeHierarchyTreeDataProvider.getFakeItem(element)];
+				}
+				const resolvedItem = await resolveTypeHierarchy(this.client, element, this.model.getDirection(), this.token);
+				if (!resolvedItem) {
+					return undefined;
+				}
+				element.children = resolvedItem.children;
+				if (element.children.length === 0) {
+					this._emitter.fire(element);
+				}
+			}
+			return element.children;
+		} else if (this.model.getDirection() === TypeHierarchyDirection.Parents) {
+			if (!element.parents) {
+				const resolvedItem = await resolveTypeHierarchy(this.client, element, this.model.getDirection(), this.token);
+				if (!resolvedItem) {
+					return undefined;
+				}
+				element.parents = resolvedItem.parents;
+				if (element.parents.length === 0) {
+					this._emitter.fire(element);
+				}
+			}
+			return element.parents;
+		}
+		return undefined;
+	}
+
+	private static isWhiteListType(item: TypeHierarchyItem): boolean {
+		if (item.name === "Object" && item.detail === "java.lang") {
+			return true;
+		}
+		return false;
+	}
+
+	private static getFakeItem(item: TypeHierarchyItem): TypeHierarchyItem {
+		let message: string;
+		if (item.name === "Object" && item.detail === "java.lang") {
+			message = "All classes are subtypes of java.lang.Object.";
+		}
+		return {
+			name: message,
+			kind: undefined,
+			children: [],
+			parents: [],
+			detail: undefined,
+			uri: undefined,
+			range: undefined,
+			selectionRange: undefined,
+			data: undefined,
+			deprecated: false,
+			expand: false,
+		};
+	}
+
+	private static themeIconIds = [
+		'symbol-file', 'symbol-module', 'symbol-namespace', 'symbol-package', 'symbol-class', 'symbol-method',
+		'symbol-property', 'symbol-field', 'symbol-constructor', 'symbol-enum', 'symbol-interface',
+		'symbol-function', 'symbol-variable', 'symbol-constant', 'symbol-string', 'symbol-number', 'symbol-boolean',
+		'symbol-array', 'symbol-object', 'symbol-key', 'symbol-null', 'symbol-enum-member', 'symbol-struct',
+		'symbol-event', 'symbol-operator', 'symbol-type-parameter'
+	];
+
+	private static getThemeIcon(kind: vscode.SymbolKind): vscode.ThemeIcon | undefined {
+		const id = TypeHierarchyTreeDataProvider.themeIconIds[kind];
+		return id ? new vscode.ThemeIcon(id) : undefined;
+	}
+}

--- a/src/typeHierarchy/protocol.ts
+++ b/src/typeHierarchy/protocol.ts
@@ -1,0 +1,35 @@
+import * as vscode from "vscode";
+import { Range, SymbolKind } from "vscode-languageclient";
+
+export enum TypeHierarchyDirection {
+	Children,
+	Parents,
+	Both
+}
+
+export class LSPTypeHierarchyItem {
+	name: string;
+	detail: string;
+	kind: SymbolKind;
+	deprecated: boolean;
+	uri: string;
+	range: Range;
+	selectionRange: Range;
+	parents: LSPTypeHierarchyItem[];
+	children: LSPTypeHierarchyItem[];
+	data: any;
+}
+
+export class TypeHierarchyItem {
+	name: string;
+	detail: string;
+	kind: vscode.SymbolKind;
+	deprecated: boolean;
+	uri: string;
+	range: vscode.Range;
+	selectionRange: vscode.Range;
+	parents: TypeHierarchyItem[];
+	children: TypeHierarchyItem[];
+	data: any;
+	expand: boolean;
+}

--- a/src/typeHierarchy/references-view.d.ts
+++ b/src/typeHierarchy/references-view.d.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * This interface describes the shape for the references viewlet API. It consists
+ * of a single `setInput` function which must be called with a full implementation
+ * of the `SymbolTreeInput`-interface. To acquire this API use the default mechanics, e.g:
+ *
+ * ```ts
+ * // get references viewlet API
+ * const api = await vscode.extensions.getExtension<SymbolTree>('ms-vscode.references-view').activate();
+ *
+ * // instantiate and set input which updates the view
+ * const myInput: SymbolTreeInput<MyItems> = ...
+ * api.setInput(myInput)
+ * ```
+ */
+export interface SymbolTree {
+
+	/**
+	 * Set the contents of the references viewlet.
+	 *
+	 * @param input A symbol tree input object
+	 */
+	setInput(input: SymbolTreeInput<unknown>): void;
+}
+
+/**
+ * A symbol tree input is the entry point for populating the references viewlet.
+ * Inputs must be anchored at a code location, they must have a title, and they
+ * must resolve to a model.
+ */
+export interface SymbolTreeInput<T> {
+
+	/**
+	 * The value of the `reference-list.source` context key. Use this to control
+	 * input dependent commands.
+	 */
+	readonly contextValue: string;
+
+	/**
+	 * The (short) title of this input, like "Implementations" or "Callers Of"
+	 */
+	readonly title: string;
+
+	/**
+	 * The location at which this position is anchored. Locations are validated and inputs
+	 * with "funny" locations might be ignored
+	 */
+	readonly location: vscode.Location;
+
+	/**
+	 * Resolve this input to a model that contains the actual data. When there are no result
+	 * than `undefined` or `null` should be returned.
+	 */
+	resolve(): vscode.ProviderResult<SymbolTreeModel<T>>;
+
+	/**
+	 * This function is called when re-running from history. The symbols tree has tracked
+	 * the original location of this input and that is now passed to this input. The
+	 * implementation of this function should return a clone where the `location`-property
+	 * uses the provided `location`
+	 *
+	 * @param location The location at which the new input should be anchored.
+	 * @returns A new input which location is anchored at the position.
+	 */
+	with(location: vscode.Location): SymbolTreeInput<T>;
+}
+
+/**
+ * A symbol tree model which is used to populate the symbols tree.
+ */
+export interface SymbolTreeModel<T> {
+
+	/**
+	 * A tree data provider which is used to populate the symbols tree.
+	 */
+	provider: vscode.TreeDataProvider<T>;
+
+	/**
+	 * An optional message that is displayed above the tree. Whenever the provider
+	 * fires a change event this message is read again.
+	 */
+	message: string | undefined;
+
+	/**
+	 * Optional support for symbol navigation. When implemented, navigation commands like
+	 * "Go to Next" and "Go to Previous" will be working with this model.
+	 */
+	navigation?: SymbolItemNavigation<T>;
+
+	/**
+	 * Optional support for editor highlights. WHen implemented, the editor will highlight
+	 * symbol ranges in the source code.
+	 */
+	highlights?: SymbolItemEditorHighlights<T>;
+
+	/**
+	 * Optional dispose function which is invoked when this model is
+	 * needed anymore
+	 */
+	dispose?(): void;
+}
+
+/**
+ * Interface to support the built-in symbol navigation.
+ */
+export interface SymbolItemNavigation<T> {
+	/**
+	 * Return the item that is the nearest to the given location or `undefined`
+	 */
+	nearest(uri: vscode.Uri, position: vscode.Position): T | undefined;
+	/**
+	 * Return the next item from the given item or the item itself.
+	 */
+	next(from: T): T;
+	/**
+	 * Return the previous item from the given item or the item itself.
+	 */
+	previous(from: T): T;
+	/**
+	 * Return the location of the given item.
+	 */
+	location(item: T): vscode.Location | undefined;
+}
+
+/**
+ * Interface to support the built-in editor highlights.
+ */
+export interface SymbolItemEditorHighlights<T> {
+	/**
+	 * Given an item and an uri return an array of ranges to highlight.
+	 */
+	getEditorHighlights(item: T, uri: vscode.Uri): vscode.Range[] | undefined;
+}

--- a/src/typeHierarchy/typeHierarchyTree.ts
+++ b/src/typeHierarchy/typeHierarchyTree.ts
@@ -1,0 +1,104 @@
+import * as vscode from "vscode";
+import { LanguageClient, Position, TextDocumentIdentifier, TextDocumentPositionParams } from "vscode-languageclient";
+import { Commands } from "../commands";
+import { getActiveLanguageClient } from "../extension";
+import { showNoLocationFound } from "../standardLanguageClient";
+import { TypeHierarchyTreeInput } from "./model";
+import { LSPTypeHierarchyItem, TypeHierarchyDirection, TypeHierarchyItem } from "./protocol";
+import { SymbolTree } from "./references-view";
+import { ToTypeHierarchyItem } from "./util";
+
+export class TypeHierarchyTree {
+	private api: SymbolTree;
+	private direction: TypeHierarchyDirection;
+	private client: LanguageClient;
+	private cancelTokenSource: vscode.CancellationTokenSource;
+	private location: vscode.Location;
+	private baseItem: TypeHierarchyItem;
+	public initialized: boolean;
+
+	constructor() {
+		this.initialized = false;
+	}
+
+	public async initialize() {
+		this.api = await vscode.extensions.getExtension<SymbolTree>('ms-vscode.references-view').activate();
+		this.client = await getActiveLanguageClient();
+		this.initialized = true;
+	}
+
+	public async setTypeHierarchy(location: vscode.Location, direction: TypeHierarchyDirection): Promise<void> {
+		if (!this.initialized) {
+			await this.initialize();
+		}
+		if (this.cancelTokenSource) {
+			this.cancelTokenSource.cancel();
+		}
+		this.cancelTokenSource = new vscode.CancellationTokenSource();
+		const textDocument: TextDocumentIdentifier = TextDocumentIdentifier.create(location.uri.toString());
+		const position: Position = Position.create(location.range.start.line, location.range.start.character);
+		const params: TextDocumentPositionParams = {
+			textDocument: textDocument,
+			position: position,
+		};
+		let lspItem: LSPTypeHierarchyItem;
+		try {
+			lspItem = await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.OPEN_TYPE_HIERARCHY, JSON.stringify(params), JSON.stringify(direction), JSON.stringify(0), this.cancelTokenSource.token);
+		} catch (e) {
+			// operation cancelled
+			return;
+		}
+		if (!lspItem) {
+			showNoLocationFound('No Type Hierarchy found');
+			return;
+		}
+		const symbolKind = this.client.protocol2CodeConverter.asSymbolKind(lspItem.kind);
+		if (direction === TypeHierarchyDirection.Both && symbolKind === vscode.SymbolKind.Interface) {
+			direction = TypeHierarchyDirection.Children;
+		}
+		const item: TypeHierarchyItem = ToTypeHierarchyItem(this.client, lspItem, direction);
+		const input: TypeHierarchyTreeInput = new TypeHierarchyTreeInput(location, direction, this.cancelTokenSource.token, item);
+		this.location = location;
+		this.direction = direction;
+		this.baseItem = item;
+		this.api.setInput(input);
+	}
+
+	public changeDirection(direction: TypeHierarchyDirection): void {
+		if (this.cancelTokenSource) {
+			this.cancelTokenSource.cancel();
+		}
+		this.cancelTokenSource = new vscode.CancellationTokenSource();
+		this.baseItem.children = undefined;
+		this.baseItem.parents = undefined;
+		const input: TypeHierarchyTreeInput = new TypeHierarchyTreeInput(this.location, direction, this.cancelTokenSource.token, this.baseItem);
+		this.direction = direction;
+		this.api.setInput(input);
+	}
+
+	public async changeBaseItem(item: TypeHierarchyItem): Promise<void> {
+		if (this.cancelTokenSource) {
+			this.cancelTokenSource.cancel();
+		}
+		this.cancelTokenSource = new vscode.CancellationTokenSource();
+		item.parents = undefined;
+		item.children = undefined;
+		const location: vscode.Location = new vscode.Location(vscode.Uri.parse(item.uri), item.selectionRange);
+		const newLocation: vscode.Location = (await this.isValidRequestPosition(location.uri, location.range.start)) ? location : this.location;
+		const input: TypeHierarchyTreeInput = new TypeHierarchyTreeInput(newLocation, this.direction, this.cancelTokenSource.token, item);
+		this.location = newLocation;
+		this.baseItem = item;
+		this.api.setInput(input);
+	}
+
+	private async isValidRequestPosition(uri: vscode.Uri, position: vscode.Position) {
+		const doc = await vscode.workspace.openTextDocument(uri);
+		let range = doc.getWordRangeAtPosition(position);
+		if (!range) {
+			range = doc.getWordRangeAtPosition(position, /[^\s]+/);
+		}
+		return Boolean(range);
+	}
+}
+
+export const typeHierarchyTree: TypeHierarchyTree = new TypeHierarchyTree();

--- a/src/typeHierarchy/util.ts
+++ b/src/typeHierarchy/util.ts
@@ -1,0 +1,121 @@
+import { CancellationToken, commands, SymbolKind } from "vscode";
+import { LanguageClient } from "vscode-languageclient";
+import { Commands } from "../commands";
+import { LSPTypeHierarchyItem, TypeHierarchyDirection, TypeHierarchyItem } from "./protocol";
+
+export function ToSingleLSPTypeHierarchyItem(client: LanguageClient, typeHierarchyItem: TypeHierarchyItem): LSPTypeHierarchyItem {
+	if (!typeHierarchyItem) {
+		return undefined;
+	}
+	return {
+		name: typeHierarchyItem.name,
+		detail: typeHierarchyItem.detail,
+		kind: client.code2ProtocolConverter.asSymbolKind(typeHierarchyItem.kind),
+		deprecated: typeHierarchyItem.deprecated,
+		uri: typeHierarchyItem.uri,
+		range: client.code2ProtocolConverter.asRange(typeHierarchyItem.range),
+		selectionRange: client.code2ProtocolConverter.asRange(typeHierarchyItem.selectionRange),
+		parents: undefined,
+		children: undefined,
+		data: typeHierarchyItem.data,
+	};
+}
+
+export function ToTypeHierarchyItem(client: LanguageClient, lspTypeHierarchyItem: LSPTypeHierarchyItem, direction: TypeHierarchyDirection): TypeHierarchyItem {
+	if (!lspTypeHierarchyItem) {
+		return undefined;
+	}
+	let parents: TypeHierarchyItem[];
+	let children: TypeHierarchyItem[];
+	if (direction === TypeHierarchyDirection.Parents || direction === TypeHierarchyDirection.Both) {
+		if (lspTypeHierarchyItem.parents) {
+			parents = [];
+			for (const parent of lspTypeHierarchyItem.parents) {
+				parents.push(ToTypeHierarchyItem(client, parent, TypeHierarchyDirection.Parents));
+			}
+			parents = parents.sort((a, b) => {
+				return (a.kind.toString() === b.kind.toString()) ? a.name.localeCompare(b.name) : b.kind.toString().localeCompare(a.kind.toString());
+			});
+		}
+	}
+	if (direction === TypeHierarchyDirection.Children || direction === TypeHierarchyDirection.Both) {
+		if (lspTypeHierarchyItem.children) {
+			children = [];
+			for (const child of lspTypeHierarchyItem.children) {
+				children.push(ToTypeHierarchyItem(client, child, TypeHierarchyDirection.Children));
+			}
+			children = children.sort((a, b) => {
+				return (a.kind.toString() === b.kind.toString()) ? a.name.localeCompare(b.name) : b.kind.toString().localeCompare(a.kind.toString());
+			});
+		}
+	}
+	return {
+		name: lspTypeHierarchyItem.name,
+		detail: lspTypeHierarchyItem.detail,
+		kind: client.protocol2CodeConverter.asSymbolKind(lspTypeHierarchyItem.kind),
+		deprecated: lspTypeHierarchyItem.deprecated,
+		uri: lspTypeHierarchyItem.uri,
+		range: client.protocol2CodeConverter.asRange(lspTypeHierarchyItem.range),
+		selectionRange: client.protocol2CodeConverter.asRange(lspTypeHierarchyItem.selectionRange),
+		parents: parents,
+		children: children,
+		data: lspTypeHierarchyItem.data,
+		expand: false,
+	};
+}
+
+export function typeHierarchyDirectionToContextString(direction: TypeHierarchyDirection): string {
+	switch (direction) {
+		case TypeHierarchyDirection.Children:
+			return "children";
+		case TypeHierarchyDirection.Parents:
+			return "parents";
+		case TypeHierarchyDirection.Both:
+			return "both";
+		default:
+			return undefined;
+	}
+}
+
+export async function resolveTypeHierarchy(client: LanguageClient, typeHierarchyItem: TypeHierarchyItem, direction: TypeHierarchyDirection, token: CancellationToken): Promise<TypeHierarchyItem> {
+	const lspTypeHierarchyItem = ToSingleLSPTypeHierarchyItem(client, typeHierarchyItem);
+	let resolvedLSPItem: LSPTypeHierarchyItem;
+	try {
+		resolvedLSPItem = await commands.executeCommand<LSPTypeHierarchyItem>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.RESOLVE_TYPE_HIERARCHY, JSON.stringify(lspTypeHierarchyItem), JSON.stringify(direction), JSON.stringify(1), token);
+	} catch (e) {
+		// operation cancelled
+		return undefined;
+	}
+	const resolvedItem = ToTypeHierarchyItem(client, resolvedLSPItem, direction);
+	if (!resolvedItem) {
+		return undefined;
+	}
+	resolvedItem.expand = typeHierarchyItem.expand;
+	return resolvedItem;
+}
+
+export async function getRootItem(client: LanguageClient, typeHierarchyItem: TypeHierarchyItem, token: CancellationToken): Promise<TypeHierarchyItem> {
+	if (!typeHierarchyItem) {
+		return undefined;
+	}
+	if (!typeHierarchyItem.parents) {
+		const resolvedItem = await resolveTypeHierarchy(client, typeHierarchyItem, TypeHierarchyDirection.Parents, token);
+		if (!resolvedItem || !resolvedItem.parents) {
+			return typeHierarchyItem;
+		} else {
+			typeHierarchyItem.parents = resolvedItem.parents;
+		}
+	}
+	if (typeHierarchyItem.parents.length === 0) {
+		return typeHierarchyItem;
+	} else {
+		for (const parent of typeHierarchyItem.parents) {
+			if (parent.kind === SymbolKind.Class) {
+				parent.children = [typeHierarchyItem];
+				parent.expand = true;
+				return getRootItem(client, parent, token);
+			}
+		}
+		return typeHierarchyItem;
+	}
+}

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -65,7 +65,12 @@ suite('Java Language Extension - Standard', () => {
 				Commands.SHOW_SERVER_TASK_STATUS,
 				Commands.SWITCH_SERVER_MODE,
 				Commands.UPDATE_SOURCE_ATTACHMENT,
-				Commands.RUNTIME_VALIDATION_OPEN
+				Commands.RUNTIME_VALIDATION_OPEN,
+				Commands.CHANGE_BASE_TYPE,
+				Commands.SHOW_TYPE_HIERARCHY,
+				Commands.SHOW_SUBTYPE_HIERARCHY,
+				Commands.SHOW_SUPERTYPE_HIERARCHY,
+				Commands.SHOW_CLASS_HIERARCHY,
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Requires [eclipse/eclipse.jdt.ls#1656](https://github.com/eclipse/eclipse.jdt.ls/pull/1656)

Will support showing type hierarchy. The user can open type hierarchy of a given type view via context of editor:
![context](https://user-images.githubusercontent.com/45906942/106692503-911be880-660f-11eb-8be3-3d72cc03e32a.jpg)

The type hierarchy view uses [reference-viewlet-API](https://github.com/microsoft/vscode-references-view) and show the result in the reference view. The focus type is highlighted:
![reference](https://user-images.githubusercontent.com/45906942/106692631-c9bbc200-660f-11eb-9889-aeb62f41f40c.jpg)

The type hierarchy has three kinds of hierarchies. Type Hierarchy, SuperType Hierarchy and SubType Hierarchy. The user can change the view via the buttons on the title of the view.

Also offer a command in the context of view to change the focus type:
![Focus](https://user-images.githubusercontent.com/45906942/106692802-215a2d80-6610-11eb-884e-f3b62975422b.jpg)

Some notes:
* `/src/typeHierarchy/references-view.d.ts` is the API definition file from [reference-viewlet-API](https://github.com/microsoft/vscode-references-view). It's a stable version and will [not break](https://github.com/microsoft/vscode/issues/115515#issuecomment-771827993) in the foreseeable future.
* ~~Currently the type hierarchy icons of VS Code is [not available yet](https://github.com/microsoft/vscode-codicons/issues/37). We use eclipse ones temporarily.~~ We have applied vscode's type hierarchy icons.

Signed-off-by: Shi Chen <chenshi@microsoft.com>