### PR TITLE
Trigger signature help on completion item selected

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -246,7 +246,8 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						resolveAdditionalTextEditsSupport: true,
 						advancedIntroduceParameterRefactoringSupport: true,
 						actionableRuntimeNotificationSupport: true,
-						shouldLanguageServerExitOnShutdown: true
+						shouldLanguageServerExitOnShutdown: true,
+						onCompletionItemSelectedCommand: "editor.action.triggerParameterHints",
 					},
 					triggerFiles,
 				},


### PR DESCRIPTION
requires https://github.com/eclipse/eclipse.jdt.ls/pull/2065

Now when a completion item is selected, it will automatically trigger signature help:

![a](https://user-images.githubusercontent.com/6193897/164412659-f3f8bfef-e912-4db2-b5a8-833c30ff578b.gif)

The value of the setting `java.signatureHelp.enabled` is still disabled by default. The reason is that, currently we cannot get which item is selected and provide that signature correctly. Considering method like `System.out.println()`, which has multiple overload versions, the current implementation won't work.

![a](https://user-images.githubusercontent.com/6193897/164414724-74280b47-91a4-48c3-89f7-8c29f3a86a2b.gif)

To solve this problem, we can leverage the command field of the completion item. Send back the selected one's information and cache it. But that needs some refactoring works to be done in IntelliCode as well. So currently, just keep it to `false`.

Signed-off-by: sheche <sheche@microsoft.com>