### PR TITLE
Remove redundant use of `await` on a return

### DIFF
--- a/src/findJavaRuntimes.ts
+++ b/src/findJavaRuntimes.ts
@@ -275,7 +275,7 @@ async function findLinkedFile(file: string): Promise<string> {
     if (!await fse.pathExists(file) || !(await fse.lstat(file)).isSymbolicLink()) {
         return file;
     }
-    return await findLinkedFile(await fse.readlink(file));
+    return findLinkedFile(await fse.readlink(file));
 }
 
 export async function getJavaVersion(javaHome: string): Promise<number | undefined> {


### PR DESCRIPTION
value.sonarlint(typescript:S4326)

Signed-off-by: Aurélien Pupier <apupier@redhat.com>