### PR TITLE
Update language-client to 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7255,33 +7255,59 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
     },
     "vscode-languageclient": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-      "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+      "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
       "requires": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.5",
-        "vscode-languageserver-protocol": "3.17.2"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.3"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
       "requires": {
-        "vscode-jsonrpc": "8.0.2",
-        "vscode-languageserver-types": "3.17.2"
+        "vscode-jsonrpc": "8.1.0",
+        "vscode-languageserver-types": "3.17.3"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
     "watchpack": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -301,7 +301,7 @@
     },
     "@types/sinon": {
       "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
       "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
       "dev": true,
       "requires": {
@@ -871,7 +871,7 @@
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true
     },
@@ -1453,7 +1453,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "requires": {
@@ -2140,7 +2140,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
           "dev": true
         }
@@ -2325,7 +2325,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
@@ -3685,7 +3685,7 @@
       "dependencies": {
         "request": {
           "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/request/-/request-2.88.2.tgz",
           "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
           "dev": true,
           "requires": {
@@ -3713,7 +3713,7 @@
         },
         "request-progress": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
           "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
           "dev": true,
           "requires": {
@@ -3730,7 +3730,7 @@
     },
     "gulp-util": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha512-q5oWPc12lwSFS9h/4VIjG+1NuNDlJ48ywV2JKItY4Ycc/n1fXJeYPVQsfu5ZrhQi7FGSDBalwUCLar/GyHXKGw==",
       "dev": true,
       "requires": {
@@ -3756,19 +3756,19 @@
       "dependencies": {
         "clone": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/clone/-/clone-1.0.4.tgz",
           "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
           "dev": true
         },
         "clone-stats": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
           "integrity": "sha512-dhUqc57gSMCo6TX85FLfe51eC/s+Im2MLkAgJwfaRRexR2tA4dd3eLEW4L6efzHc2iNorrRRXITifnDLlRrhaA==",
           "dev": true
         },
         "lodash.template": {
           "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "integrity": "sha512-0B4Y53I0OgHUJkt+7RmlDFWKjVAI/YUpWNiL9GQz5ORDr4ttgfQGo+phBWKFLJbBdtOwgMuUkdOHOnPg45jKmQ==",
           "dev": true,
           "requires": {
@@ -3785,19 +3785,19 @@
         },
         "object-assign": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
           "dev": true
         },
         "replace-ext": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "integrity": "sha512-AFBWBy9EVRTa/LhEcG8QDP3FvpwZqmvN2QFDuJswFeaVhWnZMp8q3E6Zd90SR04PlIwfGdyVjNyLPyen/ek5CQ==",
           "dev": true
         },
         "vinyl": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha512-P5zdf3WB9uzr7IFoVQ2wZTmUwHL8cMZWJGzLBNCHNZ3NB6HTMsYABtt7z8tAGIINLXyAob9B9a1yzVGMFOYKEA==",
           "dev": true,
           "requires": {
@@ -3844,7 +3844,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "requires": {
@@ -4869,7 +4869,7 @@
     },
     "minimist": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
@@ -6580,7 +6580,7 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true
     },
@@ -7254,46 +7254,34 @@
         "vinyl": "^2.0.0"
       }
     },
+    "vscode-jsonrpc": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+    },
     "vscode-languageclient": {
-      "version": "7.1.0-next.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.1.0-next.5.tgz",
-      "integrity": "sha512-TpzpAhpdCNJHaLzptFRs54xsU6xTmaiVPCse0W0rRB5jJBPjOBKilrFPMMm/sJA0y8Yxa9sOvZaNu6WPg3dYAw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+      "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
       "requires": {
         "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.17.0-next.6"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
+        "semver": "^7.3.5",
+        "vscode-languageserver-protocol": "3.17.2"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.0-next.6",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.6.tgz",
-      "integrity": "sha512-f1kGsoOpISB5jSqQNeMDl2446enxVahyux2e5vZap6pu/TC+2UlvPT4DCR0gPph95KOQZweL9zq1SzLoPdqhuA==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
       "requires": {
-        "vscode-jsonrpc": "7.0.0-next.1",
-        "vscode-languageserver-types": "3.17.0-next.2"
-      },
-      "dependencies": {
-        "vscode-jsonrpc": {
-          "version": "7.0.0-next.1",
-          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-7.0.0-next.1.tgz",
-          "integrity": "sha512-dEmliPZGbSyIcEeKRGzosCy7y7zsc8FXg1l5BBOGgMUbemlo3vUnsa2GFqpILJwJvlbvkRcF2QASNwIlKe9J7g=="
-        }
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.17.0-next.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.2.tgz",
-      "integrity": "sha512-L5S2kNLCgYJMVWgsZjBaorMM/6+itAfvOyl6Kv1bgFzDNaUKm9HsnUlehjpWPdV5DqnfJhJ5E03Z+/3Mw8ii+Q=="
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
     },
     "watchpack": {
       "version": "2.1.1",
@@ -7637,7 +7625,7 @@
     },
     "yargs-parser": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
       "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,9 +288,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+      "version": "16.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
+      "integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==",
       "dev": true
     },
     "@types/semver": {
@@ -6973,9 +6973,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -1397,7 +1397,7 @@
     "@types/glob": "5.0.30",
     "@types/lodash.findindex": "^4.6.6",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^8.10.51",
+    "@types/node": "^16.11.7",
     "@types/semver": "^7.3.8",
     "@types/sinon": "^10.0.12",
     "@types/vscode": "^1.74.0",
@@ -1418,7 +1418,7 @@
     "request": "^2.88.2",
     "sinon": "^14.0.0",
     "ts-loader": "^9.2.6",
-    "typescript": "^4.2.4",
+    "typescript": "^4.6.4",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1431,7 +1431,7 @@
     "htmlparser2": "6.0.1",
     "jdk-utils": "^0.4.4",
     "semver": "^7.3.5",
-    "vscode-languageclient": "8.0.2",
+    "vscode-languageclient": "8.1.0",
     "winreg-utf8": "^0.1.1",
     "winston": "^3.2.1",
     "winston-daily-rotate-file": "^3.10.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "virtualWorkspaces": false
   },
   "engines": {
-    "vscode": "^1.65.0"
+    "vscode": "^1.67.0"
   },
   "repository": {
     "type": "git",
@@ -1400,7 +1400,7 @@
     "@types/node": "^8.10.51",
     "@types/semver": "^7.3.8",
     "@types/sinon": "^10.0.12",
-    "@types/vscode": "^1.65.0",
+    "@types/vscode": "^1.67.0",
     "@types/winreg": "^1.2.30",
     "@types/winston": "^2.4.4",
     "@vscode/test-electron": "^2.1.5",
@@ -1431,7 +1431,7 @@
     "htmlparser2": "6.0.1",
     "jdk-utils": "^0.4.4",
     "semver": "^7.3.5",
-    "vscode-languageclient": "7.1.0-next.5",
+    "vscode-languageclient": "8.0.2",
     "winreg-utf8": "^0.1.1",
     "winston": "^3.2.1",
     "winston-daily-rotate-file": "^3.10.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,8 +167,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						resolveAdditionalTextEditsSupport: true,
 						advancedIntroduceParameterRefactoringSupport: true,
 						actionableRuntimeNotificationSupport: true,
-						// https://github.com/redhat-developer/vscode-java/pull/2377#issuecomment-1427268344
-						shouldLanguageServerExitOnShutdown: false,
 						onCompletionItemSelectedCommand: "editor.action.triggerParameterHints",
 						extractInterfaceSupport: true,
 					},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,7 +167,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						resolveAdditionalTextEditsSupport: true,
 						advancedIntroduceParameterRefactoringSupport: true,
 						actionableRuntimeNotificationSupport: true,
-						shouldLanguageServerExitOnShutdown: true,
+						// https://github.com/redhat-developer/vscode-java/pull/2377#issuecomment-1427268344
+						shouldLanguageServerExitOnShutdown: false,
 						onCompletionItemSelectedCommand: "editor.action.triggerParameterHints",
 						extractInterfaceSupport: true,
 					},

