### PR TITLE
Provide more alias for code snippets

### DIFF
--- a/snippets/java.json
+++ b/snippets/java.json
@@ -1,6 +1,6 @@
 {
 	"main": {
-		"prefix": "main",
+		"prefix": ["main", "psvm"],
 		"body": [
 			"public static void main(String[] args) {",
 			"\t$0",

--- a/snippets/server.json
+++ b/snippets/server.json
@@ -1,20 +1,20 @@
 {
 	"sysout": {
-		"prefix": "sysout",
+		"prefix": ["sysout", "sout"],
 		"body": [
 			"System.out.println($0);"
 		],
 		"description": "Print to standard out"
 	},
 	"syserr": {
-		"prefix": "syserr",
+		"prefix": ["syserr", "serr"],
 		"body": [
 			"System.err.println($0);"
 		],
 		"description": "Print to standard err"
 	},
 	"fori": {
-		"prefix": "fori",
+		"prefix": ["fori"],
 		"body": [
 			"for (${1:int} ${2:i} = ${3:0}; ${2:i} < ${4:max}; ${2:i}++) {",
 			"\t$0",
@@ -23,7 +23,7 @@
 		"description": "Indexed for loop"
 	},
 	"foreach": {
-		"prefix": "foreach",
+		"prefix": ["foreach", "iter"],
 		"body": [
 			"for (${1:type} ${2:var} : ${3:iterable}) {",
 			"\t$0",
@@ -32,7 +32,7 @@
 		"description": "Enhanced for loop"
 	},
 	"if": {
-		"prefix": "if",
+		"prefix": ["if"],
 		"body": [
 			"if (${1:condition}) {",
 			"\t$0",
@@ -41,7 +41,7 @@
 		"description": "if statement"
 	},
 	"ifelse": {
-		"prefix": "ifelse",
+		"prefix": ["ifelse"],
 		"body": [
 			"if (${1:condition}) {",
 			"\t$2",
@@ -52,7 +52,7 @@
 		"description": "if/else statement"
 	},
 	"ifnull": {
-		"prefix": "ifnull",
+		"prefix": ["ifnull"],
 		"body": [
 			"if (${1:condition} == null) {",
 			"\t$0",
@@ -61,7 +61,7 @@
 		"description": "if statement checking for null"
 	},
 	"ifnotnull": {
-		"prefix": "ifnotnull",
+		"prefix": ["ifnotnull"],
 		"body": [
 			"if (${1:condition} != null) {",
 			"\t$0",
@@ -70,7 +70,7 @@
 		"description": "if statement checking for not null"
 	},
 	"While Statement": {
-		"prefix": "while",
+		"prefix": ["while"],
 		"body": [
 			"while (${1:condition}) {",
 			"\t$0",
@@ -79,7 +79,7 @@
 		"description": "While Statement"
 	},
 	"Do-While Statement": {
-		"prefix": "dowhile",
+		"prefix": ["dowhile"],
 		"body": [
 			"do {",
 			"\t$0",

--- a/src/snippetCompletionProvider.ts
+++ b/src/snippetCompletionProvider.ts
@@ -22,15 +22,25 @@ export class SnippetCompletionProvider implements CompletionItemProvider {
         const snippetItems: CompletionItem[] = [];
         for (const label of Object.keys(this.snippets)) {
             const snippetContent = this.snippets[label];
-            const snippetItem: CompletionItem = new CompletionItem(snippetContent.prefix);
-            snippetItem.kind = CompletionItemKind.Snippet;
-            snippetItem.detail = snippetContent.description;
-            const insertText: string = (snippetContent.body as String[]).join('\n');
-            snippetItem.insertText = new SnippetString(insertText);
-            snippetItem.documentation = beautifyDocument(insertText);
-            snippetItems.push(snippetItem);
+            if (Array.isArray(snippetContent.prefix)) {
+                for (const prefix of snippetContent.prefix) {
+                    snippetItems.push(this.getCompletionItem(prefix, snippetContent));
+                }
+            } else {
+                snippetItems.push(this.getCompletionItem(snippetContent.prefix, snippetContent));
+            }
         }
         return snippetItems;
+    }
+
+    private getCompletionItem(prefix: string, snippetContent: any) {
+        const snippetItem: CompletionItem = new CompletionItem(prefix);
+        snippetItem.kind = CompletionItemKind.Snippet;
+        snippetItem.detail = snippetContent.description;
+        const insertText: string = (snippetContent.body as String[]).join('\n');
+        snippetItem.insertText = new SnippetString(insertText);
+        snippetItem.documentation = beautifyDocument(insertText);
+        return snippetItem;
     }
 }
 


### PR DESCRIPTION
The following alias are added:
- sysout -> sout
- syserr -> serr
- main -> psvm
- foreach -> iter

require https://github.com/eclipse/eclipse.jdt.ls/pull/2006

Signed-off-by: Sheng Chen <sheche@microsoft.com>