### PR TITLE
Disable Workspace Trust in tests runtime

### DIFF
--- a/test/runtest.ts
+++ b/test/runtest.ts
@@ -25,6 +25,7 @@ async function main() {
 			launchArgs: [
 				testProjectPath,
 				'--disable-extensions',
+				'--disable-workspace-trust'
 			]
 		});
 
@@ -41,6 +42,7 @@ async function main() {
 			launchArgs: [
 				testProjectPath,
 				'--disable-extensions',
+				'--disable-workspace-trust'
 			]
 		});
 	} catch (err) {


### PR DESCRIPTION
- Since VS Code 1.58.1, Workspace Trust will negatively affect tests
  requiring the standard server so we should disable the feature

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

To reproduce the issue, simply run `npm run test` on latest development branch and there should be failures.