### PR TITLE
Add a new API to wait for standard server ready

### DIFF
--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -16,6 +16,7 @@ class ApiManager {
     private onDidClasspathUpdateEmitter: Emitter<Uri> = new Emitter<Uri>();
     private onDidServerModeChangeEmitter: Emitter<ServerMode> = new Emitter<ServerMode>();
     private onDidProjectsImportEmitter: Emitter<Uri[]> = new Emitter<Uri[]>();
+    private serverReadyPromiseResolve: (result: boolean) => void;
 
     public initialize(requirements: RequirementsData, serverMode: ServerMode): void {
         const getDocumentSymbols: getDocumentSymbolsCommand = getDocumentSymbolsProvider();
@@ -37,6 +38,13 @@ class ApiManager {
         const onDidServerModeChange = this.onDidServerModeChangeEmitter.event;
         const onDidProjectsImport = this.onDidProjectsImportEmitter.event;
 
+        const serverReadyPromise: Promise<boolean> = new Promise<boolean>((resolve) => {
+            this.serverReadyPromiseResolve = resolve;
+        });
+        const waitForServerReady = async () => {
+            return serverReadyPromise;
+        };
+
         this.api = {
             apiVersion: ExtensionApiVersion,
             javaRequirement: requirements,
@@ -51,6 +59,7 @@ class ApiManager {
             serverMode,
             onDidServerModeChange,
             onDidProjectsImport,
+            waitForServerReady,
         };
     }
 
@@ -80,6 +89,10 @@ class ApiManager {
 
     public updateStatus(status: ClientStatus): void {
         this.api.status = status;
+    }
+
+    public standardServerReady(): void {
+        this.serverReadyPromiseResolve(true);
     }
 }
 

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -73,7 +73,7 @@ export enum ClientStatus {
 	Stopping = "Stopping",
 }
 
-export const ExtensionApiVersion = '0.6';
+export const ExtensionApiVersion = '0.7';
 
 export interface ExtensionAPI {
 	readonly apiVersion: string;
@@ -110,4 +110,11 @@ export interface ExtensionAPI {
 	 * An event which fires when the server mode has been switched.
 	 */
 	readonly onDidServerModeChange: Event<ServerMode>;
+
+	/**
+	 * A promise that will be resolved when the standard language server is ready.
+	 * @since API version 0.7
+	 * @since extension version 1.7.0
+	 */
+	readonly waitForServerReady: () => Promise<boolean>;
 }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -108,6 +108,7 @@ export class StandardLanguageClient {
 					case 'ServiceReady':
 						apiManager.updateServerMode(ServerMode.STANDARD);
 						apiManager.fireDidServerModeChange(ServerMode.STANDARD);
+						apiManager.standardServerReady();
 						activationProgressNotification.hide();
 						if (!hasImported) {
 							showImportFinishNotification(context);

--- a/test/standard-mode-suite/publicApi.test.ts
+++ b/test/standard-mode-suite/publicApi.test.ts
@@ -163,6 +163,11 @@ suite('Public APIs - Standard', () => {
 		});
 	});
 
+	test('waitForServerReady() should work', async function () {
+		const api: ExtensionAPI = extensions.getExtension('redhat.java').exports;
+		await api.waitForServerReady();
+	});
+
 	suiteTeardown(async function() {
 		// revert the pom content
 		const pomContent: string = await fse.readFile(pomPath, 'utf-8');


### PR DESCRIPTION
- Add waitForServerReady() which returns a promise. The promise will
  only be resolved when the standard server is ready.

Currently we have the API `serverMode` to denote which mode the current language server is working on. But so far there is no API to let other extensions know when the standard server is ready. (Ready means it's ok to send request to server and an immediate response should be returned)

The newly added API can be used by all the side extensions (test runner, intellicode, ...), to let them only register their components after the standard server is ready. This can avoid lots of LSP requests pending when the server is building the project during startup.

A sample usage for the API could be:

```js
if (extensionApi.serverMode == LanguageServerMode.LightWeight) {
    if (extensionApi.onDidServerModeChange) {
        const onDidServerModeChange: Event<string> = extensionApi.onDidServerModeChange;
        context.subscriptions.push(onDidServerModeChange(async (mode: string) => {
            if (mode === LanguageServerMode.Standard) {
                registerComponents();
            }
        }));
    }
} else {
    await extensionApi.waitForServerReady();
    registerComponents();
}
```

Signed-off-by: sheche <sheche@microsoft.com>