### PR TITLE
Configure source suffix array to a Java libraries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,6 +328,14 @@
           ],
           "scope": "window"
         },
+        "java.references.detectSourcesJarSuffix":{
+          "type": "array",
+          "description": "Configure source suffix array to a Java libraries.",
+          "default": [
+            "-sources.jar", "_src.jar"
+          ],
+          "scope": "window"
+        },
         "java.project.referencedLibraries": {
           "type": [
             "array",


### PR DESCRIPTION
## More free detection of source code packages. 
> Support ["-sources.jar", "_src.jar"]
- because there are many enterprise packages with custom suffixes. Cannot find the source code for development using vscode