### PR TITLE
Revert "Add support for Java 16"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Features
 =========
 ![ screencast ](https://raw.githubusercontent.com/redhat-developer/vscode-java/master/images/vscode-java.0.0.1.gif)
 
-* Supports code from Java 1.5 to Java 16
+* Supports code from Java 1.5 to Java 15
 * Maven pom.xml project support
 * Basic Gradle Java project support (Android not supported)
 * Standalone Java files support
@@ -76,8 +76,8 @@ If you need to compile your projects against a different JDK version, it's recom
     "path": "/path/to/jdk-11",
   },
   {
-    "name": "JavaSE-16",
-    "path": "/path/to/jdk-16",
+    "name": "JavaSE-15",
+    "path": "/path/to/jdk-15",
     "default": true
   },
 ]

--- a/package.json
+++ b/package.json
@@ -594,8 +594,7 @@
                   "JavaSE-12",
                   "JavaSE-13",
                   "JavaSE-14",
-                  "JavaSE-15",
-                  "JavaSE-16"
+                  "JavaSE-15"
                 ],
                 "description": "Java Execution Environment name. Must be unique."
               },


### PR DESCRIPTION
Reverts redhat-developer/vscode-java#1836

We should re-apply these changes after the 1.0 release.