### PR TITLE
Fix Open Java Formatter Settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -673,7 +673,7 @@ async function openFormatter(extensionPath) {
 	const formatterUrl: string = getJavaConfiguration().get('format.settings.url');
 	if (formatterUrl && formatterUrl.length > 0) {
 		if (isRemote(formatterUrl)) {
-			commands.executeCommand(Commands.OPEN_BROWSER, Uri.parse(formatterUrl));
+			return commands.executeCommand(Commands.OPEN_BROWSER, Uri.parse(formatterUrl));
 		} else {
 			const document = getPath(formatterUrl);
 			if (document && fs.existsSync(document)) {
@@ -742,7 +742,7 @@ function openDocument(extensionPath, formatterUrl, defaultFormatter, relativePat
 }
 
 function isRemote(f) {
-	return f !== null && f.startsWith('http:/') || f.startsWith('https:/');
+	return f !== null && f.startsWith('http:/') || f.startsWith('https:/') || f.startsWith('file:/');
 }
 
 async function addFormatter(extensionPath, formatterUrl, defaultFormatter, relativePath) {


### PR DESCRIPTION
Steps to reproduce:
- set the following property
```
"java.format.settings.url": "file:///<some_path>/format.xml"
```
- call Java: Open Formatter Settings

See https://github.com/redhat-developer/vscode-java/issues/1061#issuecomment-929557096

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>