### PR TITLE
Provide client-side snippet until language server is ready

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import { registerClientProviders } from './providerDispatcher';
 import * as fileEventHandler from './fileEventHandler';
 import { StandardLanguageClient } from './standardLanguageClient';
 import { apiManager } from './apiManager';
-import { SnippetCompletionProvider } from './snippetCompletionProvider';
+import { snippetCompletionProvider } from './snippetCompletionProvider';
 import { runtimeStatusBarProvider } from './runtimeStatusBarProvider';
 import { serverStatusBarProvider } from './serverStatusBarProvider';
 import { markdownPreviewProvider } from "./markdownPreviewProvider";
@@ -408,8 +408,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				}
 			});
 
-			const snippetProvider: SnippetCompletionProvider = new SnippetCompletionProvider();
-			context.subscriptions.push(languages.registerCompletionItemProvider({ scheme: 'file', language: 'java' }, snippetProvider));
+			context.subscriptions.push(snippetCompletionProvider.initialize());
 			context.subscriptions.push(serverStatusBarProvider);
 			context.subscriptions.push(runtimeStatusBarProvider);
 

--- a/src/snippetCompletionProvider.ts
+++ b/src/snippetCompletionProvider.ts
@@ -1,12 +1,24 @@
 'use strict';
 
-import { CompletionItemProvider, TextDocument, Position, CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, SnippetString, MarkdownString } from "vscode";
+import { CompletionItemProvider, TextDocument, Position, CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, SnippetString, MarkdownString, languages, Disposable } from "vscode";
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { apiManager } from "./apiManager";
-import { ClientStatus } from "./extension.api";
 
-export class SnippetCompletionProvider implements CompletionItemProvider {
+class SnippetCompletionProvider implements Disposable {
+
+    private providerImpl: Disposable;
+
+    public initialize(): SnippetCompletionProvider {
+        this.providerImpl = languages.registerCompletionItemProvider({ scheme: 'file', language: 'java' }, new SnippetCompletionProviderImpl());
+        return this;
+    }
+
+    public dispose(): void {
+        this.providerImpl.dispose();
+    }
+}
+
+class SnippetCompletionProviderImpl implements CompletionItemProvider {
 
     private snippets: {};
 
@@ -15,9 +27,6 @@ export class SnippetCompletionProvider implements CompletionItemProvider {
     }
 
     public async provideCompletionItems(_document: TextDocument, _position: Position, _token: CancellationToken, _context: CompletionContext): Promise<CompletionItem[]> {
-        if (apiManager.getApiInstance().status === ClientStatus.Started) {
-            return [];
-        }
 
         const snippetItems: CompletionItem[] = [];
         for (const label of Object.keys(this.snippets)) {
@@ -48,3 +57,5 @@ export function beautifyDocument(raw: string): MarkdownString {
     const escapedString = raw.replace(/\$\{\d:?(.*?)\}/gm, '$1').replace(/\$\d/gm, '');
     return new MarkdownString().appendCodeblock(escapedString, "java");
 }
+
+export const snippetCompletionProvider: SnippetCompletionProvider = new SnippetCompletionProvider();

--- a/src/snippetCompletionProvider.ts
+++ b/src/snippetCompletionProvider.ts
@@ -14,7 +14,9 @@ class SnippetCompletionProvider implements Disposable {
     }
 
     public dispose(): void {
-        this.providerImpl.dispose();
+        if (this.providerImpl) {
+            this.providerImpl.dispose();
+        }
     }
 }
 

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -33,6 +33,7 @@ import { TypeHierarchyDirection, TypeHierarchyItem } from "./typeHierarchy/proto
 import { buildFilePatterns } from './plugin';
 import { pomCodeActionMetadata, PomCodeActionProvider } from "./pom/pomCodeActionProvider";
 import { findRuntimes, IJavaRuntime } from "jdk-utils";
+import { snippetCompletionProvider } from "./snippetCompletionProvider";
 
 const extensionName = 'Language Support for Java';
 const GRADLE_CHECKSUM = "gradle/checksum/prompt";
@@ -110,6 +111,8 @@ export class StandardLanguageClient {
 						if (!hasImported) {
 							showImportFinishNotification(context);
 						}
+						// Disable the client-side snippet provider since LS is ready.
+						snippetCompletionProvider.dispose();
 						break;
 					case 'Started':
 						this.status = ClientStatus.Started;

--- a/src/syntaxLanguageClient.ts
+++ b/src/syntaxLanguageClient.ts
@@ -9,6 +9,7 @@ import { ServerMode } from "./settings";
 import { StatusNotification } from "./protocol";
 import { apiManager } from "./apiManager";
 import { ExtensionAPI, ClientStatus } from "./extension.api";
+import { snippetCompletionProvider } from "./snippetCompletionProvider";
 
 const extensionName = "Language Support for Java (Syntax Server)";
 
@@ -61,6 +62,8 @@ export class SyntaxLanguageClient {
 						case 'Started':
 							this.status = ClientStatus.Started;
 							apiManager.updateStatus(ClientStatus.Started);
+							// Disable the client-side snippet provider since LS is ready.
+							snippetCompletionProvider.dispose();
 							break;
 						case 'Error':
 							this.status = ClientStatus.Error;


### PR DESCRIPTION
This PR fix #684 
- postpone the client side snippet provider dispose time when the server is ready.
- dispose the provider to make sure the items will be removed in the completion list when disposing happens.

Signed-off-by: Sheng Chen<sheche@microsoft.com>