### PR TITLE
Use npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4732,14 +4732,6 @@
               "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "5.3.1",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                  "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                  "dev": true
-                }
               }
             }
           }
@@ -5140,9 +5132,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-root": {


### PR DESCRIPTION
- Update path-parse 1.0.6 -> 1.0.7

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>