### PR TITLE
Explicitly show import progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 0.81.0
+* enhancement - Show job status via progress notification on start. See [#2022](https://github.com/redhat-developer/vscode-java/pull/2022)
 * other - Change the default value of the setting `java.project.importOnFirstTimeStartup` to `automatic`. See [#2016](https://github.com/redhat-developer/vscode-java/pull/2016)
 
 ## 0.80.0 (June 30th, 2021)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,11 @@ The following settings are supported:
 * `java.codeGeneration.toString.listArrayContents`: List contents of arrays instead of using native toString(). Defaults to `true`.
 * `java.codeGeneration.toString.limitElements`: Limit number of items in arrays/collections/maps to list, if 0 then list all. Defaults to `0`.
 * `java.selectionRange.enabled`: Enable/disable Smart Selection support for Java. Disabling this option will not affect the VS Code built-in word-based and bracket-based smart selection.
-* `java.showBuildStatusOnStart.enabled`: Automatically show build status on startup. Defaults to `false`.
+* `java.showBuildStatusOnStart.enabled`: Automatically show build status on startup, defaults to `notification`.
+  - `notification`: Show the build status via progress notification.
+  - `terminal`: Show the build status via terminal.
+  - `off`: Do not show any build status.
+  > For backward compatibility, this setting also accepts boolean value, where `true` has the same meaning as `notification` and `false` has the same meaning as `off`.
 * `java.project.outputPath`: A relative path to the workspace where stores the compiled output. `Only` effective in the `WORKSPACE` scope. The setting will `NOT` affect Maven or Gradle project.
 * `java.project.referencedLibraries`: Configure glob patterns for referencing local libraries to a Java project.
 * `java.completion.maxResults`: Maximum number of completion results (not including snippets). `0` (the default value) disables the limit, all results are returned. In case of performance problems, consider setting a sensible limit..

--- a/package.json
+++ b/package.json
@@ -605,9 +605,23 @@
           "scope": "window"
         },
         "java.showBuildStatusOnStart.enabled": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "enum": [
+                "notification",
+                "terminal",
+                "off"
+              ],
+              "enumDescriptions": [
+                "Show the build status via progress notification on start",
+                "Show the build status via terminal on start",
+                "Do not show any build status on start"
+              ]
+            },
+            "boolean"
+          ],
           "description": "Automatically show build status on startup.",
