### PR TITLE
Use workspacePath to derive temporary storage location

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -115,7 +115,7 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 			params.push(HEAP_DUMP);
 		}
 		if (vmargs.indexOf(HEAP_DUMP_LOCATION) < 0) {
-			params.push(`${HEAP_DUMP_LOCATION}${context.storageUri.fsPath}`);
+			params.push(`${HEAP_DUMP_LOCATION}${path.dirname(workspacePath)}`);
 		}
 	}
 


### PR DESCRIPTION
- When no workspace is opened, storageUri will be null, but
  workspacePath will be within the temporary storage location
- Fix #2231

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>