### PR TITLE
Adjust .vscodeignore filters due to vsce@1.92 update.

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,9 +12,8 @@ vsc-extension-quickstart.md
 undefined/**
 CONTRIBUTING.md
 .vscode-test/**
-**/**.vsix
-**/**.tar.gz
-dist/**/*.map
+**/*.vsix
+**/*.tar.gz
 webpack.*.json
 node_modules
 .editorconfig


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

Let me know if you're able to verify this (`vsce ls` should show what would be published). I noticed our snapshot builds doubled in size because, as an example, `org.eclipse.jdt.ls.product/distro/jdt-language-server-1.2.0-202106160036.tar.gz` would end up in our final .vsix despite [`**/**.tar.gz`](https://github.com/redhat-developer/vscode-java/blob/master/.vscodeignore#L16). Comparing the builds showed vsce 1.91 -> 1.93, and that lead to https://github.com/microsoft/vscode-vsce/issues/576 .

So it looks like we should be using https://git-scm.com/docs/gitignore as a guide now. AFAICT `**/dist/*.map` should be covered by `**/*.map` since a leading `**` implies all directories. Might even be possible to simplify to just `*.map` according to docs.