### PR TITLE
disable extension in virtual workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "onCommand:_java.templateVariables"
   ],
   "main": "./dist/extension",
+  "capabilities": {
+    "virtualWorkspaces": false
+  },
   "contributes": {
     "javaBuildFilePatterns": [
       "^pom.xml$",


### PR DESCRIPTION
Diable it as language server is file-based and doesn't support `vscode-vfs` scheme.

See #1936 