### PR TITLE
Clean unused Java workspace storage folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ The following settings are supported:
 * `java.symbols.includeSourceMethodDeclarations` : Include method declarations from source files in symbol search. Defaults to `false`.
 
 New in 1.1.0:
- * `java.quickfix.showAt"` : Show quickfixes at the problem or line level.
+ * `java.quickfix.showAt` : Show quickfixes at the problem or line level.
+ * `java.configuration.workspaceCacheLimit` : The number of days (if enabled) to keep unused workspace cache data. Beyond this limit, cached workspace data may be removed.
 
 
 Semantic Highlighting

--- a/package.json
+++ b/package.json
@@ -343,6 +343,16 @@
           "description": "Specifies severity if the plugin execution is not covered by Maven build lifecycle.",
           "scope": "window"
         },
+        "java.configuration.workspaceCacheLimit": {
+          "type": [
+            "null",
+            "integer"
+          ],
+          "default": null,
+          "minimum": 1,
+          "description": "The number of days (if enabled) to keep unused workspace cache data. Beyond this limit, cached workspace data may be removed.",
+          "scope": "application"
+        },
         "java.format.enabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
- Clean unused workspace storage folders on startup
- Create settings "java.configuration.cleanWorkspaceCache", to allow
  users to configure maximum number of days to preserve cached data
- Fixes #2110

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>