### PR TITLE
Only show the import notification for the first time

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -390,7 +390,7 @@ async function startStandardServer(context: ExtensionContext, requirements: requ
 		apiManager.getApiInstance().serverMode = ServerMode.HYBRID;
 		apiManager.fireDidServerModeChange(ServerMode.HYBRID);
 	}
-	standardClient.initialize(context, requirements, clientOptions, workspacePath, jdtEventEmitter, resolve);
+	await standardClient.initialize(context, requirements, clientOptions, workspacePath, jdtEventEmitter, resolve);
 	standardClient.start();
 	serverStatusBarProvider.showStandardStatus();
 }


### PR DESCRIPTION
Since our message is called `Projects are imported into workspace.` So it should only be shown for the first time.

To know whether the projects have been imported or not, I check the existence of `.metadata/.plugins`, which is used before: https://github.com/redhat-developer/vscode-java/blob/master/src/extension.ts#L334

Signed-off-by: Sheng Chen <sheche@microsoft.com>

@rgrunber Sorry for the late patch. Please consider if this should be contained in 0.81.0