### PR TITLE
Can select build tool when there is a conflict

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -424,7 +424,7 @@ async function ensureNoBuildToolConflicts(context: ExtensionContext, clientOptio
 			if (!await hasBuildToolConflicts()) {
 				return true;
 			}
-			activeBuildTool = await window.showInformationMessage("Build tools conflicts are detected in workspace, which one would you like to use?", "Use Maven", "Use Gradle");
+			activeBuildTool = await window.showInformationMessage("Build tool conflicts are detected in workspace. Which one would you like to use?", "Use Maven", "Use Gradle");
 		}
 
 		if (!activeBuildTool) {
@@ -459,14 +459,16 @@ async function hasBuildToolConflicts(): Promise<boolean> {
 
 async function getBuildFilesInWorkspace(): Promise<Uri[]> {
 	const buildFiles: Uri[] = [];
-	const inclusionPatterns: string[] = getBuildFilePatterns();
-	inclusionPatterns.push("**/.project");
-	const inclusionPatternsFromNegatedExclusion: string[] = getInclusionPatternsFromNegatedExclusion();
-	if (inclusionPatterns.length > 0 && inclusionPatternsFromNegatedExclusion.length > 0) {
-		buildFiles.push(...await workspace.findFiles(convertToGlob(inclusionPatterns, inclusionPatternsFromNegatedExclusion), null /*force not use default exclusion*/));
+	const inclusionFilePatterns: string[] = getBuildFilePatterns();
+	inclusionFilePatterns.push("**/.project");
+	const inclusionFolderPatterns: string[] = getInclusionPatternsFromNegatedExclusion();
+	// Since VS Code API does not support put negated exclusion pattern in findFiles(),
+	// here we first parse the negated exclusion to inclusion and do the search.
+	if (inclusionFilePatterns.length > 0 && inclusionFolderPatterns.length > 0) {
+		buildFiles.push(...await workspace.findFiles(convertToGlob(inclusionFilePatterns, inclusionFolderPatterns), null /*force not use default exclusion*/));
 	}
 
-	const inclusionBlob: string = convertToGlob(inclusionPatterns);
+	const inclusionBlob: string = convertToGlob(inclusionFilePatterns);
 	const exclusionBlob: string = getExclusionBlob();
 	if (inclusionBlob) {
 		buildFiles.push(...await workspace.findFiles(inclusionBlob, exclusionBlob));

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -236,3 +236,5 @@ function unregisterGradleWrapperPromptDialog(sha256: string) {
 		gradleWrapperPromptDialogs.splice(index, 1);
 	}
 }
+
+export const ACTIVE_BUILD_TOOL_STATE: string = "java.activeBuildTool";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ const DEFAULT_HIDDEN_FILES: string[] = ['**/.classpath', '**/.project', '**/.set
 export const IS_WORKSPACE_JDK_ALLOWED = "java.ls.isJdkAllowed";
 export const IS_WORKSPACE_VMARGS_ALLOWED = "java.ls.isVmargsAllowed";
 const extensionName = 'Language Support for Java';
+export const ACTIVE_BUILD_TOOL_STATE = "java.activeBuildTool";
 
 const changeItem = {
 	global: 'Exclude globally',
@@ -236,5 +237,3 @@ function unregisterGradleWrapperPromptDialog(sha256: string) {
 		gradleWrapperPromptDialogs.splice(index, 1);
 	}
 }
-
-export const ACTIVE_BUILD_TOOL_STATE: string = "java.activeBuildTool";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,7 @@ export function getBuildFilePatterns(): string[] {
 		patterns.push("**/pom.xml");
 	}
 	if (isGradleImporterEnabled) {
-		patterns.push("**/build.gradle");
+		patterns.push("**/*.gradle");
 	}
 
 	return patterns;

--- a/test/standard-mode-suite/utils.test.ts
+++ b/test/standard-mode-suite/utils.test.ts
@@ -37,7 +37,7 @@ suite('Utils Test', () => {
 
 		const result: string[] = getBuildFilePatterns();
 
-		assert.deepEqual(result, ["**/pom.xml", "**/build.gradle"]);
+		assert.deepEqual(result, ["**/pom.xml", "**/*.gradle"]);
 	});
 
 	test('getBuildFilePatterns() - no importers is enabled', async function () {


### PR DESCRIPTION
fix https://github.com/redhat-developer/vscode-java/issues/600
fix https://github.com/redhat-developer/vscode-java/issues/1008

The notification will only be pop up when the following conditions meet:
- Both Maven importer and Gradle importer are enabled
- At least one folder contains both `pom.xml` & `*.gradle`, meanwhile, it does not contain `.project` (not being imported before)

So this will only affect a new workspace which has build tool conflicts

--------

During implementation, I also find some buggy things in the Java Language Server. For example,

1. User select Gradle when first opening a fresh project
2. User update the setting to enable Maven importer and disable Gradle Importer.
3. Clean workspace cache and reload

The project is still Gradle, this is because the .classpath/.project file is still in user's project and Buildship listens some broadcast events(when refreshLocal is called) for these files. Buildship will then schedule a sync job by itself.

Signed-off-by: Sheng Chen <sheche@microsoft.com>