### PR TITLE
Set o.e.j.c.formatter.join_wrapped_lines/join_lines_in_comments=false by default

### DIFF
--- a/formatters/eclipse-formatter.xml
+++ b/formatters/eclipse-formatter.xml
@@ -280,8 +280,8 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>


### PR DESCRIPTION
Fixes #2181 
A related PR -  https://github.com/eclipse/eclipse.jdt.ls/pull/1925

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>