### PR TITLE
Revert "Remove 'java.completion.overwrite'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
  * enhancement - Show server status through the language status item. See [#2351](https://github.com/redhat-developer/vscode-java/issues/2351).
  * enhancement - Add code action to extract lambda body to method. See [JLS#2027](https://github.com/eclipse/eclipse.jdt.ls/issues/2027).
  * enhancement - Navigate to class declaration. See [#2132](https://github.com/redhat-developer/vscode-java/pull/2132).
- * enhancement - Support completion insert/replace capability. See [#2343](https://github.com/redhat-developer/vscode-java/pull/2343).
  * bug fix - Provide file & type comments for newly created compilation units. See [JLS#2047](https://github.com/eclipse/eclipse.jdt.ls/pull/2047).
  * bug fix - Code snippets should be usable even before LS done resolving dependencies. See [#684](https://github.com/redhat-developer/vscode-java/issues/684).
  * bug fix - Fix an occurrence of duplicate quick fixes at the line level See [#2339](https://github.com/redhat-developer/vscode-java/issues/2339).

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The following settings are supported:
 * `java.autobuild.enabled` : Enable/disable the 'auto build'.
 * `java.maxConcurrentBuilds`: Set max simultaneous project builds.
 * `java.completion.enabled` : Enable/disable code completion support.
+* `java.completion.overwrite` : When set to true, code completion overwrites the current text. When set to false, code is simply added instead.
 * `java.completion.guessMethodArguments` : When set to true, method arguments are guessed when a method is selected from as list of code assist proposals.
 * `java.completion.filteredTypes`: Defines the type filters. All types whose fully qualified name matches the selected filter strings will be ignored in content assist or quick fix proposals and when organizing imports. For example 'java.awt.*' will hide all types from the awt packages.
 * `java.completion.favoriteStaticMembers` : Defines a list of static members or types with static members.
@@ -202,9 +203,6 @@ The following settings are supported:
 
 New in 1.5.0:
 * `java.inlayHints.parameterNames.enabled`: Enable/disable inlay hints for parameter names. Supported values are: `none`(Disable parameter name hints), `literals`(Enable parameter name hints only for literal arguments) and `all`(Enable parameter name hints for literal and non-literal arguments). Defaults to `literals`.
-
-Removed in 1.5.0:
-* `java.completion.overwrite`: Please use `editor.suggest.insertMode` instead. Meanwhile, you can quickly switch to another mode by pressing `Shift` + `Tab` or `Shift` + `Enter` (the shortcut may be different depending on the local keymap settings).
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -477,6 +477,12 @@
           "description": "Enable/disable code completion support",
           "scope": "window"
         },
+        "java.completion.overwrite": {
+          "type": "boolean",
+          "default": true,
+          "description": "When set to true, code completion overwrites the current text. When set to false, code is simply added instead.",
+          "scope": "window"
+        },
         "java.completion.guessMethodArguments": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
See: https://github.com/redhat-developer/vscode-java/issues/2406

This reverts commit 8c21e1ccc8e79a5d6c759d9bdc68e81d9321cd64

Signed-off-by: sheche <sheche@microsoft.com>