### PR TITLE
Change scope of jvmargs configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
           ],
           "default": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m",
           "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m ` to optimize memory usage with the parallel garbage collector",
-          "scope": "window"
+          "scope": "machine-overridable"
         },
         "java.errors.incompleteClasspath.severity": {
           "type": [


### PR DESCRIPTION
Signed-off-by: Frederik Claus <f.v.claus@googlemail.com>

I just started working with a Windows machine and used Settings Sync to sync my settings from my Linux machine. On Linux, I used the Lombok extension. The following `java.jdt.ls.vmargs` was synced: 

```
"java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -javaagent:\"/home/dev/.vscode/extensions/gabrielbb.vscode-lombok-1.0.1/server/lombok.jar\"",
```
On windows, this crashed the language server with
```
{
  message: 'Error opening zip file or JAR manifest missing : c:\\Users\\COMPUTERFFCL\\.vscode\\extensions\\gabrielbb.vscode-lombok-1.0.1\\server\\lombok.jar\n',
  level: 'info',
  timestamp: '2022-03-21 13:28:11.004'
}
```

After installing the Lombok extension on the Windows machine. `java.jdt.ls.vmargs` was overriden and synced as 
```
"-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -javaagent:\"c:\\Users\\COMPUTERFFCL\\.vscode\\extensions\\gabrielbb.vscode-lombok-1.0.1\\server\\lombok.jar\"",
```

I believe, the `java.jdt.ls.vmargs` should not be synced across machines. Besides the path issues with `-javaagent`, the configuration might be tailored to a specific hardware configuration.

AFAIK, this will have only one consequence: If settings are synced across machines, the JVM args on the newly synced machine will be empty. Should the `default` value, currently specified only in `package.json`, also be used in `javaServerStarter.ts`? 
https://github.com/redhat-developer/vscode-java/blob/7ed079860ac01d35099021f55d7139718b3fe9fe/src/javaServerStarter.ts#L83-L102

In the meantime, this can be used as the workaround:
```
    "settingsSync.ignoredSettings": [
        "java.jdt.ls.vmargs"
    ]
```