### PR TITLE
Do not show the import notification when no projects available

### DIFF
--- a/src/serverTaskPresenter.ts
+++ b/src/serverTaskPresenter.ts
@@ -1,4 +1,4 @@
-import { tasks, Task, TaskScope, Pseudoterminal, CustomExecution, TaskExecution, TaskRevealKind, TaskPanelKind, EventEmitter, Event, TerminalDimensions, window, ProgressLocation, Progress } from "vscode";
+import { tasks, Task, TaskScope, Pseudoterminal, CustomExecution, TaskExecution, TaskRevealKind, TaskPanelKind, EventEmitter, Event, TerminalDimensions, window, ProgressLocation, Progress, workspace } from "vscode";
 import { serverTasks } from "./serverTasks";
 import { Disposable } from "vscode-languageclient";
 import { ProgressReport } from "./protocol";
@@ -119,9 +119,11 @@ export class ActivationProgressNotification {
 	private hideEmitter = new EventEmitter<void>();
 	private onHide = this.hideEmitter.event;
 	private disposables: Disposable[] = [];
-	private lastJobId: string;
 
 	public showProgress() {
+		if (!workspace.workspaceFolders) {
+			return;
+		}
 		const showBuildStatusEnabled = getJavaConfiguration().get("showBuildStatusOnStart.enabled");
 		if (typeof showBuildStatusEnabled === "string" || showBuildStatusEnabled instanceof String) {
 			if (showBuildStatusEnabled !== "notification") {

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -446,9 +446,14 @@ export class StandardLanguageClient {
 	}
 }
 
-function showImportFinishNotification(context: ExtensionContext) {
-	const showNotification: boolean | undefined = context.globalState.get<boolean>("java.neverShowImportFinishNotification");
-	if (!showNotification) {
+async function showImportFinishNotification(context: ExtensionContext) {
+	const neverShow: boolean | undefined = context.globalState.get<boolean>("java.neverShowImportFinishNotification");
+	if (!neverShow) {
+		const projectUris: string[] = await commands.executeCommand<string[]>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_ALL_JAVA_PROJECTS);
+		if (projectUris.length === 0 || (projectUris.length === 1 && projectUris[0].includes("jdt.ls-java-project"))) {
+			return;
+		}
+
 		const options = ["Don't show again"];
 		if (extensions.getExtension("vscjava.vscode-java-dependency")) {
 			options.unshift("View projects");


### PR DESCRIPTION
@rgrunber @testforstephen  This fix some missed corner cases for #2022, which are:

1. Do not show the progress notification when there is no workspace folders available. (no root means no project)
   - For example, in a vs code window without workspace, create a new untitled file and set the language to Java
2. After import finishes, if no projects are imported, or only have the default project, do not pop-up the finishing dialog.

Signed-off-by: Sheng Chen <sheche@microsoft.com>