### PR TITLE
Enable SKIP_COMMANDS_TEST due to failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ before_install:
   fi
 - npm install -g typescript
 
+env:
+- SKIP_COMMANDS_TEST="true"
+
 install:
 - wget http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
 - mkdir server


### PR DESCRIPTION
- Related #1892
- Temporarily disable 'should register all java commands' tests due to
  intermitent failures

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>