-          "default": false,
+          "default": "notification",
           "scope": "window"
         },
         "java.configuration.runtimes": {

--- a/src/serverTaskPresenter.ts
+++ b/src/serverTaskPresenter.ts
@@ -122,8 +122,16 @@ export class ActivationProgressNotification {
 	private lastJobId: string;
 
 	public showProgress() {
-		const isProgressReportEnabled: boolean = getJavaConfiguration().get('progressReports.enabled');
-		const title = isProgressReportEnabled ? `[Importing Projects](command:${Commands.SHOW_SERVER_TASK_STATUS})` : "Importing Projects";
+		const showBuildStatusEnabled = getJavaConfiguration().get("showBuildStatusOnStart.enabled");
+		if (typeof showBuildStatusEnabled === "string" || showBuildStatusEnabled instanceof String) {
+			if (showBuildStatusEnabled !== "notification") {
+				return;
+			}
+		} else if (!showBuildStatusEnabled) {
+			return;
+		}
+		const isProgressReportEnabled: boolean = getJavaConfiguration().get("progressReports.enabled");
+		const title = isProgressReportEnabled ? `[Importing Projects](command:${Commands.SHOW_SERVER_TASK_STATUS})` : "Importing Projects...";
 		window.withProgress({
 			location: ProgressLocation.Notification,
 			title,

--- a/src/serverTaskPresenter.ts
+++ b/src/serverTaskPresenter.ts
@@ -131,7 +131,7 @@ export class ActivationProgressNotification {
 			return;
 		}
 		const isProgressReportEnabled: boolean = getJavaConfiguration().get("progressReports.enabled");
-		const title = isProgressReportEnabled ? `[Importing Projects](command:${Commands.SHOW_SERVER_TASK_STATUS})` : "Importing Projects...";
+		const title = isProgressReportEnabled ? "Importing Projects" : "Importing Projects...";
 		window.withProgress({
 			location: ProgressLocation.Notification,
 			title,
@@ -147,7 +147,7 @@ export class ActivationProgressNotification {
 						});
 						if (!taskToShow || taskToShow.complete) {
 							taskToShow = tasks.find((task) => {
-								if (!task.complete) {
+								if (!task.complete && task.task) {
 									return task;
 								}
 							});
@@ -156,9 +156,9 @@ export class ActivationProgressNotification {
 							return;
 						}
 						this.lastJobId = taskToShow.id;
-						let message: string = taskToShow.task;
+						let message: string = `([details](command:${Commands.SHOW_SERVER_TASK_STATUS})) ${taskToShow.task}`;
 						if (taskToShow.subTask) {
-							message += ": " + taskToShow.subTask;
+							message += " - " + taskToShow.subTask;
 						}
 						message = message.trim();
 						if (!message.endsWith("...")) {

--- a/src/serverTaskPresenter.ts
+++ b/src/serverTaskPresenter.ts
@@ -131,50 +131,24 @@ export class ActivationProgressNotification {
 			return;
 		}
 		const isProgressReportEnabled: boolean = getJavaConfiguration().get("progressReports.enabled");
-		const title = isProgressReportEnabled ? "Importing Projects" : "Importing Projects...";
+		const title = isProgressReportEnabled ? "Opening Java Projects" : "Opening Java Projects...";
 		window.withProgress({
 			location: ProgressLocation.Notification,
 			title,
 			cancellable: false,
 		}, (progress: Progress<{ message?: string; increment?: number }>) => {
 			return new Promise<void>((resolve) => {
-				this.disposables.push(
-					serverTasks.onDidUpdateServerTask(tasks => {
-						let taskToShow: ProgressReport | undefined = tasks.find((task) => {
-							if (task.id === this.lastJobId) {
-								return task;
-							}
-						});
-						if (!taskToShow || taskToShow.complete) {
-							taskToShow = tasks.find((task) => {
-								if (!task.complete && task.task) {
-									return task;
-								}
-							});
-						}
-						if (!taskToShow) {
-							return;
-						}
-						this.lastJobId = taskToShow.id;
-						let message: string = `([details](command:${Commands.SHOW_SERVER_TASK_STATUS})) ${taskToShow.task}`;
-						if (taskToShow.subTask) {
-							message += " - " + taskToShow.subTask;
-						}
-						message = message.trim();
-						if (!message.endsWith("...")) {
-							message += "...";
-						}
-						progress.report({
-							message
-						});
-					}),
-					this.onHide(() => {
-						for (const disposable of this.disposables) {
-							disposable.dispose();
-						}
-						return resolve();
-					}),
-				);
+				if (isProgressReportEnabled) {
+					progress.report({
+						message: `[check details](command:${Commands.SHOW_SERVER_TASK_STATUS})`
+					});
+				}
+				this.onHide(() => {
+					for (const disposable of this.disposables) {
+						disposable.dispose();
+					}
+					return resolve();
+				});
 			});
 		});
 	}

--- a/src/serverTaskPresenter.ts
+++ b/src/serverTaskPresenter.ts
@@ -3,6 +3,7 @@ import { serverTasks } from "./serverTasks";
 import { Disposable } from "vscode-languageclient";
 import { ProgressReport } from "./protocol";
 import { Commands } from "./commands";
+import { getJavaConfiguration } from "./utils";
 
 const JAVA_SERVER_TASK_PRESENTER_TASK_NAME = "Java Build Status";
 
@@ -121,9 +122,11 @@ export class ActivationProgressNotification {
 	private lastJobId: string;
 
 	public showProgress() {
+		const isProgressReportEnabled: boolean = getJavaConfiguration().get('progressReports.enabled');
+		const title = isProgressReportEnabled ? `[Importing Projects](command:${Commands.SHOW_SERVER_TASK_STATUS})` : "Importing Projects";
 		window.withProgress({
 			location: ProgressLocation.Notification,
-			title: `[Importing Projects](command:${Commands.SHOW_SERVER_TASK_STATUS})`,
+			title,
 			cancellable: false,
 		}, (progress: Progress<{ message?: string; increment?: number }>) => {
 			return new Promise<void>((resolve) => {
@@ -144,6 +147,7 @@ export class ActivationProgressNotification {
 						if (!taskToShow) {
 							return;
 						}
+						this.lastJobId = taskToShow.id;
 						let message: string = taskToShow.task;
 						if (taskToShow.subTask) {
 							message += ": " + taskToShow.subTask;

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -45,7 +45,7 @@ export class StandardLanguageClient {
 			return;
 		}
 
-		if (workspace.getConfiguration().get("java.showBuildStatusOnStart.enabled")) {
+		if (workspace.getConfiguration().get("java.showBuildStatusOnStart.enabled") === "terminal") {
 			commands.executeCommand(Commands.SHOW_SERVER_TASK_STATUS);
 		}
 


### PR DESCRIPTION
This is the first part of #2021.

In this PR:

- we show the job status more explicitly during the import stage. (Like Eclipse or IntelliJ, at the right-bottom corner, users can see what jobs are running)

- If user click the hyper link in the notification, the build status terminal will pop up and the notification get dismissed.
- After importing jobs are finished. A dialog shows up to let the user know.

https://user-images.githubusercontent.com/6193897/125410372-6a987f80-e3ef-11eb-9e40-6d3d344cd1ee.mp4



Signed-off-by: Sheng Chen <sheche@microsoft.com>