### PR TITLE
expose command to get current workspace path

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -256,4 +256,6 @@ export namespace Commands {
     export const RUNTIME_VALIDATION_OPEN = 'java.runtimeValidation.open';
 
     export const RESOLVE_WORKSPACE_SYMBOL = 'java.project.resolveWorkspaceSymbol';
+
+	export const GET_WORKSPACE_PATH = '_java.workspace.path';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -377,6 +377,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_WORKSPACE, () => cleanWorkspace(workspacePath)));
 
+			context.subscriptions.push(commands.registerCommand(Commands.GET_WORKSPACE_PATH, () => workspacePath));
+
 			context.subscriptions.push(onConfigurationChange(workspacePath));
 
 			/**


### PR DESCRIPTION
For workspace without any open folder, we are using a random temp folder as workspace storage, e.g. `vscodesws_xxxxx`.

So from outside the extension, it's impossible for me to inspect client.log to find out potential error. So I'd like to request such an internal command as implemented in this PR. 