### PR TITLE
Set java.configuration.workspaceCacheLimit default value to 90.

### DIFF
--- a/package.json
+++ b/package.json
@@ -361,7 +361,7 @@
             "null",
             "integer"
           ],
-          "default": null,
+          "default": 90,
           "minimum": 1,
           "description": "The number of days (if enabled) to keep unused workspace cache data. Beyond this limit, cached workspace data may be removed.",
           "scope": "application"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -989,7 +989,8 @@ function isPrefix(parentPath: string, childPath: string): boolean {
 async function cleanJavaWorkspaceStorage() {
 	const configCacheLimit = getJavaConfiguration().get<number>("configuration.workspaceCacheLimit");
 
-	if (!storagePath || !configCacheLimit) {
+	// Also leave temporary workspaces alone as they should have their own policy
+	if (!storagePath || !configCacheLimit || storagePath.includes('vscodesws')) {
 		return;
 	}
 


### PR DESCRIPTION
- Avoid deleting temporary workspaces as they should have their own
  policy defined by the operating system
- Enable cleaning of cache for workspaces that have been inactive for
  over 90 days

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

We should set some larger value for the setting (eg `90`), otherwise many users are unlikely to benefit from this. I've also disabled the deletion for temporary workspace folders mainly because the OS should handle policy for temp folders (if they're not deleted on every reboot anyways).

See #2110 for more information.