### PR TITLE
Show field type when generating accessors

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -246,6 +246,7 @@ export interface AccessorField {
     isStatic: boolean;
     generateGetter: boolean;
     generateSetter: boolean;
+    typeName: string;
 }
 
 export interface AccessorCodeActionParams extends CodeActionParams {

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -231,7 +231,7 @@ async function generateAccessors(languageClient: LanguageClient, params: Accesso
             description.push('setter');
         }
         return {
-            label: accessor.fieldName,
+            label: `${accessor.fieldName}: ${accessor.typeName}`,
             description: (accessor.isStatic ? 'static ' : '')+ description.join(', '),
             originalField: accessor,
         };


### PR DESCRIPTION
requires [#2093](https://github.com/eclipse/eclipse.jdt.ls/pull/2093)

![addtype](https://user-images.githubusercontent.com/45906942/168944144-bef144e3-a281-4d51-aa57-c739cd932c16.jpg)

Signed-off-by: Shi Chen <chenshi@microsoft.com>