### PR TITLE
Scan project configuration files at client

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -441,7 +441,7 @@ async function ensureNoBuildToolConflicts(context: ExtensionContext, projectConf
 		} else if (activeBuildTool.toLocaleLowerCase().includes("maven")) {
 			await context.workspaceState.update(ACTIVE_BUILD_TOOL_STATE, "maven");
 			return projectConfigurations.filter((uri) => {
-				return !uri.fsPath.endsWith(".gradle");
+				return !/.*\.gradle(\.kts)?$/.test(uri.fsPath);
 			});
 		} else if (activeBuildTool.toLocaleLowerCase().includes("gradle")) {
 			await context.workspaceState.update(ACTIVE_BUILD_TOOL_STATE, "gradle");
@@ -470,10 +470,10 @@ async function hasBuildToolConflicts(projectConfigurationUris: Uri[]): Promise<b
 }
 
 function filterOutProjectFiles(projectConfigurations: Uri[]): Uri[] {
-	// find all the directories containing pom.xml or *.gradle
+	// find all the directories containing pom.xml or *.gradle(.kts)
 	const buildToolDirectories: Set<string> = new Set();
 	for (const projectConfig of projectConfigurations) {
-		if (projectConfig.fsPath.endsWith("pom.xml") || projectConfig.fsPath.endsWith(".gradle")) {
+		if (projectConfig.fsPath.endsWith("pom.xml") || /.*\.gradle(\.kts)?$/.test(projectConfig.fsPath)) {
 			buildToolDirectories.add(path.dirname(projectConfig.fsPath));
 		}
 	}


### PR DESCRIPTION
requires https://github.com/eclipse/eclipse.jdt.ls/pull/1840.

close #2021

This PR is to scan the project configurations and pass the paths to the JLS as part of the initialize parameters(`initializationOptions.projectConfigurations`, if this field is not provided, the server will fallback to the old import process). Some reason to do that:

1. Since we already do the scan to detect the build tool conflicts. We can leverage the result to let the JLS import those configuration directly.
      - Scan multiple times at server side is redundant (each importer will do a scan currently)
      - Maintain the single of truth at client side

2. Current scan logic at the server side has some bugs. For example, opening this project: https://github.com/eclipse/eclipse.jdt.ls/tree/master/org.eclipse.jdt.ls.tests/projects/maven/multimodule, and set `java.import.exclusions` to 
```
"!**/module1/**",
"**/*"
```

clean the workspace cache and restart, the setting does not take affect. While this PR can fix this case.

> One exception is the Gradle project, even just import a sub Gradle project will still brings the entire projects into the workspace, which is the same behavior in Eclipse.

Signed-off-by: Sheng Chen <sheche@microsoft.com>