### PR TITLE
Add commands to view Java Language Server debug and error logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -924,13 +924,19 @@
       },
       {
         "command": "java.open.serverLog",
-        "title": "%java.open.serverLog%",
-        "category": "Java"
+        "when": "false"
+      },
+      {
+        "command": "java.open.serverStdoutLog",
+        "when": "false"
+      },
+      {
+        "command": "java.open.serverStderrLog",
+        "when": "false"
       },
       {
         "command": "java.open.clientLog",
-        "title": "%java.open.clientLog%",
-        "category": "Java"
+        "when": "false"
       },
       {
         "command": "java.open.logs",

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,8 +2,6 @@
 	"java.server.mode.switch": "Switch to Standard Mode",
 	"java.projectConfiguration.update": "Update Project",
 	"java.project.import": "Import Java Projects into Workspace",
-	"java.open.serverLog": "Open Java Language Server Log File",
-	"java.open.clientLog": "Open Java Extension Log File",
 	"java.open.logs": "Open All Log Files",
 	"java.workspace.compile": "Force Java Compilation",
 	"java.open.formatter.settings": "Open Java Formatter Settings",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -2,8 +2,6 @@
 	"java.server.mode.switch": "切换到标准模式",
 	"java.projectConfiguration.update": "更新项目",
 	"java.project.import": "将 Java 项目导入工作区",
-	"java.open.serverLog": "打开 Java 语言服务器日志文件",
-	"java.open.clientLog": "打开 Java 插件日志文件",
 	"java.open.logs": "打开所有日志文件",
 	"java.workspace.compile": "强制编译",
 	"java.open.formatter.settings": "打开 Java 格式设置",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -85,6 +85,16 @@ export namespace Commands {
     export const OPEN_SERVER_LOG = 'java.open.serverLog';
 
     /**
+    * Open Java Language Service Output Log file
+    */
+    export const OPEN_SERVER_STDOUT_LOG = 'java.open.serverStdoutLog';
+
+    /**
+    * Open Java Language Server Error Log file
+    */
+    export const OPEN_SERVER_STDERR_LOG = 'java.open.serverStderrLog';
+
+    /**
     * Open Java client Log file
     */
     export const OPEN_CLIENT_LOG = 'java.open.clientLog';

--- a/test/lightweight-mode-suite/extension.test.ts
+++ b/test/lightweight-mode-suite/extension.test.ts
@@ -16,6 +16,8 @@ suite('Java Language Extension - LightWeight', () => {
 			const JAVA_COMMANDS = [
 				Commands.EXECUTE_WORKSPACE_COMMAND,
 				Commands.OPEN_SERVER_LOG,
+				Commands.OPEN_SERVER_STDOUT_LOG,
+				Commands.OPEN_SERVER_STDERR_LOG,
 				Commands.OPEN_CLIENT_LOG,
 				Commands.OPEN_LOGS,
 				Commands.OPEN_FORMATTER,

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -55,6 +55,8 @@ suite('Java Language Extension - Standard', () => {
 				Commands.OPEN_LOGS,
 				Commands.OPEN_OUTPUT,
 				Commands.OPEN_SERVER_LOG,
+				Commands.OPEN_SERVER_STDOUT_LOG,
+				Commands.OPEN_SERVER_STDERR_LOG,
 				Commands.ORGANIZE_IMPORTS,
 				Commands.OVERRIDE_METHODS_PROMPT,
 				Commands.PROJECT_CONFIGURATION_STATUS,


### PR DESCRIPTION
Resolves #2367, which in spite of being closed wasn't resolved as such (we found out how to view the logs but didn't make it easy)