### PR TITLE
Disable console.log for lsp trace due to performance issue

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -18,6 +18,8 @@ export const logger = createLogger({
 		format.prettyPrint()
 	),
 	transports: [
-		new transports.Console()
+		// See https://github.com/microsoft/vscode/issues/117327
+		// Disable console.log for lsp trace because intense logging will freeze the code render process.
+		// new transports.Console()
 	]
 });


### PR DESCRIPTION
See https://github.com/microsoft/vscode/issues/117327, when enabling `"java.trace.server": "verbose"`, opening a Java project in vscode@1.53 for a while, the whole UI process is frozen. The reason is the LSP will print lots of trace to the console of VS Code Dev Tools. To mitigate that, will disable console.log for LSP trace.

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>