### PR TITLE
replace sync icon to refresh

### DIFF
--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -57,7 +57,7 @@ class ServerStatusBarProvider implements Disposable {
 
 enum StatusIcon {
 	LightWeight = "$(rocket)",
-	Busy = "$(sync~spin)",
+	Busy = "$(refresh~spin)",
 	Ready = "$(thumbsup)",
 	Error = "$(thumbsdown)"
 }


### PR DESCRIPTION
Signef-off-by: shuyaqian 717749594@qq.com

The original icon is too small, and the rotation track is incorrect.
before:
![](https://bbs-img.huaweicloud.com/blogs/img/1624603523628058908.gif)

after:
![](https://bbs-img.huaweicloud.com/blogs/img/1624603529044077751.gif)