### PR TITLE
Fix show correct build file status when conflicts

### DIFF
--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -235,7 +235,7 @@ class RuntimeStatusBarProvider implements Disposable {
 			let buildFilePath: string | undefined;
 			const activeBuildTool: string | undefined = context.workspaceState.get(ACTIVE_BUILD_TOOL_STATE);
 			if (!activeBuildTool) {
-				if (!hasBuildToolConflicts()) {
+				if (!(await hasBuildToolConflicts())) {
 					// only one build tool exists in the project
 					buildFilePath = await this.getBuildFilePathFromNames(projectPath, ["pom.xml", "build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"]);
 				} else {


### PR DESCRIPTION
`hasBuildToolConflicts()` is an async function, we should await it here.

Signed-off-by: Shi Chen <chenshi@microsoft.com>