### PR TITLE
Support Gradle invalid type code error check

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -257,5 +257,7 @@ export namespace Commands {
 
     export const RESOLVE_WORKSPACE_SYMBOL = 'java.project.resolveWorkspaceSymbol';
 
-	export const GET_WORKSPACE_PATH = '_java.workspace.path';
+    export const GET_WORKSPACE_PATH = '_java.workspace.path';
+
+    export const UPGRADE_GRADLE_WRAPPER = '_java.gradle.upgradeWrapper';
 }

--- a/src/gradle/gradleCodeActionProvider.ts
+++ b/src/gradle/gradleCodeActionProvider.ts
@@ -10,7 +10,8 @@ export class GradleCodeActionProvider implements CodeActionProvider<CodeAction> 
 
 	private static UPGRADE_GRADLE_WRAPPER_TITLE = "Upgrade Gradle Wrapper";
 	private static WRAPPER_PROPERTIES_DESCRIPTOR = "gradle/wrapper/gradle-wrapper.properties";
-	private static GRADLE_INVALID_TYPE_CODE_MESSAGE = "Exact exceptions are not shown due to an outdated Gradle version, please consider to update your Gradle version.";
+	private static GRADLE_PROBLEM_ID = 0x00080000;
+	private static GRADLE_INVALID_TYPE_CODE_ID = GradleCodeActionProvider.GRADLE_PROBLEM_ID + 1;
 
 	constructor(context: ExtensionContext) {
 		context.subscriptions.push(commands.registerCommand(Commands.UPGRADE_GRADLE_WRAPPER, (projectUri: string) => {
@@ -29,7 +30,7 @@ export class GradleCodeActionProvider implements CodeActionProvider<CodeAction> 
 		const codeActions = [];
 		for (const diagnostic of diagnostics) {
 			const documentUri = document.uri.toString();
-			if (documentUri.endsWith(GradleCodeActionProvider.WRAPPER_PROPERTIES_DESCRIPTOR) && diagnostic.message === GradleCodeActionProvider.GRADLE_INVALID_TYPE_CODE_MESSAGE) {
+			if (documentUri.endsWith(GradleCodeActionProvider.WRAPPER_PROPERTIES_DESCRIPTOR) && diagnostic.code === GradleCodeActionProvider.GRADLE_INVALID_TYPE_CODE_ID.toString()) {
 				const projectPath = path.resolve(Uri.parse(documentUri).fsPath, "..", "..", "..").normalize();
 				if (await fse.pathExists(projectPath)) {
 					const projectUri = Uri.file(projectPath).toString();

--- a/src/gradle/gradleCodeActionProvider.ts
+++ b/src/gradle/gradleCodeActionProvider.ts
@@ -23,7 +23,7 @@ export class GradleCodeActionProvider implements CodeActionProvider<CodeAction> 
 		if (context?.diagnostics?.length && context.diagnostics[0].source === "Java") {
 			return this.provideGradleCodeActions(document, context.diagnostics);
 		}
-		return undefined;
+		return [];
 	}
 
 	private async provideGradleCodeActions(document: TextDocument, diagnostics: readonly Diagnostic[]): Promise<CodeAction[]> {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -59,6 +59,7 @@ export enum EventType {
     ClasspathUpdated = 100,
     ProjectsImported = 200,
     IncompatibleGradleJdkIssue = 300,
+	UpgradeGradleWrapper = 400,
 }
 
 export enum CompileWorkspaceStatus {
@@ -413,4 +414,10 @@ export interface GradleCompatibilityInfo {
     message: string;
     highestJavaVersion: string;
     recommendedGradleVersion: string;
+}
+
+export interface UpgradeGradleWrapperInfo {
+	projectUri: string;
+	message: string;
+	recommendedGradleVersion: string;
 }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -7,7 +7,7 @@ import { prepareExecutable, awaitServerConnection } from "./javaServerStarter";
 import { getJavaConfig, applyWorkspaceEdit } from "./extension";
 import { LanguageClientOptions, Position as LSPosition, Location as LSLocation, MessageType, TextDocumentPositionParams, ConfigurationRequest, ConfigurationParams } from "vscode-languageclient";
 import { LanguageClient, StreamInfo } from "vscode-languageclient/node";
-import { CompileWorkspaceRequest, CompileWorkspaceStatus, SourceAttachmentRequest, SourceAttachmentResult, SourceAttachmentAttribute, ProjectConfigurationUpdateRequest, FeatureStatus, StatusNotification, ProgressReportNotification, ActionableNotification, ExecuteClientCommandRequest, ServerNotification, EventNotification, EventType, LinkLocation, FindLinks, GradleCompatibilityInfo } from "./protocol";
+import { CompileWorkspaceRequest, CompileWorkspaceStatus, SourceAttachmentRequest, SourceAttachmentResult, SourceAttachmentAttribute, ProjectConfigurationUpdateRequest, FeatureStatus, StatusNotification, ProgressReportNotification, ActionableNotification, ExecuteClientCommandRequest, ServerNotification, EventNotification, EventType, LinkLocation, FindLinks, GradleCompatibilityInfo, UpgradeGradleWrapperInfo } from "./protocol";
 import { setGradleWrapperChecksum, excludeProjectSettingsFiles, ServerMode } from "./settings";
 import { onExtensionChange, collectBuildFilePattern } from "./plugin";
 import { activationProgressNotification, serverTaskPresenter } from "./serverTaskPresenter";
@@ -35,6 +35,7 @@ import { pomCodeActionMetadata, PomCodeActionProvider } from "./pom/pomCodeActio
 import { findRuntimes, IJavaRuntime } from "jdk-utils";
 import { snippetCompletionProvider } from "./snippetCompletionProvider";
 import { JavaInlayHintsProvider } from "./inlayHintsProvider";
+import { gradleCodeActionMetadata, GradleCodeActionProvider } from "./gradle/gradleCodeActionProvider";
 
 const extensionName = 'Language Support for Java';
 const GRADLE_CHECKSUM = "gradle/checksum/prompt";
@@ -183,7 +184,22 @@ export class StandardLanguageClient {
 						} else {
 							options.push(USE_JAVA + runtimes[0].version.major + AS_GRADLE_JVM);
 						}
-						this.showGradleCompatibilityIssueNotification(info.message, options, info.projectUri, runtimes[0]?.homedir);
+						this.showGradleCompatibilityIssueNotification(info.message, options, info.projectUri, info.recommendedGradleVersion, runtimes[0]?.homedir);
+						break;
+					case EventType.UpgradeGradleWrapper:
+						const neverShow: boolean | undefined = context.globalState.get<boolean>("java.neverShowUpgradeWrapperNotification");
+						if (!neverShow) {
+							const upgradeInfo = notification.data as UpgradeGradleWrapperInfo;
+							const option = `Upgrade to ${upgradeInfo.recommendedGradleVersion}`;
+							window.showWarningMessage(upgradeInfo.message, option, "Don't show again").then(async (choice) => {
+								if (choice === option) {
+									await upgradeGradle(upgradeInfo.projectUri, upgradeInfo.recommendedGradleVersion);
+								} else if (choice === "Don't show again") {
+									context.globalState.update("java.neverShowUpgradeWrapperNotification", true);
+								}
+							});
+						}
+						break;
 					default:
 						break;
 				}
@@ -257,7 +273,7 @@ export class StandardLanguageClient {
 		this.status = ClientStatus.Initialized;
 	}
 
-	private showGradleCompatibilityIssueNotification(message: string, options: string[], projectUri: string, newJavaHome: string) {
+	private showGradleCompatibilityIssueNotification(message: string, options: string[], projectUri: string, gradleVersion: string, newJavaHome: string) {
 		window.showErrorMessage(message + " [Learn More](https://docs.gradle.org/current/userguide/compatibility.html)", ...options).then(async (choice) => {
 			if (choice === GET_JDK) {
 				commands.executeCommand(Commands.OPEN_BROWSER, Uri.parse(getJdkUrl()));
@@ -266,31 +282,7 @@ export class StandardLanguageClient {
 				commands.executeCommand("workbench.action.openSettings", GRADLE_IMPORT_JVM);
 				commands.executeCommand(Commands.IMPORT_PROJECTS_CMD);
 			} else if (choice.startsWith(UPGRADE_GRADLE)) {
-				const useWrapper = workspace.getConfiguration().get<boolean>("java.import.gradle.wrapper.enabled");
-				if (!useWrapper) {
-					await workspace.getConfiguration().update("java.import.gradle.wrapper.enabled", true, ConfigurationTarget.Workspace);
-				}
-				const result = await window.withProgress({
-					location: ProgressLocation.Notification,
-					title: "Upgrading Gradle wrapper...",
-					cancellable: true,
-				}, (_progress, token) => {
-					return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, "java.project.upgradeGradle", projectUri, token);
-				});
-				if (result) {
-					const propertiesFile = path.join(Uri.parse(projectUri).fsPath, "gradle", "wrapper", "gradle-wrapper.properties");
-					if (fse.pathExists(propertiesFile)) {
-						const content = await fse.readFile(propertiesFile);
-						const offset = content.toString().indexOf("distributionUrl");
-						if (offset >= 0) {
-							const document = await workspace.openTextDocument(propertiesFile);
-							const position = document.positionAt(offset);
-							const distributionUrlRange = document.getWordRangeAtPosition(position);
-							window.showTextDocument(document, {selection: new Range(distributionUrlRange.start, new Position(distributionUrlRange.start.line + 1, 0))});
-						}
-					}
-					commands.executeCommand(Commands.IMPORT_PROJECTS_CMD);
-				}
+				await upgradeGradle(projectUri, gradleVersion);
 			}
 		});
 	}
@@ -503,6 +495,11 @@ export class StandardLanguageClient {
 				pattern: "**/pom.xml"
 			}, new PomCodeActionProvider(context), pomCodeActionMetadata);
 
+			languages.registerCodeActionsProvider({
+				scheme: "file",
+				pattern: "**/gradle/wrapper/gradle-wrapper.properties"
+			}, new GradleCodeActionProvider(context), gradleCodeActionMetadata);
+
 			if (languages.registerInlayHintsProvider) {
 				context.subscriptions.push(languages.registerInlayHintsProvider([
 					{ scheme: "file", language: "java", pattern: "**/*.java" },
@@ -632,4 +629,32 @@ export function showNoLocationFound(message: string): void {
 		'goto',
 		message
 	);
+}
+
+export async function upgradeGradle(projectUri: string, version?: string): Promise<void> {
+	const useWrapper = workspace.getConfiguration().get<boolean>("java.import.gradle.wrapper.enabled");
+	if (!useWrapper) {
+		await workspace.getConfiguration().update("java.import.gradle.wrapper.enabled", true, ConfigurationTarget.Workspace);
+	}
+	const result = await window.withProgress({
+		location: ProgressLocation.Notification,
+		title: "Upgrading Gradle wrapper...",
+		cancellable: true,
+	}, (_progress, token) => {
+		return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, "java.project.upgradeGradle", projectUri, version, token);
+	});
+	if (result) {
+		const propertiesFile = path.join(Uri.parse(projectUri).fsPath, "gradle", "wrapper", "gradle-wrapper.properties");
+		if (fse.pathExists(propertiesFile)) {
+			const content = await fse.readFile(propertiesFile);
+			const offset = content.toString().indexOf("distributionUrl");
+			if (offset >= 0) {
+				const document = await workspace.openTextDocument(propertiesFile);
+				const position = document.positionAt(offset);
+				const distributionUrlRange = document.getWordRangeAtPosition(position);
+				window.showTextDocument(document, {selection: new Range(distributionUrlRange.start, new Position(distributionUrlRange.start.line + 1, 0))});
+			}
+		}
+		commands.executeCommand(Commands.IMPORT_PROJECTS_CMD);
+	}
 }


### PR DESCRIPTION
fix #1594, requires https://github.com/eclipse/eclipse.jdt.ls/pull/2082

The upstream issues are https://github.com/gradle/gradle/issues/13957, https://github.com/gradle/gradle/issues/9339, and https://github.com/eclipse/buildship/issues/1084.

There is an upstream PR: https://github.com/gradle/gradle/pull/17397, which fixes this issue and has been available since Gradle 7.2. So we offer a quickfix and notification to help users upgrade wrapper to see the exact error.

![quickfix](https://user-images.githubusercontent.com/45906942/166895170-56188635-de14-4dac-9a7c-45614c89fdfd.gif)


Signed-off-by: Shi Chen <chenshi@microsoft.com>