--- a/src/fileEventHandler.ts
+++ b/src/fileEventHandler.ts
@@ -165,7 +165,7 @@ function getWillRenameHandler(client: LanguageClient) {
                 const edit = await client.sendRequest(WillRenameFiles.type, {
                     files: javaRenameEvents
                 });
-                resolve(client.protocol2CodeConverter.asWorkspaceEdit(edit));
+                resolve(await client.protocol2CodeConverter.asWorkspaceEdit(edit));
             } catch (ex) {
                 reject(ex);
             }

--- a/src/pasteEventHandler.ts
+++ b/src/pasteEventHandler.ts
@@ -94,7 +94,7 @@ class PasteEditProvider implements DocumentPasteEditProvider {
 			if (pasteResponse) {
 				return {
 					insertText: pasteResponse.insertText,
-					additionalEdit: pasteResponse.additionalEdit ? this.languageClient.protocol2CodeConverter.asWorkspaceEdit(pasteResponse.additionalEdit) : undefined
+					additionalEdit: pasteResponse.additionalEdit ? await this.languageClient.protocol2CodeConverter.asWorkspaceEdit(pasteResponse.additionalEdit) : undefined
 				} as VDocumentPasteEdit;
 			}
 		} catch (e) {

--- a/src/providerDispatcher.ts
+++ b/src/providerDispatcher.ts
@@ -99,10 +99,10 @@ function createDocumentSymbolProvider(): DocumentSymbolProvider {
 			}
 
 			if ((<any>symbolResponse[0]).containerName) {
-				return await languageClient.protocol2CodeConverter.asSymbolInformations(<clientSymbolInformation[]>symbolResponse);
+				return languageClient.protocol2CodeConverter.asSymbolInformations(<clientSymbolInformation[]>symbolResponse);
 			}
 
-			return await languageClient.protocol2CodeConverter.asDocumentSymbols(<clientDocumentSymbol[]>symbolResponse);
+			return languageClient.protocol2CodeConverter.asDocumentSymbols(<clientDocumentSymbol[]>symbolResponse);
 		}
 	};
 }

--- a/src/providerDispatcher.ts
+++ b/src/providerDispatcher.ts
@@ -99,10 +99,10 @@ function createDocumentSymbolProvider(): DocumentSymbolProvider {
 			}
 
 			if ((<any>symbolResponse[0]).containerName) {
-				return languageClient.protocol2CodeConverter.asSymbolInformations(<clientSymbolInformation[]>symbolResponse);
+				return await languageClient.protocol2CodeConverter.asSymbolInformations(<clientSymbolInformation[]>symbolResponse);
 			}
 
