### PR TITLE
Configure whether to show recommendations of external installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ The following settings are supported:
 * `java.templates.typeComment`: Specifies the type comment for new Java type. Supports configuring multi-line comments with an array of strings, and using ${variable} to reference the [predefined variables](https://github.com/redhat-developer/vscode-java/wiki/Predefined-Variables-for-Java-Template-Snippets).
 * `java.references.includeAccessors`: Include getter, setter and builder/constructor when finding references. Default to true.
 * `java.configuration.maven.globalSettings` : Path to Maven's global settings.xml.
-
-New in 0.74.0:
 * `java.eclipse.downloadSources` : Enable/disable download of Maven source artifacts for Eclipse projects.
 
+New in 0.76.0:
+* `java.recommendations.dependency.analytics.show` : Show the recommended Dependency Analytics extension.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -382,6 +382,12 @@
           "scope": "window",
           "minimum": 1
         },
+        "java.recommendations.dependency.analytics.show": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the recommended Dependency Analytics extension.",
+          "scope": "window"
+        },
         "java.completion.maxResults": {
           "type": "integer",
           "default": 0,

--- a/src/recommendation/dependencyAnalytics.ts
+++ b/src/recommendation/dependencyAnalytics.ts
@@ -8,12 +8,17 @@ import { IHandler } from "./handler";
 const EXTENSION_NAME = "redhat.fabric8-analytics";
 const GH_ORG_URL = `https://github.com/fabric8-analytics`;
 const RECOMMENDATION_MESSAGE = `Do you want to install the [Dependency Analytics](${GH_ORG_URL}) extension to stay informed about vulnerable dependencies in pom.xml files?`;
+const JAVA_DEPENDENCY_ANALYTICS_SHOW = "java.recommendations.dependency.analytics.show";
 
 function isPomDotXml(uri: vscode.Uri) {
 	return !!uri.path && uri.path.toLowerCase().endsWith("pom.xml");
 }
 
 export function initialize (context: vscode.ExtensionContext, handler: IHandler): void {
+	const show = vscode.workspace.getConfiguration().get(JAVA_DEPENDENCY_ANALYTICS_SHOW);
+	if (!show) {
+		return;
+	}
 	if (!handler.canRecommendExtension(EXTENSION_NAME)) {
 		return;
 	}


### PR DESCRIPTION
Fixes #1816 

You can use
```
"java.dependency.analytics.show": false
```

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>