### PR TITLE
change max size of client.log

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -5,7 +5,7 @@ export function initializeLogFile(filename: string) {
 	logger.add(new DailyRotateFile({
 		filename: filename,
 		datePattern: 'YYYY-MM-DD',
-		maxSize: '100k', // 100k max size per file
+		maxSize: '1m', // 1MB max size per file
 		maxFiles: '2d' // retain logs of the last two days
 	}));
 }


### PR DESCRIPTION
improve the case mentioned in https://github.com/redhat-developer/vscode-java/issues/2319

With `100k` as max size, sometimes it creates several log files for a single session, which is not convenient for diagnose. E.g. I have to try opening several log files to find the the one containing the command to start Java language server. 

This PR simply increases it to `1m`, in order to mitigate the inconvenience.