### PR TITLE
update jdk-utils to detect JDKs installed by Homebrew

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2974,9 +2974,9 @@
       "dev": true
     },
     "jdk-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.3.1.tgz",
-      "integrity": "sha512-0a7qkPdlXqltqgJOiXBjawFYfL1w0eRQ4vrjKVRkNgB0U8+P/J5ZMZS5LW/BtQwdM3mBUpodtI0nWklm4pmOSg=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.2.tgz",
+      "integrity": "sha512-Xc9KTVXJ048A3EaCyBRAzLRNhDEZQq/awcZHCQCvV9lnYEFMrnLZh7ZzCnFiXLCXWN9JDm9A0BW8MfTbLthA3g=="
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -1154,7 +1154,7 @@
     "fmtr": "^1.1.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.3",
-    "jdk-utils": "^0.3.1",
+    "jdk-utils": "^0.4.2",
     "semver": "^7.3.5",
     "vscode-languageclient": "7.1.0-next.5",
     "winreg-utf8": "^0.1.1",


### PR DESCRIPTION
See #2254 

[changelog](https://github.com/Eskibear/node-jdk-utils/blob/main/CHANGELOG.md#042) of jdk-utils