### PR TITLE
Deprecate 'java.configuration.checkProjectSettingsExclusions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following settings are supported:
 * `java.trace.server` : Traces the communication between VS Code and the Java language server.
 * `java.configuration.updateBuildConfiguration` : Specifies how modifications on build files update the Java classpath/configuration. Supported values are `disabled` (nothing happens), `interactive` (asks about updating on every modification), `automatic` (updating is automatically triggered).
 * `java.configuration.maven.userSettings` : Path to Maven's user settings.xml.
-* `java.configuration.checkProjectSettingsExclusions`: Controls whether to exclude extension-generated project settings files (`.project`, `.classpath`, `.factorypath`, `.settings/`) from the file explorer. Defaults to `true`.
+* `java.configuration.checkProjectSettingsExclusions`: **Deprecated, please use 'java.import.generatesMetadataFilesAtProjectRoot' to control whether to generate the project metadata files at the project root. And use 'files.exclude' to control whether to hide the project metadata files from the file explorer.** Controls whether to exclude extension-generated project settings files (`.project`, `.classpath`, `.factorypath`, `.settings/`) from the file explorer. Defaults to `false`.
 * `java.referencesCodeLens.enabled` : Enable/disable the references code lenses.
 * `java.implementationsCodeLens.enabled` : Enable/disable the implementations code lenses.
 * `java.signatureHelp.enabled` : Enable/disable signature help support (triggered on `(`).

--- a/package.json
+++ b/package.json
@@ -207,8 +207,9 @@
           "scope": "window"
         },
         "java.configuration.checkProjectSettingsExclusions": {
+          "deprecationMessage": "Please use 'java.import.generatesMetadataFilesAtProjectRoot' to control whether to generate the project metadata files at the project root. And use 'files.exclude' to control whether to hide the project metadata files from the file explorer.",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Controls whether to exclude extension-generated project settings files (.project, .classpath, .factorypath, .settings/) from the file explorer.",
           "scope": "window"
         },


### PR DESCRIPTION
The setting `java.configuration.checkProjectSettingsExclusions` was introduced to mitigate the problem that metadata files are generated at the project root. Now since we have `java.import.generatesMetadataFilesAtProjectRoot` to completely solve the problem, I think it's a good time to deprecated it.

This PR deprecates `java.configuration.checkProjectSettingsExclusions`, and change its default value to `false`, so:

- If users want to change the place to generate metadata files they can use `java.import.generatesMetadataFilesAtProjectRoot`.
- If users just want to hide the metadata files at the file explorer, they can use `files.exclude` directly. Though I don't think it's a common case (explicitly let the metadata files generate at project root but hide them in the file explorer).

Signed-off-by: Sheng Chen <sheche@microsoft.com>