### PR TITLE
Show server status via language status item

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,6 +185,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 	cleanJavaWorkspaceStorage();
 
+	serverStatusBarProvider.initialize();
+
 	return requirements.resolveRequirements(context).catch(error => {
 		// show error
 		window.showErrorMessage(error.message, error.label).then((selection) => {
@@ -424,7 +426,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				if (event === ServerMode.STANDARD) {
 					syntaxClient.stop();
 					fileEventHandler.setServerStatus(true);
-					runtimeStatusBarProvider.initialize(context.storagePath);
+					runtimeStatusBarProvider.initialize(context);
 				}
 				commands.executeCommand('setContext', 'java:serverMode', event);
 			});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -546,7 +546,7 @@ async function ensureNoBuildToolConflicts(context: ExtensionContext, clientOptio
 	return true;
 }
 
-async function hasBuildToolConflicts(): Promise<boolean> {
+export async function hasBuildToolConflicts(): Promise<boolean> {
 	const projectConfigurationUris: Uri[] = await getBuildFilesInWorkspace();
 	const projectConfigurationFsPaths: string[] = projectConfigurationUris.map((uri) => uri.fsPath);
 	const eclipseDirectories = getDirectoriesByBuildFile(projectConfigurationFsPaths, [], ".project");

--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -22,7 +22,7 @@ export namespace StatusCommands {
 	export const switchToStandardCommand = {
 		title: "Load Projects",
 		command: Commands.SWITCH_SERVER_MODE,
-		arguments: ["Standard"],
+		arguments: ["Standard", true],
 		tooltip: "LightWeight mode only provides limited features, please load projects to get full feature set"
 	};
 

--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -29,7 +29,7 @@ export namespace StatusCommands {
 	export const showServerStatusCommand = {
 		title: "Show Build Status",
 		command: Commands.SHOW_SERVER_TASK_STATUS,
-		tooltip: "Show build status"
+		tooltip: "Show Build Status"
 	};
 
 	export const configureJavaRuntimeCommand = {
@@ -82,12 +82,12 @@ export namespace ServerStatusItemFactory {
 		item.busy = false;
 		item.severity = vscode.LanguageStatusSeverity?.Error;
 		item.command = {
-			title: "Show PROBLEMS panel",
+			title: "Show PROBLEMS Panel",
 			command: "workbench.panel.markers.view.focus",
 			tooltip: "Errors occurred in project configurations, click to show the PROBLEMS panel"
 		};
 		item.text = StatusIcon.Warning;
-		item.detail = "Project configuration error";
+		item.detail = "Project Configuration Error";
 	}
 
 	export function setReady(item: any): void {
@@ -99,35 +99,25 @@ export namespace ServerStatusItemFactory {
 	}
 }
 
-export namespace CleanServerStatusItemFactory {
-	export function create(): any {
-		if (supportsLanguageStatus()) {
-			const item = vscode.languages.createLanguageStatusItem("javaServerCleanItem", languageServerDocumentSelector);
-			item.name = "Clean Java language server workspace";
-			item.command = {
-				title: "Clean workspace",
-				command: Commands.CLEAN_WORKSPACE,
-				tooltip: "Click to clean Java language server workspace"
-			};
-			item.severity = vscode.LanguageStatusSeverity?.Error;
-			item.text = "Project out of sync";
-			return item;
-		}
-		return undefined;
-	}
-}
-
 export namespace RuntimeStatusItemFactory {
-	export function create(text: string): any {
+	export function create(text: string, vmInstallPath: string): any {
 		if (supportsLanguageStatus()) {
 			const item = vscode.languages.createLanguageStatusItem("javaRuntimeStatusItem", languageServerDocumentSelector);
 			item.severity = vscode.LanguageStatusSeverity?.Information;
 			item.name = "Java Runtime";
 			item.text = text;
 			item.command = StatusCommands.configureJavaRuntimeCommand;
+			if (vmInstallPath) {
+				item.command.tooltip = `Language Level: ${text} <${vmInstallPath}>`;
+			}
 			return item;
 		}
 		return undefined;
+	}
+
+	export function update(item: any, text: string, vmInstallPath: string): void {
+		item.text = text;
+		item.command.tooltip = vmInstallPath ? `Language Level: ${text} <${vmInstallPath}>` : "Configure Java Runtime";
 	}
 }
 
@@ -139,14 +129,25 @@ export namespace BuildFileStatusItemFactory {
 			item.severity = vscode.LanguageStatusSeverity?.Information;
 			item.name = "Java Build File";
 			item.text = fileName;
-			item.command = {
-				title: `Open config file`,
-				command: Commands.OPEN_BROWSER,
-				arguments: [vscode.Uri.file(buildFilePath)],
-				tooltip: `Open config file`
-			};
+			item.command = getOpenBuildFileCommand(buildFilePath);
 			return item;
 		}
 		return undefined;
+	}
+
+	export function update(item: any, buildFilePath: string): void {
+		const fileName = path.basename(buildFilePath);
+		item.text = fileName;
+		item.command = getOpenBuildFileCommand(buildFilePath);
+	}
+
+	function getOpenBuildFileCommand(buildFilePath: string): vscode.Command {
+		const relativePath = vscode.workspace.asRelativePath(buildFilePath);
+		return {
+			title: `Open Config File`,
+			command: Commands.OPEN_BROWSER,
+			arguments: [vscode.Uri.file(buildFilePath)],
+			tooltip: `Open ${relativePath}`
+		};
 	}
 }

--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -14,14 +14,16 @@ const languageServerDocumentSelector = [
 	{ pattern: '**/{build,settings}.gradle.kts'}
 ];
 
-const languageStatusItemAPI = (vscode.languages as any).createLanguageStatusItem;
+export function supportsLanguageStatus(): boolean {
+	return !vscode.languages.createLanguageStatusItem;
+}
 
 export namespace StatusCommands {
 	export const switchToStandardCommand = {
 		title: "Load Projects",
 		command: Commands.SWITCH_SERVER_MODE,
 		arguments: ["Standard"],
-		tooltip: "Java language server is running in LightWeight mode, load projects to switch to Standard mode"
+		tooltip: "LightWeight mode only provides limited features, please load projects to get full feature set"
 	};
 
 	export const showServerStatusCommand = {
@@ -38,10 +40,10 @@ export namespace StatusCommands {
 	};
 }
 
-export namespace LanguageStatusItemFactory {
+export namespace ServerStatusItemFactory {
 	export function create(): any {
-		if (languageStatusItemAPI) {
-			const item = languageStatusItemAPI("JavaServerStatusItem", languageServerDocumentSelector);
+		if (supportsLanguageStatus()) {
+			const item = vscode.languages.createLanguageStatusItem("JavaServerStatusItem", languageServerDocumentSelector);
 			item.name = "Java Language Server Status";
 			return item;
 		}
@@ -99,8 +101,8 @@ export namespace LanguageStatusItemFactory {
 
 export namespace CleanServerStatusItemFactory {
 	export function create(): any {
-		if (languageStatusItemAPI) {
-			const item = languageStatusItemAPI("javaServerCleanItem", languageServerDocumentSelector);
+		if (supportsLanguageStatus()) {
+			const item = vscode.languages.createLanguageStatusItem("javaServerCleanItem", languageServerDocumentSelector);
 			item.name = "Clean Java language server workspace";
 			item.command = {
 				title: "Clean workspace",
@@ -117,8 +119,8 @@ export namespace CleanServerStatusItemFactory {
 
 export namespace RuntimeStatusItemFactory {
 	export function create(text: string): any {
-		if (languageStatusItemAPI) {
-			const item = languageStatusItemAPI("javaRuntimeStatusItem", languageServerDocumentSelector);
+		if (supportsLanguageStatus()) {
+			const item = vscode.languages.createLanguageStatusItem("javaRuntimeStatusItem", languageServerDocumentSelector);
 			item.severity = (vscode as any).LanguageStatusSeverity?.Information;
 			item.name = "Java Runtime";
 			item.text = text;
@@ -131,9 +133,9 @@ export namespace RuntimeStatusItemFactory {
 
 export namespace BuildFileStatusItemFactory {
 	export function create(buildFilePath: string): any {
-		if (languageStatusItemAPI) {
+		if (supportsLanguageStatus()) {
 			const fileName = path.basename(buildFilePath);
-			const item = languageStatusItemAPI("javaBuildFileStatusItem", languageServerDocumentSelector);
+			const item = vscode.languages.createLanguageStatusItem("javaBuildFileStatusItem", languageServerDocumentSelector);
 			item.severity = (vscode as any).LanguageStatusSeverity?.Information;
 			item.name = "Java Build File";
 			item.text = fileName;

--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -1,0 +1,150 @@
+'use strict';
+
+import * as path from "path";
+import * as vscode from "vscode";
+import { Commands } from "./commands";
+import { StatusIcon } from "./serverStatusBarProvider";
+
+const languageServerDocumentSelector = [
+	{ scheme: 'file', language: 'java' },
+	{ scheme: 'jdt', language: 'java' },
+	{ scheme: 'untitled', language: 'java' },
+	{ pattern: '**/pom.xml' },
+	{ pattern: '**/{build,settings}.gradle'},
+	{ pattern: '**/{build,settings}.gradle.kts'}
+];
+
+const languageStatusItemAPI = (vscode.languages as any).createLanguageStatusItem;
+
+export namespace StatusCommands {
+	export const switchToStandardCommand = {
+		title: "Load Projects",
+		command: Commands.SWITCH_SERVER_MODE,
+		arguments: ["Standard"],
+		tooltip: "Java language server is running in LightWeight mode, load projects to switch to Standard mode"
+	};
+
+	export const showServerStatusCommand = {
+		title: "Show Build Status",
+		command: Commands.SHOW_SERVER_TASK_STATUS,
+		tooltip: "Show build status"
+	};
+
+	export const configureJavaRuntimeCommand = {
+		title: "Configure Java Runtime",
+		command: "workbench.action.openSettings",
+		arguments: ["java.configuration.runtimes"],
+		tooltip: "Configure Java Runtime"
+	};
+}
+
+export namespace LanguageStatusItemFactory {
+	export function create(): any {
+		if (languageStatusItemAPI) {
+			const item = languageStatusItemAPI("JavaServerStatusItem", languageServerDocumentSelector);
+			item.name = "Java Language Server Status";
+			return item;
+		}
+		return undefined;
+	}
+
+	export function showLightWeightStatus(item: any): void {
+		item.severity = (vscode as any).LanguageStatusSeverity?.Warning;
+		item.text = StatusIcon.LightWeight;
+		item.detail = "Lightweight Mode";
+		item.command = StatusCommands.switchToStandardCommand;
+	}
+
+	export function showStandardStatus(item: any): void {
+		item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+		item.command = StatusCommands.showServerStatusCommand;
+	}
+
+	export function setBusy(item: any): void {
+		item.text = "Building";
+		item.busy = true;
+	}
+
+	export function setError(item: any): void {
+		item.busy = false;
+		item.severity = (vscode as any).LanguageStatusSeverity?.Error;
+		item.command = {
+			title: "Open logs",
+			command: Commands.OPEN_LOGS
+		};
+		item.text = StatusIcon.Error;
+		item.detail = "Errors occurred in initializing language server";
+	}
+
+	export function setWarning(item: any): void {
+		item.busy = false;
+		item.severity = (vscode as any).LanguageStatusSeverity?.Error;
+		item.command = {
+			title: "Show PROBLEMS panel",
+			command: "workbench.panel.markers.view.focus",
+			tooltip: "Errors occurred in project configurations, click to show the PROBLEMS panel"
+		};
+		item.text = StatusIcon.Warning;
+		item.detail = "Project configuration error";
+	}
+
+	export function setReady(item: any): void {
+		item.busy = false;
+		item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+		item.command = StatusCommands.showServerStatusCommand;
+		item.text = StatusIcon.Ready;
+		item.detail = "";
+	}
+}
+
+export namespace CleanServerStatusItemFactory {
+	export function create(): any {
+		if (languageStatusItemAPI) {
+			const item = languageStatusItemAPI("javaServerCleanItem", languageServerDocumentSelector);
+			item.name = "Clean Java language server workspace";
+			item.command = {
+				title: "Clean workspace",
+				command: Commands.CLEAN_WORKSPACE,
+				tooltip: "Click to clean Java language server workspace"
+			};
+			item.severity = (vscode as any).LanguageStatusSeverity?.Error;
+			item.text = "Project out of sync";
+			return item;
+		}
+		return undefined;
+	}
+}
+
+export namespace RuntimeStatusItemFactory {
+	export function create(text: string): any {
+		if (languageStatusItemAPI) {
+			const item = languageStatusItemAPI("javaRuntimeStatusItem", languageServerDocumentSelector);
+			item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+			item.name = "Java Runtime";
+			item.text = text;
+			item.command = StatusCommands.configureJavaRuntimeCommand;
+			return item;
+		}
+		return undefined;
+	}
+}
+
+export namespace BuildFileStatusItemFactory {
+	export function create(buildFilePath: string): any {
+		if (languageStatusItemAPI) {
+			const fileName = path.basename(buildFilePath);
+			const item = languageStatusItemAPI("javaBuildFileStatusItem", languageServerDocumentSelector);
+			item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+			item.name = "Java Build File";
+			item.text = fileName;
+			item.command = {
+				title: `Open config file`,
+				command: Commands.OPEN_BROWSER,
+				arguments: [vscode.Uri.file(buildFilePath)],
+				tooltip: `Open config file`
+			};
+			return item;
+		}
+		return undefined;
+	}
+}

--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -15,7 +15,7 @@ const languageServerDocumentSelector = [
 ];
 
 export function supportsLanguageStatus(): boolean {
-	return !vscode.languages.createLanguageStatusItem;
+	return !!vscode.languages.createLanguageStatusItem;
 }
 
 export namespace StatusCommands {
@@ -51,14 +51,14 @@ export namespace ServerStatusItemFactory {
 	}
 
 	export function showLightWeightStatus(item: any): void {
-		item.severity = (vscode as any).LanguageStatusSeverity?.Warning;
+		item.severity = vscode.LanguageStatusSeverity?.Warning;
 		item.text = StatusIcon.LightWeight;
 		item.detail = "Lightweight Mode";
 		item.command = StatusCommands.switchToStandardCommand;
 	}
 
 	export function showStandardStatus(item: any): void {
-		item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+		item.severity = vscode.LanguageStatusSeverity?.Information;
 		item.command = StatusCommands.showServerStatusCommand;
 	}
 
@@ -69,7 +69,7 @@ export namespace ServerStatusItemFactory {
 
 	export function setError(item: any): void {
 		item.busy = false;
-		item.severity = (vscode as any).LanguageStatusSeverity?.Error;
+		item.severity = vscode.LanguageStatusSeverity?.Error;
 		item.command = {
 			title: "Open logs",
 			command: Commands.OPEN_LOGS
@@ -80,7 +80,7 @@ export namespace ServerStatusItemFactory {
 
 	export function setWarning(item: any): void {
 		item.busy = false;
-		item.severity = (vscode as any).LanguageStatusSeverity?.Error;
+		item.severity = vscode.LanguageStatusSeverity?.Error;
 		item.command = {
 			title: "Show PROBLEMS panel",
 			command: "workbench.panel.markers.view.focus",
@@ -92,7 +92,7 @@ export namespace ServerStatusItemFactory {
 
 	export function setReady(item: any): void {
 		item.busy = false;
-		item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+		item.severity = vscode.LanguageStatusSeverity?.Information;
 		item.command = StatusCommands.showServerStatusCommand;
 		item.text = StatusIcon.Ready;
 		item.detail = "";
@@ -109,7 +109,7 @@ export namespace CleanServerStatusItemFactory {
 				command: Commands.CLEAN_WORKSPACE,
 				tooltip: "Click to clean Java language server workspace"
 			};
-			item.severity = (vscode as any).LanguageStatusSeverity?.Error;
+			item.severity = vscode.LanguageStatusSeverity?.Error;
 			item.text = "Project out of sync";
 			return item;
 		}
@@ -121,7 +121,7 @@ export namespace RuntimeStatusItemFactory {
 	export function create(text: string): any {
 		if (supportsLanguageStatus()) {
 			const item = vscode.languages.createLanguageStatusItem("javaRuntimeStatusItem", languageServerDocumentSelector);
-			item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+			item.severity = vscode.LanguageStatusSeverity?.Information;
 			item.name = "Java Runtime";
 			item.text = text;
 			item.command = StatusCommands.configureJavaRuntimeCommand;
@@ -136,7 +136,7 @@ export namespace BuildFileStatusItemFactory {
 		if (supportsLanguageStatus()) {
 			const fileName = path.basename(buildFilePath);
 			const item = vscode.languages.createLanguageStatusItem("javaBuildFileStatusItem", languageServerDocumentSelector);
-			item.severity = (vscode as any).LanguageStatusSeverity?.Information;
+			item.severity = vscode.LanguageStatusSeverity?.Information;
 			item.name = "Java Build File";
 			item.text = fileName;
 			item.command = {

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -1,15 +1,14 @@
 'use strict';
 
-import { StatusBarItem, window, StatusBarAlignment, version, languages } from "vscode";
+import { StatusBarItem, window, StatusBarAlignment, version } from "vscode";
 import { Commands } from "./commands";
 import { Disposable } from "vscode-languageclient";
 import * as semver from "semver";
-import { ServerStatusItemFactory, StatusCommands, CleanServerStatusItemFactory, supportsLanguageStatus } from "./languageStatusItemFactory";
+import { ServerStatusItemFactory, StatusCommands, supportsLanguageStatus } from "./languageStatusItemFactory";
 
 class ServerStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
 	private languageStatusItem: any;
-	private cleanServerStatusItem: any;
 	// Adopt new API for status bar item, meanwhile keep the compatibility with Theia.
 	// See: https://github.com/redhat-developer/vscode-java/issues/1982
 	private isAdvancedStatusBarItem: boolean;
@@ -70,7 +69,6 @@ class ServerStatusBarProvider implements Disposable {
 	public setError(): void {
 		if (supportsLanguageStatus()) {
 			ServerStatusItemFactory.setError(this.languageStatusItem);
-			this.showCleanItem();
 		} else {
 			this.statusBarItem.text = StatusIcon.Error;
 			this.statusBarItem.command = Commands.OPEN_LOGS;
@@ -80,7 +78,6 @@ class ServerStatusBarProvider implements Disposable {
 	public setWarning(): void {
 		if (supportsLanguageStatus()) {
 			ServerStatusItemFactory.setWarning(this.languageStatusItem);
-			this.showCleanItem();
 		} else {
 			this.statusBarItem.text = StatusIcon.Warning;
 			this.statusBarItem.command = "workbench.panel.markers.view.focus";
@@ -91,7 +88,6 @@ class ServerStatusBarProvider implements Disposable {
 	public setReady(): void {
 		if (supportsLanguageStatus()) {
 			ServerStatusItemFactory.setReady(this.languageStatusItem);
-			this.hideCleanItem();
 		} else {
 			this.statusBarItem.text = StatusIcon.Ready;
 			this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
@@ -105,22 +101,9 @@ class ServerStatusBarProvider implements Disposable {
 		}
 	}
 
-	private showCleanItem(): void {
-		if (this.cleanServerStatusItem) {
-			return;
-		}
-		this.cleanServerStatusItem = CleanServerStatusItemFactory.create();
-	}
-
-	private hideCleanItem(): void {
-		this.cleanServerStatusItem?.dispose();
-		this.cleanServerStatusItem = undefined;
-	}
-
 	public dispose(): void {
 		this.statusBarItem?.dispose();
 		this.languageStatusItem?.dispose();
-		this.cleanServerStatusItem?.dispose();
 	}
 }
 

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -4,7 +4,7 @@ import { StatusBarItem, window, StatusBarAlignment, version, languages } from "v
 import { Commands } from "./commands";
 import { Disposable } from "vscode-languageclient";
 import * as semver from "semver";
-import { LanguageStatusItemFactory, StatusCommands, CleanServerStatusItemFactory } from "./languageStatusItemFactory";
+import { ServerStatusItemFactory, StatusCommands, CleanServerStatusItemFactory, supportsLanguageStatus } from "./languageStatusItemFactory";
 
 class ServerStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
@@ -13,17 +13,14 @@ class ServerStatusBarProvider implements Disposable {
 	// Adopt new API for status bar item, meanwhile keep the compatibility with Theia.
 	// See: https://github.com/redhat-developer/vscode-java/issues/1982
 	private isAdvancedStatusBarItem: boolean;
-	// Adopt new API for language status item, meanwhile keep the compatibility with Theia.
-	private languageStatusItemAPI: any;
 
 	constructor() {
-		this.languageStatusItemAPI = (languages as any).createLanguageStatusItem;
 		this.isAdvancedStatusBarItem = semver.gte(version, "1.57.0");
 	}
 
 	public initialize(): void {
-		if (this.languageStatusItemAPI) {
-			this.languageStatusItem = LanguageStatusItemFactory.create();
+		if (supportsLanguageStatus()) {
+			this.languageStatusItem = ServerStatusItemFactory.create();
 		} else {
 			if (this.isAdvancedStatusBarItem) {
 				this.statusBarItem = (window.createStatusBarItem as any)("java.serverStatus", StatusBarAlignment.Right, Number.MIN_VALUE);
@@ -34,8 +31,8 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public showLightWeightStatus(): void {
-		if (this.languageStatusItemAPI) {
-			LanguageStatusItemFactory.showLightWeightStatus(this.languageStatusItem);
+		if (supportsLanguageStatus()) {
+			ServerStatusItemFactory.showLightWeightStatus(this.languageStatusItem);
 		} else {
 			if (this.isAdvancedStatusBarItem) {
 				(this.statusBarItem as any).name = "Java Server Mode";
@@ -48,9 +45,9 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public showStandardStatus(): void {
-		if (this.languageStatusItemAPI) {
-			LanguageStatusItemFactory.showStandardStatus(this.languageStatusItem);
-			LanguageStatusItemFactory.setBusy(this.languageStatusItem);
+		if (supportsLanguageStatus()) {
+			ServerStatusItemFactory.showStandardStatus(this.languageStatusItem);
+			ServerStatusItemFactory.setBusy(this.languageStatusItem);
 		} else {
 			if (this.isAdvancedStatusBarItem) {
 				(this.statusBarItem as any).name = "Java Server Status";
@@ -63,16 +60,16 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public setBusy(): void {
-		if (this.languageStatusItemAPI) {
-			LanguageStatusItemFactory.setBusy(this.languageStatusItem);
+		if (supportsLanguageStatus()) {
+			ServerStatusItemFactory.setBusy(this.languageStatusItem);
 		} else {
 			this.statusBarItem.text = StatusIcon.Busy;
 		}
 	}
 
 	public setError(): void {
-		if (this.languageStatusItemAPI) {
-			LanguageStatusItemFactory.setError(this.languageStatusItem);
+		if (supportsLanguageStatus()) {
+			ServerStatusItemFactory.setError(this.languageStatusItem);
 			this.showCleanItem();
 		} else {
 			this.statusBarItem.text = StatusIcon.Error;
@@ -81,8 +78,8 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public setWarning(): void {
-		if (this.languageStatusItemAPI) {
-			LanguageStatusItemFactory.setWarning(this.languageStatusItem);
+		if (supportsLanguageStatus()) {
+			ServerStatusItemFactory.setWarning(this.languageStatusItem);
 			this.showCleanItem();
 		} else {
 			this.statusBarItem.text = StatusIcon.Warning;
@@ -92,8 +89,8 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public setReady(): void {
-		if (this.languageStatusItemAPI) {
-			LanguageStatusItemFactory.setReady(this.languageStatusItem);
+		if (supportsLanguageStatus()) {
+			ServerStatusItemFactory.setReady(this.languageStatusItem);
 			this.hideCleanItem();
 		} else {
 			this.statusBarItem.text = StatusIcon.Ready;
@@ -103,7 +100,7 @@ class ServerStatusBarProvider implements Disposable {
 	}
 
 	public updateTooltip(tooltip: string): void {
-		if (!this.languageStatusItemAPI) {
+		if (!supportsLanguageStatus()) {
 			this.statusBarItem.tooltip = tooltip;
 		}
 	}

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -1,85 +1,133 @@
 'use strict';
 
-import { StatusBarItem, window, StatusBarAlignment, version } from "vscode";
+import { StatusBarItem, window, StatusBarAlignment, version, languages } from "vscode";
 import { Commands } from "./commands";
 import { Disposable } from "vscode-languageclient";
-import { ServerMode } from "./settings";
 import * as semver from "semver";
+import { LanguageStatusItemFactory, StatusCommands, CleanServerStatusItemFactory } from "./languageStatusItemFactory";
 
 class ServerStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
+	private languageStatusItem: any;
+	private cleanServerStatusItem: any;
 	// Adopt new API for status bar item, meanwhile keep the compatibility with Theia.
 	// See: https://github.com/redhat-developer/vscode-java/issues/1982
 	private isAdvancedStatusBarItem: boolean;
+	// Adopt new API for language status item, meanwhile keep the compatibility with Theia.
+	private languageStatusItemAPI: any;
 
 	constructor() {
+		this.languageStatusItemAPI = (languages as any).createLanguageStatusItem;
 		this.isAdvancedStatusBarItem = semver.gte(version, "1.57.0");
-		if (this.isAdvancedStatusBarItem) {
-			this.statusBarItem = (window.createStatusBarItem as any)("java.serverStatus", StatusBarAlignment.Right, Number.MIN_VALUE);
+	}
+
+	public initialize(): void {
+		if (this.languageStatusItemAPI) {
+			this.languageStatusItem = LanguageStatusItemFactory.create();
 		} else {
-			this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, Number.MIN_VALUE);
+			if (this.isAdvancedStatusBarItem) {
+				this.statusBarItem = (window.createStatusBarItem as any)("java.serverStatus", StatusBarAlignment.Right, Number.MIN_VALUE);
+			} else {
+				this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, Number.MIN_VALUE);
+			}
 		}
 	}
 
 	public showLightWeightStatus(): void {
-		if (this.isAdvancedStatusBarItem) {
-			(this.statusBarItem as any).name = "Java Server Mode";
+		if (this.languageStatusItemAPI) {
+			LanguageStatusItemFactory.showLightWeightStatus(this.languageStatusItem);
+		} else {
+			if (this.isAdvancedStatusBarItem) {
+				(this.statusBarItem as any).name = "Java Server Mode";
+			}
+			this.statusBarItem.text = StatusIcon.LightWeight;
+			this.statusBarItem.command = StatusCommands.switchToStandardCommand;
+			this.statusBarItem.tooltip = "Java language server is running in LightWeight mode, click to switch to Standard mode";
+			this.statusBarItem.show();
 		}
-		this.statusBarItem.text = StatusIcon.LightWeight;
-		this.statusBarItem.command = {
-			title: "Switch to Standard mode",
-			command: Commands.SWITCH_SERVER_MODE,
-			arguments: [ServerMode.STANDARD],
-		};
-		this.statusBarItem.tooltip = "Java language server is running in LightWeight mode, click to switch to Standard mode";
-		this.statusBarItem.show();
 	}
 
 	public showStandardStatus(): void {
-		if (this.isAdvancedStatusBarItem) {
-			(this.statusBarItem as any).name = "Java Server Status";
+		if (this.languageStatusItemAPI) {
+			LanguageStatusItemFactory.showStandardStatus(this.languageStatusItem);
+			LanguageStatusItemFactory.setBusy(this.languageStatusItem);
+		} else {
+			if (this.isAdvancedStatusBarItem) {
+				(this.statusBarItem as any).name = "Java Server Status";
+			}
+			this.statusBarItem.text = StatusIcon.Busy;
+			this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
+			this.statusBarItem.tooltip = "";
+			this.statusBarItem.show();
 		}
-		this.statusBarItem.text = StatusIcon.Busy;
-		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-		this.statusBarItem.tooltip = "";
-		this.statusBarItem.show();
-	}
-
-	public updateText(text: string): void {
-		this.statusBarItem.text = text;
 	}
 
 	public setBusy(): void {
-		this.statusBarItem.text = StatusIcon.Busy;
+		if (this.languageStatusItemAPI) {
+			LanguageStatusItemFactory.setBusy(this.languageStatusItem);
+		} else {
+			this.statusBarItem.text = StatusIcon.Busy;
+		}
 	}
 
 	public setError(): void {
-		this.statusBarItem.text = StatusIcon.Error;
-		this.statusBarItem.command = Commands.OPEN_LOGS;
+		if (this.languageStatusItemAPI) {
+			LanguageStatusItemFactory.setError(this.languageStatusItem);
+			this.showCleanItem();
+		} else {
+			this.statusBarItem.text = StatusIcon.Error;
+			this.statusBarItem.command = Commands.OPEN_LOGS;
+		}
 	}
 
 	public setWarning(): void {
-		this.statusBarItem.text = StatusIcon.Warning;
-		this.statusBarItem.command = "workbench.panel.markers.view.focus";
-		this.statusBarItem.tooltip = "Errors occurred in project configurations, click to show the PROBLEMS panel";
+		if (this.languageStatusItemAPI) {
+			LanguageStatusItemFactory.setWarning(this.languageStatusItem);
+			this.showCleanItem();
+		} else {
+			this.statusBarItem.text = StatusIcon.Warning;
+			this.statusBarItem.command = "workbench.panel.markers.view.focus";
+			this.statusBarItem.tooltip = "Errors occurred in project configurations, click to show the PROBLEMS panel";
+		}
 	}
 
 	public setReady(): void {
-		this.statusBarItem.text = StatusIcon.Ready;
-		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-		this.statusBarItem.tooltip = "ServiceReady";
+		if (this.languageStatusItemAPI) {
+			LanguageStatusItemFactory.setReady(this.languageStatusItem);
+			this.hideCleanItem();
+		} else {
+			this.statusBarItem.text = StatusIcon.Ready;
+			this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
+			this.statusBarItem.tooltip = "ServiceReady";
+		}
 	}
 
 	public updateTooltip(tooltip: string): void {
-		this.statusBarItem.tooltip = tooltip;
+		if (!this.languageStatusItemAPI) {
+			this.statusBarItem.tooltip = tooltip;
+		}
+	}
+
+	private showCleanItem(): void {
+		if (this.cleanServerStatusItem) {
+			return;
+		}
+		this.cleanServerStatusItem = CleanServerStatusItemFactory.create();
+	}
+
+	private hideCleanItem(): void {
+		this.cleanServerStatusItem?.dispose();
+		this.cleanServerStatusItem = undefined;
 	}
 
 	public dispose(): void {
-		this.statusBarItem.dispose();
+		this.statusBarItem?.dispose();
+		this.languageStatusItem?.dispose();
+		this.cleanServerStatusItem?.dispose();
 	}
 }
 
-enum StatusIcon {
+export enum StatusIcon {
 	LightWeight = "$(rocket)",
 	Busy = "$(sync~spin)",
 	Ready = "$(thumbsup)",


### PR DESCRIPTION
fix #2351 

We can use language status item to show the server's status. Once the language status API is available (the check is for the compatibility with Theia), we will show the new language status item, instead of previously runtime status (language level) and server status (thumb).

## when service is ready:
![image](https://user-images.githubusercontent.com/45906942/158581892-7e7c54e6-fb39-4369-8b99-26b054eac077.png)

we will show serval statuses. 

- The first one is build file status. If the current project is an invisible project this item will disappear. The related command can help you to open the corresponding build file
- The second one is runtime status, similar with previously runtime status
- The third one is server status, similar with previously server status

We can choose to pin these statuses:
![image](https://user-images.githubusercontent.com/45906942/158582569-889a9e52-293b-4739-b141-438a3abb578e.png)

clicking the item will trigger its command as well.
## when running in lightweight mode:
![image](https://user-images.githubusercontent.com/45906942/158582781-80da9128-af55-4614-aa0a-ef84e9e90124.png)

we will show a server status telling the current lightweight mode.

We can choose to pin the status:
![image](https://user-images.githubusercontent.com/45906942/158583055-ab5813d7-a820-47a1-8b69-9e351db002e4.png)

## when there is error (`ServerStatusKind.Error` and `ServerStatusKind.Warning`, previously thumb down)

![image](https://user-images.githubusercontent.com/45906942/158583386-88d54467-91a1-4d79-90da-e2a3631879ed.png)

Compared with the first one, we will show one more item to help you clean the language server workspace.

after pinned:
![image](https://user-images.githubusercontent.com/45906942/158583647-a1563267-b617-4f92-94d3-84ed391ece01.png)
