### PR TITLE
Introduce syntaxServerExitsOnShutdown as an extended capability.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						gradleChecksumWrapperPromptSupport: true,
 						resolveAdditionalTextEditsSupport: true,
 						advancedIntroduceParameterRefactoringSupport: true,
-						actionableRuntimeNotificationSupport: true
+						actionableRuntimeNotificationSupport: true,
+						syntaxServerExitsOnShutdown: true
 					},
 					triggerFiles,
 				},


### PR DESCRIPTION
- Fixes #1928
- In languageclient 7.x, the client fails to send the necessary exit()
  once a shutdown() response is received from the language server
- When client defines syntaxServerExitsOnShutdown as true, the language
  server will exit immediately after the shutdown request

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This change depends on https://github.com/eclipse/eclipse.jdt.ls/pull/1790 .