### PR TITLE
Fix TreeItem API usage for VS Code 1.50.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,9 +95,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
-      "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.50.0.tgz",
+      "integrity": "sha512-QnIeyi4L2DiD9M2bAQKRzT/EQvc80qP9UL6JD5TiLlNRL1khIDg4ej4mDSRbtFrDAsRntFI1RhMvdomUThMsqg==",
       "dev": true
     },
     "@types/winreg": {
@@ -4724,14 +4724,6 @@
               "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "5.3.1",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                  "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                  "dev": true
-                }
               }
             }
           }

--- a/src/typeHierarchy/model.ts
+++ b/src/typeHierarchy/model.ts
@@ -115,7 +115,8 @@ class TypeHierarchyTreeDataProvider implements vscode.TreeDataProvider<TypeHiera
 		if (!element) {
 			return undefined;
 		}
-		const treeItem: vscode.TreeItem = (element === this.model.getBaseItem()) ? new vscode.TreeItem({ label: element.name, highlights: [[0, element.name.length]] }) : new vscode.TreeItem(element.name);
+		// const treeItem: vscode.TreeItem = (element === this.model.getBaseItem()) ? new vscode.TreeItem({ label: element.name, highlights: [[0, element.name.length]] }) : new vscode.TreeItem(element.name);
+		const treeItem: vscode.TreeItem = new vscode.TreeItem(element.name);
 		treeItem.contextValue = (element === this.model.getBaseItem() || !element.uri) ? "false" : "true";
 		treeItem.description = element.detail;
 		treeItem.iconPath = TypeHierarchyTreeDataProvider.getThemeIcon(element.kind);


### PR DESCRIPTION
- The TreeItemLabel constructor for vscode.TreeItem was introduced in
  1.52.0, so use the string constructor for compatibility. The only
  downside is tree items that are the basis of the search, will not be
  highlighted
- Update package-lock.json

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

The commit in vscode that introduced the functionality (in 1.52.0) that we were using : https://github.com/microsoft/vscode/commit/0286c4f793a508837176e1ee3b76a0431d22bb6a