### PR TITLE
Add setting to control method declaration lookups in source files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ The following settings are supported:
 * `java.configuration.maven.globalSettings` : Path to Maven's global settings.xml.
 * `java.eclipse.downloadSources` : Enable/disable download of Maven source artifacts for Eclipse projects.
 * `java.recommendations.dependency.analytics.show` : Show the recommended Dependency Analytics extension.
-
-New in 0.77.0:
 * `java.references.includeDecompiledSources` : Include the decompiled sources when finding references. Default to true.
 * `java.project.sourcePaths`: Relative paths to the workspace where stores the source files. `Only` effective in the `WORKSPACE` scope. The setting will `NOT` affect Maven or Gradle project.
 * `java.typeHierarchy.lazyLoad`: Enable/disable lazy loading the content in type hierarchy. Lazy loading could save a lot of loading time but every type should be expanded manually to load its content.
@@ -191,6 +189,9 @@ New in 0.77.0:
   - `beforeCursor`: Insert the generated code before the member where the cursor is located.
   - `lastMember`: Insert the generated code as the last member of the target type.
 * `java.settings.url` : Specifies the url or file path to the workspace Java settings. See [Setting Global Preferences](https://github.com/redhat-developer/vscode-java/wiki/Settings-Global-Preferences)
+
+New in 0.78.0:
+* `java.symbols.includeSourceMethodDeclarations` : Include method declarations from source files in symbol search. Defaults to `false`.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -760,6 +760,12 @@
           "markdownDescription": "Specifies the url or file path to the workspace Java settings. See [Setting Global Preferences](https://github.com/redhat-developer/vscode-java/wiki/Settings-Global-Preferences)",
           "default": null,
           "scope": "window"
+        },
+        "java.symbols.includeSourceMethodDeclarations": {
+          "type": "boolean",
+          "markdownDescription": "Include method declarations from source files in symbol search.",
+          "default": false,
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
- Requires eclipse/eclipse.jdt.ls#1688
- Add java.symbols.includeSourceMethodDeclarations, defaulting to false

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>