### PR TITLE
Exclude jdk.*, org.graalvm.* and io.micrometer.shaded.* from completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -481,7 +481,10 @@
           "default": [
             "java.awt.*",
             "com.sun.*",
-            "sun.*"
+            "sun.*",
+            "jdk.*",
+            "org.graalvm.*",
+            "io.micrometer.shaded.*"
           ],
           "scope": "window"
         },


### PR DESCRIPTION
... to align with default exclusions from Eclipse IDE