### PR TITLE
Continue to support VS Code 1.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "preview": true,
   "enableProposedApi": false,
   "engines": {
-    "vscode": "^1.53.2"
+    "vscode": "^1.50.0"
   },
   "repository": {
     "type": "git",
@@ -1047,7 +1047,7 @@
     "@types/lodash.findindex": "^4.6.6",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.51",
-    "@types/vscode": "^1.53.0",
+    "@types/vscode": "^1.50.0",
     "@types/winreg": "^1.2.30",
     "@types/winston": "^2.4.4",
     "gulp": "^4.0.2",

--- a/src/typeHierarchy/typeHierarchyTree.ts
+++ b/src/typeHierarchy/typeHierarchyTree.ts
@@ -31,6 +31,9 @@ export class TypeHierarchyTree {
 		if (!this.initialized) {
 			await this.initialize();
 		}
+		if (!this.api) {
+			return;
+		}
 		if (this.cancelTokenSource) {
 			this.cancelTokenSource.cancel();
 		}
@@ -65,6 +68,9 @@ export class TypeHierarchyTree {
 	}
 
 	public changeDirection(direction: TypeHierarchyDirection): void {
+		if (!this.api) {
+			return;
+		}
 		if (this.cancelTokenSource) {
 			this.cancelTokenSource.cancel();
 		}
@@ -77,6 +83,9 @@ export class TypeHierarchyTree {
 	}
 
 	public async changeBaseItem(item: TypeHierarchyItem): Promise<void> {
+		if (!this.api) {
+			return;
+		}
 		if (this.cancelTokenSource) {
 			this.cancelTokenSource.cancel();
 		}


### PR DESCRIPTION
- Undo our update of the VS Code engine requirement to ^1.53.2, moving
  it down to ^1.50.0
- Allow those basing their language client off of VS Code 1.50.0 to
  continue to use this version and not be forced to install an earlier
  version
- Guard the 'api' field (which holds the reference view) if using a
  version that does not support it

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>