### PR TITLE
Rename to shouldLanguageServerExitOnShutdown extended capability.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,7 +193,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						resolveAdditionalTextEditsSupport: true,
 						advancedIntroduceParameterRefactoringSupport: true,
 						actionableRuntimeNotificationSupport: true,
-						syntaxServerExitsOnShutdown: true
+						shouldLanguageServerExitOnShutdown: true
 					},
 					triggerFiles,
 				},


### PR DESCRIPTION
- syntaxServerExitsOnShutdown -> shouldLanguageServerExitOnShutdown
- Standard language server should also exit on shutdown
- Related #1928

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>