-			return languageClient.protocol2CodeConverter.asDocumentSymbols(<clientDocumentSymbol[]>symbolResponse);
+			return await languageClient.protocol2CodeConverter.asDocumentSymbols(<clientDocumentSymbol[]>symbolResponse);
 		}
 	};
 }

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -226,7 +226,7 @@ async function applyRefactorEdit(languageClient: LanguageClient, refactorEdit: R
     }
 
     if (refactorEdit.edit) {
-        const edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(refactorEdit.edit);
+        const edit = await languageClient.protocol2CodeConverter.asWorkspaceEdit(refactorEdit.edit);
         if (edit) {
             await workspace.applyEdit(edit);
         }

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -385,7 +385,7 @@ function registerGenerateDelegateMethodsCommand(languageClient: LanguageClient, 
 }
 
 async function revealWorkspaceEdit(workspaceEdit: WorkspaceEdit, languageClient: LanguageClient): Promise<void> {
-    const codeWorkspaceEdit = languageClient.protocol2CodeConverter.asWorkspaceEdit(workspaceEdit);
+    const codeWorkspaceEdit = await languageClient.protocol2CodeConverter.asWorkspaceEdit(workspaceEdit);
     if (!codeWorkspaceEdit) {
         return;
     }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -5,7 +5,7 @@ import { findRuntimes } from "jdk-utils";
 import * as net from 'net';
 import * as path from 'path';
 import { CancellationToken, CodeActionKind, commands, ConfigurationTarget, DocumentSelector, EventEmitter, ExtensionContext, extensions, languages, Location, ProgressLocation, TextEditor, Uri, ViewColumn, window, workspace } from "vscode";
-import { ConfigurationParams, ConfigurationRequest, LanguageClientOptions, Location as LSLocation, MessageType, Position as LSPosition, TextDocumentPositionParams } from "vscode-languageclient";
+import { ConfigurationParams, ConfigurationRequest, LanguageClientOptions, Location as LSLocation, MessageType, Position as LSPosition, TextDocumentPositionParams, WorkspaceEdit } from "vscode-languageclient";
 import { LanguageClient, StreamInfo } from "vscode-languageclient/node";
 import { apiManager } from "./apiManager";
 import * as buildPath from './buildpath';
@@ -61,8 +61,6 @@ export class StandardLanguageClient {
 			return;
 		}
 
-		const hasImported: boolean = await fse.pathExists(path.join(workspacePath, ".metadata", ".plugins"));
-
 		if (workspace.getConfiguration().get("java.showBuildStatusOnStart.enabled") === "terminal") {
 			commands.executeCommand(Commands.SHOW_SERVER_TASK_STATUS);
 		}
@@ -108,186 +106,477 @@ export class StandardLanguageClient {
 		// Create the language client and start the client.
 		this.languageClient = new LanguageClient('java', extensionName, serverOptions, clientOptions);
 
-		this.languageClient.onReady().then(() => {
-			activationProgressNotification.showProgress();
-			this.languageClient.onNotification(StatusNotification.type, (report) => {
-				switch (report.type) {
-					case 'ServiceReady':
-						apiManager.updateServerMode(ServerMode.standard);
-						apiManager.fireDidServerModeChange(ServerMode.standard);
-						apiManager.resolveServerReadyPromise();
-
-						if (extensions.onDidChange) {// Theia doesn't support this API yet
-							extensions.onDidChange(async () => {
-								await onExtensionChange(extensions.all);
-							});
-						}
-
-						registerPasteEventHandler(context, this.languageClient);
-						activationProgressNotification.hide();
-						if (!hasImported) {
-							showImportFinishNotification(context);
-						}
-						checkLombokDependency(context);
-						apiManager.getApiInstance().onDidClasspathUpdate((e: Uri) => {
-							checkLombokDependency(context);
-						});
-						// Disable the client-side snippet provider since LS is ready.
-						snippetCompletionProvider.dispose();
-						break;
-					case 'Started':
-						this.status = ClientStatus.started;
-						serverStatus.updateServerStatus(ServerStatusKind.ready);
-						commands.executeCommand('setContext', 'javaLSReady', true);
-						apiManager.updateStatus(ClientStatus.started);
-						break;
-					case 'Error':
-						this.status = ClientStatus.error;
-						serverStatus.updateServerStatus(ServerStatusKind.error);
-						apiManager.updateStatus(ClientStatus.error);
-						break;
-					case 'ProjectStatus':
-						if (report.message === "WARNING") {
-							serverStatus.updateServerStatus(ServerStatusKind.warning);
-						} else if (report.message === "OK") {
-							this.status = ClientStatus.started;
-							serverStatus.errorResolved();
-							serverStatus.updateServerStatus(ServerStatusKind.ready);
-						}
-						return;
-					case 'Starting':
-					case 'Message':
-						// message goes to progress report instead
-						break;
-				}
-				if (!serverStatus.hasErrors()) {
-					serverStatusBarProvider.updateTooltip(report.message);
-				}
-			});
-
-			this.languageClient.onNotification(ProgressReportNotification.type, (progress) => {
-				serverTasks.updateServerTask(progress);
-			});
-
-			this.languageClient.onNotification(EventNotification.type, async (notification) => {
-				switch (notification.eventType) {
-					case EventType.classpathUpdated:
-						apiManager.fireDidClasspathUpdate(Uri.parse(notification.data));
-						break;
-					case EventType.projectsImported:
-						const projectUris: Uri[] = [];
-						if (notification.data) {
-							for (const uriString of notification.data) {
-								projectUris.push(Uri.parse(uriString));
-							}
-						}
-						if (projectUris.length > 0) {
-							apiManager.fireDidProjectsImport(projectUris);
-						}
-						break;
-					case EventType.incompatibleGradleJdkIssue:
-						const options: string[] = [];
-						const info = notification.data as GradleCompatibilityInfo;
-						const highestJavaVersion = Number(info.highestJavaVersion);
-						let runtimes = await findRuntimes({checkJavac: true, withVersion: true, withTags: true});
-						runtimes = runtimes.filter(runtime => {
-							return runtime.version.major <= highestJavaVersion;
-						});
-						sortJdksByVersion(runtimes);
-						sortJdksBySource(runtimes);
-						options.push(UPGRADE_GRADLE + info.recommendedGradleVersion);
-						if (!runtimes.length) {
-							options.push(GET_JDK);
-						} else {
-							options.push(USE_JAVA + runtimes[0].version.major + AS_GRADLE_JVM);
-						}
-						this.showGradleCompatibilityIssueNotification(info.message, options, info.projectUri, info.recommendedGradleVersion, runtimes[0]?.homedir);
-						break;
-					case EventType.upgradeGradleWrapper:
-						const neverShow: boolean | undefined = context.globalState.get<boolean>("java.neverShowUpgradeWrapperNotification");
-						if (!neverShow) {
-							const upgradeInfo = notification.data as UpgradeGradleWrapperInfo;
-							const option = `Upgrade to ${upgradeInfo.recommendedGradleVersion}`;
-							window.showWarningMessage(upgradeInfo.message, option, "Don't show again").then(async (choice) => {
-								if (choice === option) {
-									await upgradeGradle(upgradeInfo.projectUri, upgradeInfo.recommendedGradleVersion);
-								} else if (choice === "Don't show again") {
-									context.globalState.update("java.neverShowUpgradeWrapperNotification", true);
-								}
-							});
-						}
-						break;
-					default:
-						break;
-				}
-			});
-
-			this.languageClient.onNotification(ActionableNotification.type, (notification) => {
-				let show = null;
-				switch (notification.severity) {
-					case MessageType.Log:
-						show = logNotification;
-						break;
-					case MessageType.Info:
-						show = window.showInformationMessage;
-						break;
-					case MessageType.Warning:
-						show = window.showWarningMessage;
-						break;
-					case MessageType.Error:
-						show = window.showErrorMessage;
-						break;
-				}
-				if (!show) {
-					return;
-				}
-				const titles = notification.commands.map(a => a.title);
-				show(notification.message, ...titles).then((selection) => {
-					for (const action of notification.commands) {
-						if (action.title === selection) {
-							const args: any[] = (action.arguments) ? action.arguments : [];
-							commands.executeCommand(action.command, ...args);
-							break;
-						}
-					}
-				});
-			});
-
-			this.languageClient.onRequest(ExecuteClientCommandRequest.type, (params) => {
-				return commands.executeCommand(params.command, ...params.arguments);
-			});
-
-			this.languageClient.onNotification(ServerNotification.type, (params) => {
-				commands.executeCommand(params.command, ...params.arguments);
-			});
-
-			this.languageClient.onRequest(ConfigurationRequest.type, (params: ConfigurationParams) => {
-				const result: any[] = [];
-				const activeEditor: TextEditor | undefined = window.activeTextEditor;
-				for (const item of params.items) {
-					const scopeUri: Uri | undefined = item.scopeUri && Uri.parse(item.scopeUri);
-					if (scopeUri && scopeUri.toString() === activeEditor?.document.uri.toString()) {
-						if (item.section === "java.format.insertSpaces") {
-							result.push(activeEditor.options.insertSpaces);
-						} else if (item.section === "java.format.tabSize") {
-							result.push(activeEditor.options.tabSize);
-						} else {
-							result.push(null);
-						}
-					} else {
-						result.push(workspace.getConfiguration(null, scopeUri).get(item.section, null /* defaultValue */));
-					}
-				}
-				return result;
-			});
-		});
-
 		this.registerCommandsForStandardServer(context, jdtEventEmitter);
 		fileEventHandler.registerFileEventHandlers(this.languageClient, context);
 
 		collectBuildFilePattern(extensions.all);
 
 		this.status = ClientStatus.initialized;
+	}
+
+	public registerLanguageClientActions(context: ExtensionContext, hasImported: boolean, jdtEventEmitter: EventEmitter<Uri>) {
+		activationProgressNotification.showProgress();
+		this.languageClient.onNotification(StatusNotification.type, (report) => {
+			switch (report.type) {
+				case 'ServiceReady':
+					apiManager.updateServerMode(ServerMode.standard);
+					apiManager.fireDidServerModeChange(ServerMode.standard);
+					apiManager.resolveServerReadyPromise();
+
+					if (extensions.onDidChange) {// Theia doesn't support this API yet
+						extensions.onDidChange(async () => {
+							await onExtensionChange(extensions.all);
+						});
+					}
+
+					registerPasteEventHandler(context, this.languageClient);
+					activationProgressNotification.hide();
+					if (!hasImported) {
+						showImportFinishNotification(context);
+					}
+					checkLombokDependency(context);
+					apiManager.getApiInstance().onDidClasspathUpdate((e: Uri) => {
+						checkLombokDependency(context);
+					});
+					// Disable the client-side snippet provider since LS is ready.
+					snippetCompletionProvider.dispose();
+					break;
+				case 'Started':
+					this.status = ClientStatus.started;
+					serverStatus.updateServerStatus(ServerStatusKind.ready);
+					commands.executeCommand('setContext', 'javaLSReady', true);
+					apiManager.updateStatus(ClientStatus.started);
+					break;
+				case 'Error':
+					this.status = ClientStatus.error;
+					serverStatus.updateServerStatus(ServerStatusKind.error);
+					apiManager.updateStatus(ClientStatus.error);
+					break;
+				case 'ProjectStatus':
+					if (report.message === "WARNING") {
+						serverStatus.updateServerStatus(ServerStatusKind.warning);
+					} else if (report.message === "OK") {
+						this.status = ClientStatus.started;
+						serverStatus.errorResolved();
+						serverStatus.updateServerStatus(ServerStatusKind.ready);
+					}
+					return;
+				case 'Starting':
+				case 'Message':
+					// message goes to progress report instead
+					break;
+			}
+			if (!serverStatus.hasErrors()) {
+				serverStatusBarProvider.updateTooltip(report.message);
+			}
+		});
+
+		this.languageClient.onNotification(ProgressReportNotification.type, (progress) => {
+			serverTasks.updateServerTask(progress);
+		});
+
+		this.languageClient.onNotification(EventNotification.type, async (notification) => {
+			switch (notification.eventType) {
+				case EventType.classpathUpdated:
+					apiManager.fireDidClasspathUpdate(Uri.parse(notification.data));
+					break;
+				case EventType.projectsImported:
+					const projectUris: Uri[] = [];
+					if (notification.data) {
+						for (const uriString of notification.data) {
+							projectUris.push(Uri.parse(uriString));
+						}
+					}
+					if (projectUris.length > 0) {
+						apiManager.fireDidProjectsImport(projectUris);
+					}
+					break;
+				case EventType.incompatibleGradleJdkIssue:
+					const options: string[] = [];
+					const info = notification.data as GradleCompatibilityInfo;
+					const highestJavaVersion = Number(info.highestJavaVersion);
+					let runtimes = await findRuntimes({ checkJavac: true, withVersion: true, withTags: true });
+					runtimes = runtimes.filter(runtime => {
+						return runtime.version.major <= highestJavaVersion;
+					});
+					sortJdksByVersion(runtimes);
+					sortJdksBySource(runtimes);
+					options.push(UPGRADE_GRADLE + info.recommendedGradleVersion);
+					if (!runtimes.length) {
+						options.push(GET_JDK);
+					} else {
+						options.push(USE_JAVA + runtimes[0].version.major + AS_GRADLE_JVM);
+					}
+					this.showGradleCompatibilityIssueNotification(info.message, options, info.projectUri, info.recommendedGradleVersion, runtimes[0]?.homedir);
+					break;
+				case EventType.upgradeGradleWrapper:
+					const neverShow: boolean | undefined = context.globalState.get<boolean>("java.neverShowUpgradeWrapperNotification");
+					if (!neverShow) {
+						const upgradeInfo = notification.data as UpgradeGradleWrapperInfo;
+						const option = `Upgrade to ${upgradeInfo.recommendedGradleVersion}`;
+						window.showWarningMessage(upgradeInfo.message, option, "Don't show again").then(async (choice) => {
+							if (choice === option) {
+								await upgradeGradle(upgradeInfo.projectUri, upgradeInfo.recommendedGradleVersion);
+							} else if (choice === "Don't show again") {
+								context.globalState.update("java.neverShowUpgradeWrapperNotification", true);
+							}
+						});
+					}
+					break;
+				default:
+					break;
+			}
+		});
+
+		this.languageClient.onNotification(ActionableNotification.type, (notification) => {
+			let show = null;
+			switch (notification.severity) {
+				case MessageType.Log:
+					show = logNotification;
+					break;
+				case MessageType.Info:
+					show = window.showInformationMessage;
+					break;
+				case MessageType.Warning:
+					show = window.showWarningMessage;
+					break;
+				case MessageType.Error:
+					show = window.showErrorMessage;
+					break;
+			}
+			if (!show) {
+				return;
+			}
+			const titles = notification.commands.map(a => a.title);
+			show(notification.message, ...titles).then((selection) => {
+				for (const action of notification.commands) {
+					if (action.title === selection) {
+						const args: any[] = (action.arguments) ? action.arguments : [];
+						commands.executeCommand(action.command, ...args);
+						break;
+					}
+				}
+			});
+		});
+
+		this.languageClient.onRequest(ExecuteClientCommandRequest.type, (params) => {
+			return commands.executeCommand(params.command, ...params.arguments);
+		});
+
+		this.languageClient.onNotification(ServerNotification.type, (params) => {
+			commands.executeCommand(params.command, ...params.arguments);
+		});
+
+		this.languageClient.onRequest(ConfigurationRequest.type, (params: ConfigurationParams) => {
+			const result: any[] = [];
+			const activeEditor: TextEditor | undefined = window.activeTextEditor;
+			for (const item of params.items) {
+				const scopeUri: Uri | undefined = item.scopeUri && Uri.parse(item.scopeUri);
+				if (scopeUri && scopeUri.toString() === activeEditor?.document.uri.toString()) {
+					if (item.section === "java.format.insertSpaces") {
+						result.push(activeEditor.options.insertSpaces);
+					} else if (item.section === "java.format.tabSize") {
+						result.push(activeEditor.options.tabSize);
+					} else {
+						result.push(null);
+					}
+				} else {
+					result.push(workspace.getConfiguration(null, scopeUri).get(item.section, null /* defaultValue */));
+				}
+			}
+			return result;
+		});
+
+		context.subscriptions.push(commands.registerCommand(GRADLE_CHECKSUM, (wrapper: string, sha256: string) => {
+			setGradleWrapperChecksum(wrapper, sha256);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.SHOW_JAVA_REFERENCES, (uri: string, position: LSPosition, locations: LSLocation[]) => {
+			commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), this.languageClient.protocol2CodeConverter.asPosition(position), locations.map(this.languageClient.protocol2CodeConverter.asLocation));
+		}));
+		context.subscriptions.push(commands.registerCommand(Commands.SHOW_JAVA_IMPLEMENTATIONS, (uri: string, position: LSPosition, locations: LSLocation[]) => {
+			commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), this.languageClient.protocol2CodeConverter.asPosition(position), locations.map(this.languageClient.protocol2CodeConverter.asLocation));
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.CONFIGURATION_UPDATE, async (uri) => {
+			await projectConfigurationUpdate(this.languageClient, uri);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH, () => setIncompleteClasspathSeverity('ignore')));
+
+		context.subscriptions.push(commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH_HELP, () => {
+			commands.executeCommand(Commands.OPEN_BROWSER, Uri.parse('https://github.com/redhat-developer/vscode-java/wiki/%22Classpath-is-incomplete%22-warning'));
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.PROJECT_CONFIGURATION_STATUS, async (uri, status) => {
+			await setProjectConfigurationUpdate(this.languageClient, uri, status);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.NULL_ANALYSIS_SET_MODE, (status) => setNullAnalysisStatus(status)));
+
+		context.subscriptions.push(commands.registerCommand(Commands.APPLY_WORKSPACE_EDIT, (obj) => {
+			applyWorkspaceEdit(obj, this.languageClient);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND, async (location: LinkLocation | Uri) => {
+			let superImplLocation: Location | undefined;
+
+			if (!location) { // comes from command palette
+				if (window.activeTextEditor?.document.languageId !== "java") {
+					return;
+				}
+				location = window.activeTextEditor.document.uri;
+			}
+
+			if (location instanceof Uri) { // comes from context menu
+				const params: TextDocumentPositionParams = {
+					textDocument: {
+						uri: location.toString(),
+					},
+					position: this.languageClient.code2ProtocolConverter.asPosition(window.activeTextEditor.selection.active),
+				};
+				const response = await this.languageClient.sendRequest(FindLinks.type, {
+					type: 'superImplementation',
+					position: params,
+				});
+
+				if (response && response.length > 0) {
+					const superImpl = response[0];
+					superImplLocation = new Location(
+						Uri.parse(superImpl.uri),
+						this.languageClient.protocol2CodeConverter.asRange(superImpl.range)
+					);
+				}
+			} else { // comes from hover information
+				superImplLocation = new Location(
+					Uri.parse(decodeBase64(location.uri)),
+					this.languageClient.protocol2CodeConverter.asRange(location.range),
+				);
+			}
+
+			if (superImplLocation) {
+				return window.showTextDocument(superImplLocation.uri, {
+					preserveFocus: true,
+					selection: superImplLocation.range,
+				});
+			} else {
+				return showNoLocationFound('No super implementation found');
+			}
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.SHOW_TYPE_HIERARCHY, (location: any) => {
+			if (location instanceof Uri) {
+				typeHierarchyTree.setTypeHierarchy(new Location(location, window.activeTextEditor.selection.active), TypeHierarchyDirection.both);
+			} else {
+				if (window.activeTextEditor?.document?.languageId !== "java") {
+					return;
+				}
+				typeHierarchyTree.setTypeHierarchy(new Location(window.activeTextEditor.document.uri, window.activeTextEditor.selection.active), TypeHierarchyDirection.both);
+			}
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.SHOW_CLASS_HIERARCHY, () => {
+			typeHierarchyTree.changeDirection(TypeHierarchyDirection.both);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.SHOW_SUPERTYPE_HIERARCHY, () => {
+			typeHierarchyTree.changeDirection(TypeHierarchyDirection.parents);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.SHOW_SUBTYPE_HIERARCHY, () => {
+			typeHierarchyTree.changeDirection(TypeHierarchyDirection.children);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.CHANGE_BASE_TYPE, async (item: TypeHierarchyItem) => {
+			typeHierarchyTree.changeBaseItem(item);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.BUILD_PROJECT, async (uris: Uri[] | Uri, isFullBuild: boolean, token: CancellationToken) => {
+			let resources: Uri[] = [];
+			if (uris instanceof Uri) {
+				resources.push(uris);
+			} else if (Array.isArray(uris)) {
+				for (const uri of uris) {
+					if (uri instanceof Uri) {
+						resources.push(uri);
+					}
+				}
+			}
+
+			if (!resources.length) {
+				resources = await askForProjects(
+					window.activeTextEditor?.document.uri,
+					"Please select the project(s) to rebuild.",
+				);
+				if (!resources?.length) {
+					return;
+				}
+			}
+
+			const params: BuildProjectParams = {
+				identifiers: resources.map((u => {
+					return { uri: u.toString() };
+				})),
+				// we can consider expose 'isFullBuild' according to users' feedback,
+				// currently set it to true by default.
+				isFullBuild: isFullBuild === undefined ? true : isFullBuild,
+			};
+
+			return window.withProgress({ location: ProgressLocation.Window }, async p => {
+				p.report({ message: 'Rebuilding projects...' });
+				return new Promise(async (resolve, reject) => {
+					const start = new Date().getTime();
+
+					let res: CompileWorkspaceStatus;
+					try {
+						res = token ? await this.languageClient.sendRequest(BuildProjectRequest.type, params, token) :
+							await this.languageClient.sendRequest(BuildProjectRequest.type, params);
+					} catch (error) {
+						if (error && error.code === -32800) { // Check if the request is cancelled.
+							res = CompileWorkspaceStatus.cancelled;
+						}
+						reject(error);
+					}
+
+					const elapsed = new Date().getTime() - start;
+					const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
+					setTimeout(() => { // set a timeout so user would still see the message when build time is short
+						resolve(res);
+					}, humanVisibleDelay);
+				});
+			});
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.COMPILE_WORKSPACE, (isFullCompile: boolean, token?: CancellationToken) => {
+			return window.withProgress({ location: ProgressLocation.Window }, async p => {
+				if (typeof isFullCompile !== 'boolean') {
+					const selection = await window.showQuickPick(['Incremental', 'Full'], { placeHolder: 'please choose compile type:' });
+					isFullCompile = selection !== 'Incremental';
+				}
+				p.report({ message: 'Compiling workspace...' });
+				const start = new Date().getTime();
+				let res: CompileWorkspaceStatus;
+				try {
+					res = token ? await this.languageClient.sendRequest(CompileWorkspaceRequest.type, isFullCompile, token)
+						: await this.languageClient.sendRequest(CompileWorkspaceRequest.type, isFullCompile);
+				} catch (error) {
+					if (error && error.code === -32800) { // Check if the request is cancelled.
+						res = CompileWorkspaceStatus.cancelled;
+					} else {
+						throw error;
+					}
+				}
+
+				const elapsed = new Date().getTime() - start;
+				const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
+				return new Promise((resolve, reject) => {
+					setTimeout(() => { // set a timeout so user would still see the message when build time is short
+						if (res === CompileWorkspaceStatus.succeed) {
+							resolve(res);
+						} else {
+							reject(res);
+						}
+					}, humanVisibleDelay);
+				});
+			});
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.UPDATE_SOURCE_ATTACHMENT_CMD, async (classFileUri: Uri): Promise<boolean> => {
+			const resolveRequest: SourceAttachmentRequest = {
+				classFileUri: classFileUri.toString(),
+			};
+			const resolveResult: SourceAttachmentResult = await <SourceAttachmentResult>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.RESOLVE_SOURCE_ATTACHMENT, JSON.stringify(resolveRequest));
+			if (resolveResult.errorMessage) {
+				window.showErrorMessage(resolveResult.errorMessage);
+				return false;
+			}
+
+			const attributes: SourceAttachmentAttribute = resolveResult.attributes || {};
+			const defaultPath = attributes.sourceAttachmentPath || attributes.jarPath;
+			const sourceFileUris: Uri[] = await window.showOpenDialog({
+				defaultUri: defaultPath ? Uri.file(defaultPath) : null,
+				openLabel: 'Select Source File',
+				canSelectFiles: true,
+				canSelectFolders: false,
+				canSelectMany: false,
+				filters: {
+					// eslint-disable-next-line @typescript-eslint/naming-convention
+					'Source files': ['jar', 'zip']
+				},
+			});
+
+			if (sourceFileUris && sourceFileUris.length) {
+				const updateRequest: SourceAttachmentRequest = {
+					classFileUri: classFileUri.toString(),
+					attributes: {
+						...attributes,
+						sourceAttachmentPath: sourceFileUris[0].fsPath
+					},
+				};
+				const updateResult: SourceAttachmentResult = await <SourceAttachmentResult>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.UPDATE_SOURCE_ATTACHMENT, JSON.stringify(updateRequest));
+				if (updateResult.errorMessage) {
+					window.showErrorMessage(updateResult.errorMessage);
+					return false;
+				}
+
+				// Notify jdt content provider to rerender the classfile contents.
+				jdtEventEmitter.fire(classFileUri);
+				return true;
+			}
+		}));
+
+		buildPath.registerCommands(context);
+		sourceAction.registerCommands(this.languageClient, context);
+		refactorAction.registerCommands(this.languageClient, context);
+		pasteAction.registerCommands(this.languageClient, context);
+
+		excludeProjectSettingsFiles();
+
+		context.subscriptions.push(languages.registerCodeActionsProvider({ scheme: 'file', language: 'java' }, new RefactorDocumentProvider(), RefactorDocumentProvider.metadata));
+		context.subscriptions.push(commands.registerCommand(Commands.LEARN_MORE_ABOUT_REFACTORING, async (kind: CodeActionKind) => {
+			const sectionId: string = javaRefactorKinds.get(kind) || '';
+			markdownPreviewProvider.show(context.asAbsolutePath(path.join('document', `${Commands.LEARN_MORE_ABOUT_REFACTORING}.md`)), 'Java Refactoring', sectionId, context);
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.CREATE_MODULE_INFO_COMMAND, async () => {
+			const uri = await askForProjects(
+				window.activeTextEditor?.document.uri,
+				"Please select the project to create module-info.java",
+				false,
+			);
+			if (!uri?.length) {
+				return;
+			}
+
+			const moduleInfoUri: string = await commands.executeCommand(
+				Commands.EXECUTE_WORKSPACE_COMMAND,
+				Commands.CREATE_MODULE_INFO,
+				uri[0].toString(),
+			);
+
+			if (moduleInfoUri) {
+				await window.showTextDocument(Uri.parse(moduleInfoUri));
+			}
+		}));
+
+		context.subscriptions.push(commands.registerCommand(Commands.UPGRADE_GRADLE_WRAPPER, (projectUri: string, version?: string) => {
+			upgradeGradle(projectUri, version);
+		}));
+
+		languages.registerCodeActionsProvider({
+			language: "xml",
+			scheme: "file",
+			pattern: "**/pom.xml"
+		}, new PomCodeActionProvider(context), pomCodeActionMetadata);
+
+		languages.registerCodeActionsProvider({
+			scheme: "file",
+			pattern: "**/{gradle/wrapper/gradle-wrapper.properties,build.gradle,build.gradle.kts,settings.gradle,settings.gradle.kts}"
+		}, new GradleCodeActionProvider(), gradleCodeActionMetadata);
+
+		if (languages.registerInlayHintsProvider) {
+			context.subscriptions.push(languages.registerInlayHintsProvider(JAVA_SELECTOR, new JavaInlayHintsProvider(this.languageClient)));
+		}
 	}
 
 	private showGradleCompatibilityIssueNotification(message: string, options: string[], projectUri: string, gradleVersion: string, newJavaHome: string) {
@@ -311,302 +600,12 @@ export class StandardLanguageClient {
 
 		context.subscriptions.push(commands.registerCommand(Commands.OPEN_OUTPUT, () => this.languageClient.outputChannel.show(ViewColumn.Three)));
 		context.subscriptions.push(commands.registerCommand(Commands.SHOW_SERVER_TASK_STATUS, () => serverTaskPresenter.presentServerTaskView()));
-
-		this.languageClient.onReady().then(() => {
-			context.subscriptions.push(commands.registerCommand(GRADLE_CHECKSUM, (wrapper: string, sha256: string) => {
-				setGradleWrapperChecksum(wrapper, sha256);
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.SHOW_JAVA_REFERENCES, (uri: string, position: LSPosition, locations: LSLocation[]) => {
-				commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), this.languageClient.protocol2CodeConverter.asPosition(position), locations.map(this.languageClient.protocol2CodeConverter.asLocation));
-			}));
-			context.subscriptions.push(commands.registerCommand(Commands.SHOW_JAVA_IMPLEMENTATIONS, (uri: string, position: LSPosition, locations: LSLocation[]) => {
-				commands.executeCommand(Commands.SHOW_REFERENCES, Uri.parse(uri), this.languageClient.protocol2CodeConverter.asPosition(position), locations.map(this.languageClient.protocol2CodeConverter.asLocation));
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.CONFIGURATION_UPDATE, uri => projectConfigurationUpdate(this.languageClient, uri)));
-
-			context.subscriptions.push(commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH, () => setIncompleteClasspathSeverity('ignore')));
-
-			context.subscriptions.push(commands.registerCommand(Commands.IGNORE_INCOMPLETE_CLASSPATH_HELP, () => {
-				commands.executeCommand(Commands.OPEN_BROWSER, Uri.parse('https://github.com/redhat-developer/vscode-java/wiki/%22Classpath-is-incomplete%22-warning'));
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.PROJECT_CONFIGURATION_STATUS, (uri, status) => setProjectConfigurationUpdate(this.languageClient, uri, status)));
-
-			context.subscriptions.push(commands.registerCommand(Commands.NULL_ANALYSIS_SET_MODE, (status) => setNullAnalysisStatus(status)));
-
-			context.subscriptions.push(commands.registerCommand(Commands.APPLY_WORKSPACE_EDIT, (obj) => {
-				applyWorkspaceEdit(obj, this.languageClient);
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.NAVIGATE_TO_SUPER_IMPLEMENTATION_COMMAND, async (location: LinkLocation | Uri) => {
-				let superImplLocation: Location | undefined;
-
-				if (!location) { // comes from command palette
-					if (window.activeTextEditor?.document.languageId !== "java") {
-						return;
-					}
-					location = window.activeTextEditor.document.uri;
-				}
-
-				if (location instanceof Uri) { // comes from context menu
-					const params: TextDocumentPositionParams = {
-						textDocument: {
-							uri: location.toString(),
-						},
-						position: this.languageClient.code2ProtocolConverter.asPosition(window.activeTextEditor.selection.active),
-					};
-					const response = await this.languageClient.sendRequest(FindLinks.type, {
-						type: 'superImplementation',
-						position: params,
-					});
-
-					if (response && response.length > 0) {
-						const superImpl = response[0];
-						superImplLocation = new Location(
-							Uri.parse(superImpl.uri),
-							this.languageClient.protocol2CodeConverter.asRange(superImpl.range)
-						);
-					}
-				} else { // comes from hover information
-					superImplLocation = new Location(
-						Uri.parse(decodeBase64(location.uri)),
-						this.languageClient.protocol2CodeConverter.asRange(location.range),
-					);
-				}
-
-				if (superImplLocation) {
-					return window.showTextDocument(superImplLocation.uri, {
-						preserveFocus: true,
-						selection: superImplLocation.range,
-					});
-				} else {
-					return showNoLocationFound('No super implementation found');
-				}
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.SHOW_TYPE_HIERARCHY, (location: any) => {
-				if (location instanceof Uri) {
-					typeHierarchyTree.setTypeHierarchy(new Location(location, window.activeTextEditor.selection.active), TypeHierarchyDirection.both);
-				} else {
-					if (window.activeTextEditor?.document?.languageId !== "java") {
-						return;
-					}
-					typeHierarchyTree.setTypeHierarchy(new Location(window.activeTextEditor.document.uri, window.activeTextEditor.selection.active), TypeHierarchyDirection.both);
-				}
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.SHOW_CLASS_HIERARCHY, () => {
-				typeHierarchyTree.changeDirection(TypeHierarchyDirection.both);
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.SHOW_SUPERTYPE_HIERARCHY, () => {
-				typeHierarchyTree.changeDirection(TypeHierarchyDirection.parents);
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.SHOW_SUBTYPE_HIERARCHY, () => {
-				typeHierarchyTree.changeDirection(TypeHierarchyDirection.children);
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.CHANGE_BASE_TYPE, async (item: TypeHierarchyItem) => {
-				typeHierarchyTree.changeBaseItem(item);
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.BUILD_PROJECT, async (uris: Uri[] | Uri, isFullBuild: boolean, token: CancellationToken) => {
-				let resources: Uri[] = [];
-				if (uris instanceof Uri) {
-					resources.push(uris);
-				} else if (Array.isArray(uris)) {
-					for (const uri of uris) {
-						if (uri instanceof Uri) {
-							resources.push(uri);
-						}
-					}
-				}
-
-				if (!resources.length) {
-					resources = await askForProjects(
-						window.activeTextEditor?.document.uri,
-						"Please select the project(s) to rebuild.",
-					);
-					if (!resources?.length) {
-						return;
-					}
-				}
-
-				const params: BuildProjectParams = {
-					identifiers: resources.map((u => {
-						return { uri: u.toString() };
-					})),
-					// we can consider expose 'isFullBuild' according to users' feedback,
-					// currently set it to true by default.
-					isFullBuild: isFullBuild === undefined ? true : isFullBuild,
-				};
-
-				return window.withProgress({ location: ProgressLocation.Window }, async p => {
-					p.report({ message: 'Rebuilding projects...' });
-					return new Promise(async (resolve, reject) => {
-						const start = new Date().getTime();
-
-						let res: CompileWorkspaceStatus;
-						try {
-							res = token ? await this.languageClient.sendRequest(BuildProjectRequest.type, params, token) :
-								await this.languageClient.sendRequest(BuildProjectRequest.type, params);
-						} catch (error) {
-							if (error && error.code === -32800) { // Check if the request is cancelled.
-								res = CompileWorkspaceStatus.cancelled;
-							}
-							reject(error);
-						}
-
-						const elapsed = new Date().getTime() - start;
-						const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
-						setTimeout(() => { // set a timeout so user would still see the message when build time is short
-							resolve(res);
-						}, humanVisibleDelay);
-					});
-				});
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.COMPILE_WORKSPACE, (isFullCompile: boolean, token?: CancellationToken) => {
-				return window.withProgress({ location: ProgressLocation.Window }, async p => {
-					if (typeof isFullCompile !== 'boolean') {
-						const selection = await window.showQuickPick(['Incremental', 'Full'], { placeHolder: 'please choose compile type:' });
-						isFullCompile = selection !== 'Incremental';
-					}
-					p.report({ message: 'Compiling workspace...' });
-					const start = new Date().getTime();
-					let res: CompileWorkspaceStatus;
-					try {
-						res = token ? await this.languageClient.sendRequest(CompileWorkspaceRequest.type, isFullCompile, token)
-							: await this.languageClient.sendRequest(CompileWorkspaceRequest.type, isFullCompile);
-					} catch (error) {
-						if (error && error.code === -32800) { // Check if the request is cancelled.
-							res = CompileWorkspaceStatus.cancelled;
-						} else {
-							throw error;
-						}
-					}
-
-					const elapsed = new Date().getTime() - start;
-					const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
-					return new Promise((resolve, reject) => {
-						setTimeout(() => { // set a timeout so user would still see the message when build time is short
-							if (res === CompileWorkspaceStatus.succeed) {
-								resolve(res);
-							} else {
-								reject(res);
-							}
-						}, humanVisibleDelay);
-					});
-				});
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.UPDATE_SOURCE_ATTACHMENT_CMD, async (classFileUri: Uri): Promise<boolean> => {
-				const resolveRequest: SourceAttachmentRequest = {
-					classFileUri: classFileUri.toString(),
-				};
-				const resolveResult: SourceAttachmentResult = await <SourceAttachmentResult>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.RESOLVE_SOURCE_ATTACHMENT, JSON.stringify(resolveRequest));
-				if (resolveResult.errorMessage) {
-					window.showErrorMessage(resolveResult.errorMessage);
-					return false;
-				}
-
-				const attributes: SourceAttachmentAttribute = resolveResult.attributes || {};
-				const defaultPath = attributes.sourceAttachmentPath || attributes.jarPath;
-				const sourceFileUris: Uri[] = await window.showOpenDialog({
-					defaultUri: defaultPath ? Uri.file(defaultPath) : null,
-					openLabel: 'Select Source File',
-					canSelectFiles: true,
-					canSelectFolders: false,
-					canSelectMany: false,
-					filters: {
-						// eslint-disable-next-line @typescript-eslint/naming-convention
-						'Source files': ['jar', 'zip']
-					},
-				});
-
-				if (sourceFileUris && sourceFileUris.length) {
-					const updateRequest: SourceAttachmentRequest = {
-						classFileUri: classFileUri.toString(),
-						attributes: {
-							...attributes,
-							sourceAttachmentPath: sourceFileUris[0].fsPath
-						},
-					};
-					const updateResult: SourceAttachmentResult = await <SourceAttachmentResult>commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.UPDATE_SOURCE_ATTACHMENT, JSON.stringify(updateRequest));
-					if (updateResult.errorMessage) {
-						window.showErrorMessage(updateResult.errorMessage);
-						return false;
-					}
-
-					// Notify jdt content provider to rerender the classfile contents.
-					jdtEventEmitter.fire(classFileUri);
-					return true;
-				}
-			}));
-
-			buildPath.registerCommands(context);
-			sourceAction.registerCommands(this.languageClient, context);
-			refactorAction.registerCommands(this.languageClient, context);
-			pasteAction.registerCommands(this.languageClient, context);
-
-			excludeProjectSettingsFiles();
-
-			context.subscriptions.push(languages.registerCodeActionsProvider({ scheme: 'file', language: 'java' }, new RefactorDocumentProvider(), RefactorDocumentProvider.metadata));
-			context.subscriptions.push(commands.registerCommand(Commands.LEARN_MORE_ABOUT_REFACTORING, async (kind: CodeActionKind) => {
-				const sectionId: string = javaRefactorKinds.get(kind) || '';
-				markdownPreviewProvider.show(context.asAbsolutePath(path.join('document', `${Commands.LEARN_MORE_ABOUT_REFACTORING}.md`)), 'Java Refactoring', sectionId, context);
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.CREATE_MODULE_INFO_COMMAND, async () => {
-				const uri = await askForProjects(
-					window.activeTextEditor?.document.uri,
-					"Please select the project to create module-info.java",
-					false,
-				);
-				if (!uri?.length) {
-					return;
-				}
-
-				const moduleInfoUri: string = await commands.executeCommand(
-					Commands.EXECUTE_WORKSPACE_COMMAND,
-					Commands.CREATE_MODULE_INFO,
-					uri[0].toString(),
-				);
-
-				if (moduleInfoUri) {
-					await window.showTextDocument(Uri.parse(moduleInfoUri));
-				}
-			}));
-
-			context.subscriptions.push(commands.registerCommand(Commands.UPGRADE_GRADLE_WRAPPER, (projectUri: string, version?: string) => {
-				upgradeGradle(projectUri, version);
-			}));
-
-			languages.registerCodeActionsProvider({
-				language: "xml",
-				scheme: "file",
-				pattern: "**/pom.xml"
-			}, new PomCodeActionProvider(context), pomCodeActionMetadata);
-
-			languages.registerCodeActionsProvider({
-				scheme: "file",
-				pattern: "**/{gradle/wrapper/gradle-wrapper.properties,build.gradle,build.gradle.kts,settings.gradle,settings.gradle.kts}"
-			}, new GradleCodeActionProvider(), gradleCodeActionMetadata);
-
-			if (languages.registerInlayHintsProvider) {
-				context.subscriptions.push(languages.registerInlayHintsProvider(JAVA_SELECTOR, new JavaInlayHintsProvider(this.languageClient)));
-			}
-
-		});
 	}
 
-	public start(): void {
+	public start(): Promise<void> {
 		if (this.languageClient && this.status === ClientStatus.initialized) {
-			this.languageClient.start();
 			this.status = ClientStatus.starting;
+			return this.languageClient.start();
 		}
 	}
 
@@ -677,7 +676,7 @@ function setIncompleteClasspathSeverity(severity: string) {
 	);
 }
 
-function setProjectConfigurationUpdate(languageClient: LanguageClient, uri: Uri, status: FeatureStatus) {
+async function setProjectConfigurationUpdate(languageClient: LanguageClient, uri: Uri, status: FeatureStatus) {
 	const config = getJavaConfiguration();
 	const section = 'configuration.updateBuildConfiguration';
 
@@ -687,7 +686,7 @@ function setProjectConfigurationUpdate(languageClient: LanguageClient, uri: Uri,
 		(error) => logger.error(error)
 	);
 	if (status !== FeatureStatus.disabled) {
-		projectConfigurationUpdate(languageClient, uri);
+		await projectConfigurationUpdate(languageClient, uri);
 	}
 }
 
@@ -717,10 +716,10 @@ export function showNoLocationFound(message: string): void {
 	);
 }
 
-export function applyWorkspaceEdit(obj, languageClient): Thenable<boolean> {
-	const edit = languageClient.protocol2CodeConverter.asWorkspaceEdit(obj);
-	if (edit) {
-		return workspace.applyEdit(edit);
+export async function applyWorkspaceEdit(workspaceEdit: WorkspaceEdit, languageClient: LanguageClient): Promise<boolean> {
+	const codeEdit = await languageClient.protocol2CodeConverter.asWorkspaceEdit(workspaceEdit);
+	if (codeEdit) {
+		return await workspace.applyEdit(codeEdit);
 	} else {
 		return Promise.resolve(true);
 	}

--- a/src/standardLanguageClientUtils.ts
+++ b/src/standardLanguageClientUtils.ts
@@ -33,11 +33,11 @@ export async function projectConfigurationUpdate(languageClient: LanguageClient,
 	}
 
 	if (resources.length === 1) {
-		languageClient.sendNotification(ProjectConfigurationUpdateRequest.type, {
+		await languageClient.sendNotification(ProjectConfigurationUpdateRequest.type, {
 			uri: resources[0].toString(),
 		});
 	} else if (resources.length > 1) {
-		languageClient.sendNotification(ProjectConfigurationUpdateRequest.typeV2, {
+		await languageClient.sendNotification(ProjectConfigurationUpdateRequest.typeV2, {
 			identifiers: resources.map(r => {
 				return { uri: r.toString() };
 			}),


### PR DESCRIPTION
This PR is a part of #2376, to reduce the complexity of that PR. Type Hierarchy support has been introduced since language-client 8.0.0-next.4 so we should update this dependency, the language-client version requires vscode 1.61.0 for compiling, so I update this dependency as well.

- for notification part: see https://github.com/microsoft/vscode-languageserver-node#3170-next-protocol-800-next-json-rpc-800-next-client-and-800-next-server, now all `sendNotification` methods will return a promise.
 
This update is incompatible with current Theia. see: https://github.com/eclipse-theia/theia/issues/10993