### PR TITLE
Make java.configuration.runtimes machine-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
       "restrictedConfigurations": [
         "java.jdt.ls.java.home",
         "java.home",
-        "java.jdt.ls.vmargs"
+        "java.jdt.ls.vmargs",
+        "java.configuration.runtimes"
       ]
     },
     "virtualWorkspaces": false

--- a/package.json
+++ b/package.json
@@ -721,7 +721,7 @@
             "additionalProperties": false
           },
           "default": [],
-          "scope": "machine"
+          "scope": "machine-overridable"
         },
         "java.server.launchMode": {
           "type": "string",


### PR DESCRIPTION
Potential fix for https://github.com/redhat-developer/vscode-java/issues/2001

I have no idea if changing this configuration's scope can cause unintentional side effects. If so, do educate me and I'd be happy to make some code changes if it is not a lot.