### PR TITLE
Support platform specific extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 undefined
 target
 dist
+jre
 bin/
 .settings
 .classpath

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,21 +17,6 @@
 			"preLaunchTask": "npm: watch"
 		},
 		{
-			"name": "Launch Extension with Embedded JRE",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-			"env": {
-				"DEBUG_VSCODE_JAVA":"true",
-				"EMBEDDED_JRE_FIRST":"true"
-			},
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
-			"preLaunchTask": "npm: watch"
-		},
-		{
 			"name": "Launch Extension - Remote Server",
 			"type": "extensionHost",
 			"request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -110,6 +110,26 @@
 			"outFiles": ["${workspaceRoot}/out/**/*.js"],
 			"preLaunchTask": "prepareLightweightTest",
 			"postDebugTask": "cleanTestFolder"
+		},
+		{
+			"args": [
+				"${input:gulpTask}"
+			],
+			"name": "Launch Gulp Task",
+			"program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
+			"request": "launch",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"type": "pwa-node"
+		}
+	],
+	"inputs": [
+		{
+			"id": "gulpTask",
+			"type": "promptString",
+			"description": "Name of the Gulp task to execute",
+			"default": "download_jre"
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,21 @@
 			"preLaunchTask": "npm: watch"
 		},
 		{
+			"name": "Launch Extension with Embedded JRE",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"env": {
+				"DEBUG_VSCODE_JAVA":"true",
+				"EMBEDDED_JRE_FIRST":"true"
+			},
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+			"preLaunchTask": "npm: watch"
+		},
+		{
 			"name": "Launch Extension - Remote Server",
 			"type": "extensionHost",
 			"request": "launch",

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,3 +22,4 @@ gulpfile.js
 Jenkinsfile
 tslint.json
 webpack.config.js
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,12 @@ The following will be a start to finish guide to get the entire language server 
 	```bash
 	$ npm install
 	```
+5. (**\*Optional**) Build a platform specific JRE:
+
+	```bash
+	$ npx gulp download_jre
+	```
+	You can also use the options `--target` and `--javaVersion` to build the specified JRE version for the specified target architecture.
 
 #
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,10 +55,24 @@ node('rhel8'){
 		sh "npm test --silent"
 	}
 
-	stage 'Upload vscode-java to staging'
 	def vsix = findFiles(glob: '**.vsix')
-	sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/jdt.ls/staging"
-	stash name:'vsix', includes:files[0].path
+	stash name:'vsix', includes:vsix[0].path
+
+	// Package platform specific versions
+	stage "Package platform specific vscode-java"
+	def platforms = ["win32-x64", "linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"]
+	def embeddedJRE = 17
+	for(platform in platforms){
+		sh "npx gulp download_jre --target ${platform} --javaVersion ${embeddedJRE}"
+		sh "vsce package --target ${platform} -o java-${platform}-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
+	}
+	stash name:'platformVsix', includes:'java-win32-*.vsix,java-linux-*.vsix,java-darwin-*.vsix'
+
+	stage 'Upload vscode-java to staging'
+	def artifacts = findFiles(glob: '**.vsix')
+	for(artifact in artifacts){
+		sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${artifact.path} ${UPLOAD_LOCATION}/jdt.ls/staging"
+	}
 }
 
 node('rhel8'){
@@ -67,24 +81,36 @@ node('rhel8'){
 			input message:'Approve deployment?', submitter: 'fbricon,rgrunber'
 		}
 
-		stage "Publish to Marketplaces"
+		stage "Publish to Open-vsx Marketplace"
 		unstash 'vsix'
 		def vsix = findFiles(glob: '**.vsix')
-		// VS Code Marketplace
-		withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
-			sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
-		}
-
 		// Open-vsx Marketplace
 		sh "npm install -g ovsx"
 		withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
 			sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
 		}
 
