### PR TITLE
Fix watch_server & dev_server tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ const gulp = require('gulp');
 const cp = require('child_process');
 const decompress = require('gulp-decompress');
 const download = require('gulp-download');
+const glob = require('glob');
 const fse = require('fs-extra');
 const path = require('path');
 const server_dir = '../eclipse.jdt.ls';
@@ -27,26 +28,22 @@ gulp.task('build_server', function(done) {
 });
 
 gulp.task('dev_server', function(done) {
-	let command = mvnw() +' -Pserver-distro,fast -o clean package ';
-	if(isLinux()){
-		command +='-Denvironment.os=linux -Denvironment.ws=gtk -Denvironment.arch=x86_64';
-	}
-	else if(isMac()){
-		command += '-Denvironment.os=macosx -Denvironment.ws=cocoa -Denvironment.arch=x86_64';
-	}
-	else if(isWin()){
-		command += '-Denvironment.os=win32 -Denvironment.ws=win32 -Denvironment.arch=x86_64';
-	}
+	let command = mvnw() +' -o -pl org.eclipse.jdt.ls.core,org.eclipse.jdt.ls.target clean package';
 	console.log('executing '+command);
 	cp.execSync(command, {cwd:server_dir, stdio:[0,1,2]} );
-	gulp.src(server_dir +'/org.eclipse.jdt.ls.product/distro/*.tar.gz')
-		.pipe(decompress())
-		.pipe(gulp.dest('./server'))
+	glob.Glob(server_dir +'/org.eclipse.jdt.ls.core/target/org.eclipse.jdt.ls.core-*-SNAPSHOT.jar',
+	    (_error, sources) => {
+			glob.Glob('./server/plugins/org.eclipse.jdt.ls.core_*.jar',
+				(_error, targets) => {
+					console.log('Copying '+sources[0]+ ' to '+targets[0]);
+					fse.copy(sources[0], targets[0]);
+			});
+	});
 	done();
 });
 
 gulp.task('watch_server',function(done) {
-	gulp.watch(server_dir+'/org.eclipse.jdt.ls.core/**/*.java',['dev_server']);
+	gulp.watch(server_dir+'/org.eclipse.jdt.ls.core/**/*.java', gulp.series('dev_server'));
 	done();
 });
 


### PR DESCRIPTION
- Fixes #230
- Update watch_server task to comply with Gulp v4

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This isn't ideal, because the buid isn't as fast as it could be, but it does fix watch_server & dev_server.

Unfortunately I'm not sure how they were ever built for a single OS only. Maybe earlier Tycho versions allowed this ? Basically, the JDT-LS tarball includes bundle fragments for all platforms (so one tarball can be used everywhere). If we try to restrict the target platform to just a single OS then the product build will fail since each of the platform specific bundles is mandatory.

If there's a way to make the platform specific bundles optional then maybe this could work.