### PR TITLE
Unexpected 'Project xxx has no explicit encoding set' warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,14 @@ The following settings are supported:
  * `java.quickfix.showAt` : Show quickfixes at the problem or line level.
  * `java.configuration.workspaceCacheLimit` : The number of days (if enabled) to keep unused workspace cache data. Beyond this limit, cached workspace data may be removed.
  * `java.import.generatesMetadataFilesAtProjectRoot` : Specify whether the project metadata files(.project, .classpath, .factorypath, .settings/) will be generated at the project root. Defaults to `false`.
- * `java.inlayHints.parameterNames.enabled`: Enable/disable inlay hints for parameter names. Supported values are: `none`(isable parameter name hints), `literals`(Enable parameter name hints only for literal arguments) and `all`(Enable parameter name hints for literal and non-literal arguments). Defaults to `literals`.
+ * `java.inlayHints.parameterNames.enabled`: Enable/disable inlay hints for parameter names. Supported values are: `none`(disable parameter name hints), `literals`(Enable parameter name hints only for literal arguments) and `all`(Enable parameter name hints for literal and non-literal arguments). Defaults to `literals`.
 
-New in 1.6.0:
+New in 1.6.0
 * `java.signatureHelp.description.enabled`: Enable/disable to show the description in signature help. Defaults to `false`.
+* `java.project.encoding`: Project encoding settings.
+  - `ignore`: Ignore project encoding settings (default).
+  - `warning`: Show warning if a project has no explicit encoding set.
+  - `setDefault`: Set the default workspace encoding settings.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -880,6 +880,21 @@
           "default": "literals",
           "markdownDescription": "Enable/disable inlay hints for parameter names:\n```java\n\nInteger.valueOf(/* s: */ '123', /* radix: */ 10)\n \n```\n",
           "scope": "window"
+        },
+        "java.project.encoding": {
+          "enum": [
+            "ignore",
+            "warning",
+            "setDefault"
+          ],
+          "enumDescriptions": [
+            "Ignore project encoding settings",
+            "Show warning if a project has no explicit encoding set",
+            "Set the default workspace encoding settings"
+          ],
+          "default": "ignore",
+          "markdownDescription": "Project encoding settings",
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
Fixes #2416 
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/2061

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>