+		stage "Publish to VS Code Marketplace"
+		// VS Code Marketplace
+		withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
+			// Publish a generic version
+			sh 'vsce publish -p ${TOKEN} --target win32-ia32 win32-arm64 linux-armhf alpine-x64 alpine-arm64'
+
+			// Publish platform specific versions
+			unstash 'platformVsix'
+			def platformVsixes = findFiles(glob: '**.vsix', excludes: vsix[0].path)
+			for(platformVsix in platformVsixes){
+				sh 'vsce publish -p ${TOKEN}' + " --packagePath ${platformVsix.path}"
+			}
+		}
+
 		archive includes:"**.vsix"
 
 		stage "Publish to http://download.jboss.org/jbosstools/static/jdt.ls/stable/"
+		def artifacts = findFiles(glob: '**.vsix')
 		// copy this stable build to Akamai-mirrored /static/ URL, so staging can be cleaned out more easily
-		sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/static/jdt.ls/stable/"
+		for(artifact in artifacts){
+			sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${artifact.path} ${UPLOAD_LOCATION}/static/jdt.ls/stable/"
+		}
 	}// if publishToMarketPlace
 }

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ See the [changelog](CHANGELOG.md) for the latest release. You might also find us
 Setting the JDK
 ===============
 ## Java Tooling JDK
