### PR TITLE
Make commands wait for applyEdit 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -718,10 +718,12 @@ async function addFormatter(extensionPath, formatterUrl, defaultFormatter, relat
 	});
 }
 
-export function applyWorkspaceEdit(obj, languageClient) {
+export function applyWorkspaceEdit(obj, languageClient): Thenable<boolean> {
 	const edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(obj);
 	if (edit) {
-		workspace.applyEdit(edit);
+		return workspace.applyEdit(edit);
+	} else {
+		return Promise.resolve(true);
 	}
 }
 

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -62,7 +62,7 @@ function registerOverrideMethodsCommand(languageClient: LanguageClient, context:
             context: params,
             overridableMethods: selectedItems.map((item) => item.originalMethod),
         });
-        applyWorkspaceEdit(workspaceEdit, languageClient);
+        await applyWorkspaceEdit(workspaceEdit, languageClient);
     }));
 }
 
@@ -105,14 +105,14 @@ function registerHashCodeEqualsCommand(languageClient: LanguageClient, context: 
             fields: selectedFields.map((item) => item.originalField),
             regenerate
         });
-        applyWorkspaceEdit(workspaceEdit, languageClient);
+        await applyWorkspaceEdit(workspaceEdit, languageClient);
     }));
 }
 
 function registerOrganizeImportsCommand(languageClient: LanguageClient, context: ExtensionContext): void {
     context.subscriptions.push(commands.registerCommand(Commands.ORGANIZE_IMPORTS, async (params: CodeActionParams) => {
         const workspaceEdit = await languageClient.sendRequest(OrganizeImportsRequest.type, params);
-        applyWorkspaceEdit(workspaceEdit, languageClient);
+        await applyWorkspaceEdit(workspaceEdit, languageClient);
     }));
 }
 
@@ -203,7 +203,7 @@ function registerGenerateToStringCommand(languageClient: LanguageClient, context
             context: params,
             fields,
         });
-        applyWorkspaceEdit(workspaceEdit, languageClient);
+        await applyWorkspaceEdit(workspaceEdit, languageClient);
     }));
 }
 
@@ -240,7 +240,7 @@ function registerGenerateAccessorsCommand(languageClient: LanguageClient, contex
             context: params,
             accessors: selectedAccessors.map((item) => item.originalField),
         });
-        applyWorkspaceEdit(workspaceEdit, languageClient);
+        await applyWorkspaceEdit(workspaceEdit, languageClient);
     }));
 }
 
@@ -294,7 +294,7 @@ function registerGenerateConstructorsCommand(languageClient: LanguageClient, con
             constructors: selectedConstructors,
             fields: selectedFields,
         });
-        applyWorkspaceEdit(workspaceEdit, languageClient);
+        await applyWorkspaceEdit(workspaceEdit, languageClient);
     }));
 }
 
@@ -355,6 +355,6 @@ function registerGenerateDelegateMethodsCommand(languageClient: LanguageClient, 
             context: params,
             delegateEntries,
         });
-        applyWorkspaceEdit(workspaceEdit, languageClient);
+        await applyWorkspaceEdit(workspaceEdit, languageClient);
     }));
 }


### PR DESCRIPTION
I stumbled over this trying to find out why `organizeImports` in combination with Prettier and `formatDocument` would always alternate its output. My configuration looked like this:
```
        "editor.codeActionsOnSave": [ 
            "source.organizeImports",
            "source.formatDocument",
        ]
```
![import_order_alternating](https://user-images.githubusercontent.com/2384738/127015797-2da223ec-be0a-4139-bb53-a759c455d5b2.gif)

The list is executed in order and the commands are awaited for completion. I must organize imports before saving to get rid of unused imports and because I cannot recreate Prettier's import order using vscode-java. (More details here: https://gitter.im/redhat-developer/vscode-java?at=60e84814f1274d5e503bf7d8)
Trying to recreate this issue with a simple extension, I found out that this occurs, when the command returns before all its asynchronous work is done.

After my changes, the behavior changes to the following:
![import_order_stable](https://user-images.githubusercontent.com/2384738/127015899-cb2bf1d5-9fbf-41f8-9dde-a2239e51fbe9.gif)

I applied the changes to all commands that use `applyWorkspaceEdit`. I used the code for about a week and did not find any (new) problems.

  