### PR TITLE
Recollect Java bundles when granting workspace trust

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -352,7 +352,12 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			if (onDidGrantWorkspaceTrust !== undefined) { // keep compatibility for old engines < 1.56.0
 				context.subscriptions.push(onDidGrantWorkspaceTrust(() => {
 					if (getJavaServerMode() !== ServerMode.LIGHTWEIGHT) {
-						commands.executeCommand(Commands.SWITCH_SERVER_MODE, ServerMode.STANDARD, true);
+						// See the issue https://github.com/redhat-developer/vscode-java/issues/1994
+						// Need to recollect the Java bundles before starting standard mode.
+						setTimeout(() => {
+							clientOptions.initializationOptions.bundles = collectJavaExtensions(extensions.all);
+							commands.executeCommand(Commands.SWITCH_SERVER_MODE, ServerMode.STANDARD, true);
+						}, 1000);
 					}
 				}));
 			}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -57,7 +57,7 @@ export function onExtensionChange(extensions: readonly vscode.Extension<any>[]) 
 	}
 }
 
-function isContributedPartUpdated(oldContributedPart: Array<string>, newContributedPart: Array<string>) {
+export function isContributedPartUpdated(oldContributedPart: Array<string>, newContributedPart: Array<string>) {
 	if (!oldContributedPart) {
 		return false;
 	}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fixes #1994

In untrusted workspaces, those extensions that do not declare support for workspace trust are not visible to the `extensions.all API`. Since the variable `clientOptions` is preconfigured when activating the Java extension, it becomes outdated after we trust the workspace. The list of Java bundles needs to be recollected before switching to standard mode.

It seems that `extensions.all` still does not include the new available Java extensions during the callback `onDidGrantWorkspaceTrust`. This looks like a VS code bug. A workaround would be to add a timeout to allow Java extensions to get the latest available Java bundles.