### PR TITLE
Remove 'container environments' term.

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
             "null"
           ],
           "default": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m",
-          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m ` to optimize memory usage for container environments with the parallel garbage collector",
+          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m ` to optimize memory usage with the parallel garbage collector",
           "scope": "window"
         },
         "java.errors.incompleteClasspath.severity": {


### PR DESCRIPTION
- The default memory options passed to the JVM help for desktop
  environments as well, so let's make the description less confusing

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>