### PR TITLE
Upgrade infrastructure to support GLIBCXX 3.4.21.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ language: java
 matrix:
   include:
   - os: linux
-    dist: trusty
+    dist: bionic
+    services:
+      - xvfb
     jdk: openjdk11
     env:
       - JDK_HOME=~/openjdk11 # force launching JLS using JDK11
@@ -15,10 +17,8 @@ matrix:
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
+      export CXX="g++-4.9" CC="gcc-4.9";
+  fi
 - npm install -g typescript
 
 install:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def buildVscodeExtension(){
 	sh "npm run vscode:prepublish"
 }
 
-node('rhel7'){
+node('rhel8'){
 	stage 'Build JDT LS'
 
 	env.JAVA_HOME="${tool 'openjdk-11'}"
@@ -26,7 +26,7 @@ node('rhel7'){
 	stash name: 'server_distro', includes :files[0].path
 }
 
-node('rhel7'){
+node('rhel8'){
 	env.JAVA_HOME="${tool 'openjdk-11'}"
 	env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
 	stage 'Checkout vscode-java code'
@@ -61,7 +61,7 @@ node('rhel7'){
 	stash name:'vsix', includes:files[0].path
 }
 
-node('rhel7'){
+node('rhel8'){
 	if(publishToMarketPlace.equals('true')){
 		timeout(time:5, unit:'DAYS') {
 			input message:'Approve deployment?', submitter: 'fbricon,rgrunber'

--- a/test/runtest.ts
+++ b/test/runtest.ts
@@ -21,7 +21,6 @@ async function main() {
 		});
 
 		await runTests({
-			version: '1.52.1',
 			extensionDevelopmentPath,
 			extensionTestsPath: path.resolve(__dirname, './standard-mode-suite'),
 			launchArgs: [
@@ -38,7 +37,6 @@ async function main() {
 
 		console.log("running lightweight cases...");
 		await runTests({
-			version: '1.52.1',
 			extensionDevelopmentPath,
 			extensionTestsPath: path.resolve(__dirname, './lightweight-mode-suite'),
 			launchArgs: [


### PR DESCRIPTION
This reverts commit 371e6c1cf6917ce77698ec2b0cc7c312e11ed0c6 and
upgrades build infrastructure to work with VSCode 1.53.

- Use rhel8 nodes instead of rhel7 on Jenkins infra
- Use Ubuntu Bionic Beaver instead of Trusty Tahr on Travis infra