-Now that Java extension will publish platform specific versions, it will embed a JRE for supported platforms such as `win32-x64`, `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`. The embedded JRE is used to launch Java Language Server itself, you're only responsible for configuring [Project JDKs](#project-jdks) to compile your project.
+Now that Java extension will publish platform specific versions, it will embed a JRE for supported platforms such as `win32-x64`, `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`. The embedded JRE is used to launch the Language Server for Java. Users are only responsible for configuring [Project JDKs](#project-jdks) to compile your Java projects.
 
 The following part is only kept for the universal version without embedded JRE.
 
->The tooling JDK will be used to launch the Java Language Server. And by default, will also be used to compile your projects.\
+>The tooling JDK will be used to launch the Language Server for Java. And by default, will also be used to compile your projects.\
 \
 The path to the Java Development Kit can be specified by the `java.home` setting in VS Code settings (workspace/user settings). If not specified, it is searched in the following order until a JDK meets current minimum requirement.
 >- the `JDK_HOME` environment variable

--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ See the [changelog](CHANGELOG.md) for the latest release. You might also find us
 Setting the JDK
 ===============
 ## Java Tooling JDK
-This JDK will be used to launch the Java Language Server. And by default, will also be used to compile your projects.
+Now that Java extension will publish platform specific versions, it will embed a JRE for supported platforms such as `win32-x64`, `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`. The embedded JRE is used to launch Java Language Server itself, you're only responsible for configuring [Project JDKs](#project-jdks) to compile your project.
 
+The following part is only kept for the universal version without embedded JRE.
+
+>The tooling JDK will be used to launch the Java Language Server. And by default, will also be used to compile your projects.\
+\
 The path to the Java Development Kit can be specified by the `java.home` setting in VS Code settings (workspace/user settings). If not specified, it is searched in the following order until a JDK meets current minimum requirement.
-
-- the `JDK_HOME` environment variable
-- the `JAVA_HOME` environment variable
-- on the current system path
+>- the `JDK_HOME` environment variable
+>- the `JAVA_HOME` environment variable
+>- on the current system path
 
 ## Project JDKs
 If you need to compile your projects against a different JDK version, it's recommended you configure the `java.configuration.runtimes` property in your user settings, eg:
@@ -107,7 +110,7 @@ Supported VS Code settings
 ==========================
 The following settings are supported:
 
-* `java.home` : Absolute path to JDK home folder used to launch the Java Language Server. Requires VS Code restart.
+* `java.home` : **Deprecated, only used for universal version without embedded JRE.** Absolute path to JDK home folder used to launch the Java Language Server. Requires VS Code restart.
 * `java.jdt.ls.vmargs` : Extra VM arguments used to launch the Java Language Server. Requires VS Code restart.
 * `java.errors.incompleteClasspath.severity` : Specifies the severity of the message when the classpath is incomplete for a Java file. Supported values are `ignore`, `info`, `warning`, `error`.
 * `java.trace.server` : Traces the communication between VS Code and the Java language server.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,16 +85,16 @@ gulp.task('download_jre', async function(done) {
 
 		/**
 		 * A sample justj.manifest
-		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-linux-aarch64.tar.gz
-		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-linux-x86_64.tar.gz
-		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-macosx-aarch64.tar.gz
-		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-macosx-x86_64.tar.gz
-		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-win32-x86_64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.full.stripped-17-linux-aarch64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.full.stripped-17-linux-x86_64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.full.stripped-17-macosx-aarch64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.full.stripped-17-macosx-x86_64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.full.stripped-17-win32-x86_64.tar.gz
 		 */
 		const javaPlatform = platformMapping[targetPlatform];
 		const list = value.split(/\r?\n/);
 		const jreIdentifier = list.find((value) => {
-			return value.indexOf("org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped") >= 0 && value.indexOf(javaPlatform) >= 0;
+			return value.indexOf("org.eclipse.justj.openjdk.hotspot.jre.full.stripped") >= 0 && value.indexOf(javaPlatform) >= 0;
 		});
 
 		if (!jreIdentifier) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,11 +6,124 @@ const download = require('gulp-download');
 const glob = require('glob');
 const fse = require('fs-extra');
 const path = require('path');
+const url = require("url");
+const argv = require('minimist')(process.argv.slice(2));
 const server_dir = '../eclipse.jdt.ls';
 const originalTestFolder = path.join(__dirname, 'test', 'resources', 'projects', 'maven', 'salut');
 const tempTestFolder = path.join(__dirname, 'test-temp');
 const testSettings = path.join(tempTestFolder, '.vscode', 'settings.json');
 //...
+
+gulp.task('clean_jre', function(done) {
+	if (fse.existsSync('./jre')) {
+		fse.removeSync('./jre');
+	}
+
+	done();
+});
+
+function cleanManifest() {
+	if (fse.existsSync('./jre/justj.manifest')) {
+		fse.removeSync('./jre/justj.manifest');
+	}
+}
+
+const LATEST_JRE = 17;
+/**
+ * Usage:
+ * npx gulp download_jre --target darwin-x64 --javaVersion latest
+ *
+ * Supported platforms:
+ *  win32-x64,
+ *  linux-x64,
+ *  linux-arm64,
+ *  darwin-x64,
+ *  darwin-arm64
+ */
+gulp.task('download_jre', async function(done) {
+	if (fse.existsSync('./jre')) {
+		fse.removeSync('./jre');
+	}
+
+	const platformMapping = {
+		"linux-arm64": "linux-aarch64",
+		"linux-x64": "linux-x86_64",
+		"darwin-arm64": "macosx-aarch64",
+		"darwin-x64": "macosx-x86_64",
+		"win32-x64": "win32-x86_64"
+	}
+
+	if (argv.target && Object.keys(platformMapping).includes(argv.target)) {
+		const javaVersion = (!argv.javaVersion || argv.javaVersion === "latest") ? LATEST_JRE : javaVersion;
+		console.log("Downloading justj JRE " + javaVersion);
+
+		const mafinestUrl = `https://download.eclipse.org/justj/jres/${javaVersion}/downloads/latest/justj.manifest`;
+		// Download justj.manifest file
+		await new Promise(function(resolve, reject) {
+			download(mafinestUrl)
+				.on('error', reject)
+				.pipe(gulp.dest('./jre'))
+				.on('end', resolve);
+		});
+
+		if (!fse.existsSync('./jre/justj.manifest')) {
+			cleanManifest();
+			done(new Error(`Failed to download justj.manifest, please check if the link ${mafinestUrl} is valid.`))
+			return;
+		}
+
+		const value = fse.readFileSync('./jre/justj.manifest').toString();
+		if (value.startsWith("<!DOCTYPE html>")) {
+			cleanManifest();
+			done(new Error(`Failed to download justj.manifest, please check if the link ${mafinestUrl} is valid.`))
+			return;
+		}
+
+		/**
+		 * A sample justj.manifest
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-linux-aarch64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-linux-x86_64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-macosx-aarch64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-macosx-x86_64.tar.gz
+		 * ../20211012_0921/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17-win32-x86_64.tar.gz
+		 */
+		const prefix = "org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped";
+		const platformLabel = platformMapping[argv.target];
+		const list = value.split(/\r?\n/);
+		const jreIdentifier = list.find((value) => {
+			return value.indexOf("org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped") >= 0 && value.indexOf(platformLabel) >= 0;
+		});
+
+		if (!jreIdentifier) {
+			cleanManifest();
+			done(new Error(`justj doesn't support the platform ${platformLabel} jre of ${javaVersion}, please refer to the link ${mafinestUrl} for the supported platforms.`));
+			return;
+		}
+
+		const jreDownloadUrl = `https://download.eclipse.org/justj/jres/${javaVersion}/downloads/latest/${jreIdentifier}`;
+		const parsedDownloadUrl = url.parse(jreDownloadUrl);
+		const jreFileName = path.basename(parsedDownloadUrl.pathname)
+								.replace(/[\.7z|\.bz2|\.gz|\.rar|\.tar|\.zip|\.xz]*$/, "");
+		const idx = jreFileName.indexOf('-');
+		const jreVersionLabel = idx >= 0 ? jreFileName.substring(idx + 1) : jreFileName;
+		// Download justj JRE.
+		await new Promise(function(resolve, reject) {
+			download(jreDownloadUrl)
+				.on('error', reject)
+				.pipe(decompress({strip: 0}))
+				.pipe(gulp.dest('./jre/' + jreVersionLabel))
+				.on('end', resolve);
+		});
+	} else {
+		console.log("[Error] download_jre failed, please specify a valid target platform. Here are the supported platform list:");
+		for (const platform of Object.keys(platformMapping)) {
+			console.log(platform);
+		}
+	}
+
+	cleanManifest();
+	done();
+});
 
 gulp.task('download_server', function(done) {
 	fse.removeSync('./server');

--- a/package-lock.json
+++ b/package-lock.json
@@ -322,12 +322,12 @@
       }
     },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -534,9 +534,9 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -605,9 +605,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
     "babel-code-frame": {
@@ -1099,9 +1099,9 @@
       }
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -1911,9 +1911,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -2420,7 +2420,7 @@
       "dev": true,
       "requires": {
         "gulp-util": "^3.0.8",
-        "request": "^2.88.0",
+        "request": "^2.88.2",
         "request-progress": "^3.0.0",
         "through": "^2.3.8"
       },
@@ -2535,12 +2535,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
@@ -3039,9 +3039,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -3071,14 +3071,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -3505,18 +3505,18 @@
       }
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.51.0"
       }
     },
     "mimic-fn": {
@@ -4449,9 +4449,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "pump": {
@@ -4620,9 +4620,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -4632,7 +4632,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -4642,7 +4642,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
@@ -5083,9 +5083,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -5396,21 +5396,13 @@
       }
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "triple-beam": {
@@ -5778,9 +5770,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "virtualWorkspaces": false
   },
   "engines": {
-    "vscode": "^1.53.2"
+    "vscode": "^1.61.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1139,6 +1139,7 @@
     "lodash.template": ">=4.5.0",
     "minimist": ">=1.2.5",
     "mocha": "^9.1.3",
+    "request": "^2.88.2",
     "ts-loader": "^9.2.6",
     "tslint": "^5.11.0",
     "typescript": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
           ],
           "default": null,
           "description": "Specifies the folder path to the JDK (11 or more recent) used to launch the Java Language Server.\nOn Windows, backslashes must be escaped, i.e.\n\"java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk11.0_8\"",
-          "scope": "machine-overridable"
+          "scope": "machine-overridable",
+          "deprecationMessage": "This setting will be deprecated, please use the environment variable 'JAVA_HOME' instead."
         },
         "java.jdt.ls.vmargs": {
           "type": [

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -29,7 +29,7 @@ export function prepareExecutable(requirements: RequirementsData, workspacePath,
 	const options: ExecutableOptions = Object.create(null);
 	options.env = Object.assign({ syntaxserver : isSyntaxServer }, process.env);
 	executable.options = options;
-	executable.command = path.resolve(requirements.java_home + '/bin/java');
+	executable.command = path.resolve(requirements.tooling_jre + '/bin/java');
 	executable.args = prepareParams(requirements, javaConfig, workspacePath, context, isSyntaxServer);
 	logger.info(`Starting Java server with: ${executable.command} ${executable.args.join(' ')}`);
 	return executable;
@@ -59,13 +59,12 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 		// suspend=y is the default. Use this form if you need to debug the server startup code:
 		//  params.push('-agentlib:jdwp=transport=dt_socket,server=y,address=1044');
 	}
-	if (requirements.java_version > 8) {
-		params.push('--add-modules=ALL-SYSTEM',
-					'--add-opens',
-					'java.base/java.util=ALL-UNNAMED',
-					'--add-opens',
-					'java.base/java.lang=ALL-UNNAMED');
-	}
+
+	params.push('--add-modules=ALL-SYSTEM',
+				'--add-opens',
+				'java.base/java.util=ALL-UNNAMED',
+				'--add-opens',
+				'java.base/java.lang=ALL-UNNAMED');
 
 	params.push('-Declipse.application=org.eclipse.jdt.ls.core.id1',
 				'-Dosgi.bundles.defaultStartLevel=4',
@@ -122,7 +121,7 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 	// "OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify
 	// were deprecated in JDK 13 and will likely be removed in a future release."
 	// so only add -noverify for older versions
-	if (params.indexOf('-noverify') < 0 && params.indexOf('-Xverify:none') < 0 && requirements.java_version < 13) {
+	if (params.indexOf('-noverify') < 0 && params.indexOf('-Xverify:none') < 0 && requirements.tooling_jre_version < 13) {
 		params.push('-noverify');
 	}
 

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -113,10 +113,6 @@ export async function resolveRequirements(context: ExtensionContext): Promise<Re
 async function findEmbeddedJRE(context: ExtensionContext): Promise<string | undefined> {
     const jreHome = context.asAbsolutePath("jre");
     if (fse.existsSync(jreHome) && fse.statSync(jreHome).isDirectory()) {
-        if (fse.existsSync(path.join(jreHome, "bin", JAVA_FILENAME))) {
-            return jreHome;
-        }
-
         const candidates = fse.readdirSync(jreHome);
         for (const candidate of candidates) {
             if (fse.existsSync(path.join(jreHome, candidate, "bin", JAVA_FILENAME))) {


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

This will address the issue https://github.com/redhat-developer/vscode-java/issues/2109

Below are the tasks added by PR:
- [x] Add a gulp task to download a platform specific JRE.
      The full version is `npx gulp download_jre --target darwin-x64 --javaVersion 17`.
      The short version is `npx gulp download_jre`, which will download latest JRE for your dev machine platform.

   This task will download and decompress the artifact to a jre folder under root directory of vscode-java.
![image](https://user-images.githubusercontent.com/14052197/139040076-ddaed72c-3080-4d26-abcd-0cd1ad743c8b.png)

- [x] Adjust the JDK search logic in Java extension to allow using embedded JRE to launch Java extension itself.
      **1)** We plan to embed `org.eclipse.justj.openjdk.hotspot.jre.full.stripped-17` instead of `org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17`. The minimal stripped is about 30M, and the full jre stripped is about 55M (only plus 25M). But the full jre stripped includes a full set of Java modules, and can cover maven project import better.
https://download.eclipse.org/justj/jres/17/downloads/latest/

    **2)** For platform extensions, we will always use the embedded JRE to launch Java extension. "java.home" setting is useless and may cause confusion, we will mark it as deprecated. And it can only be used for universal versions without embedded JRE.

    **3)** For platform extensions, it will still detect the installed JDKs in local machine. If no one was found, then pop up to install a JDK to compile users' project. The difference is we don't limit the JDK version any more. The concern is because the embedded JRE doesn't include JDK source, GTD cannot find source. To avoid confusion later, we can ask the user to install a project JDK when starting the Java extension.

- [x] Update CI job (Jenkinsfile) to allow publishing platform specific extension to VS Code marketplace.
       Since JustJ only provides 5 JRE platforms, we're going to support embedded JRE for these platforms. For other platforms, we publish a universal one without embedded JRE.
        
  Below are the CI artifacts, it includes a generic version for not supported platforms, 5 platform specific versions.
![image](https://user-images.githubusercontent.com/14052197/140313777-fe0eea2d-cead-4a4d-9f39-3d86c5984de5.png)
