### PR TITLE
Temporarily use VSCode 1.52.1 for test runs.

### DIFF
--- a/test/runtest.ts
+++ b/test/runtest.ts
@@ -21,6 +21,7 @@ async function main() {
 		});
 
 		await runTests({
+			version: '1.52.1',
 			extensionDevelopmentPath,
 			extensionTestsPath: path.resolve(__dirname, './standard-mode-suite'),
 			launchArgs: [
@@ -37,6 +38,7 @@ async function main() {
 
 		console.log("running lightweight cases...");
 		await runTests({
+			version: '1.52.1',
 			extensionDevelopmentPath,
 			extensionTestsPath: path.resolve(__dirname, './lightweight-mode-suite'),
 			launchArgs: [


### PR DESCRIPTION
- VSCode 1.53 bumped minimum GLIBCXX to 3.4.21 making it difficult to
  run tests on older platforms. Instead of disabling, we can use 1.52.1
  runtime temporarily and eventually upgrade infrastructure.
- https://code.visualstudio.com/updates/v1_53#_electron-11-update

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>