### PR TITLE
Rename 'waitForServerReady()' to 'serverReady()'

### DIFF
--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -41,7 +41,7 @@ class ApiManager {
         const serverReadyPromise: Promise<boolean> = new Promise<boolean>((resolve) => {
             this.serverReadyPromiseResolve = resolve;
         });
-        const standardServerReady = async () => {
+        const serverReady = async () => {
             return serverReadyPromise;
         };
 
@@ -59,7 +59,7 @@ class ApiManager {
             serverMode,
             onDidServerModeChange,
             onDidProjectsImport,
-            standardServerReady,
+            serverReady,
         };
     }
 

--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -41,7 +41,7 @@ class ApiManager {
         const serverReadyPromise: Promise<boolean> = new Promise<boolean>((resolve) => {
             this.serverReadyPromiseResolve = resolve;
         });
-        const waitForServerReady = async () => {
+        const standardServerReady = async () => {
             return serverReadyPromise;
         };
 
@@ -59,7 +59,7 @@ class ApiManager {
             serverMode,
             onDidServerModeChange,
             onDidProjectsImport,
-            waitForServerReady,
+            standardServerReady,
         };
     }
 
@@ -91,7 +91,7 @@ class ApiManager {
         this.api.status = status;
     }
 
-    public standardServerReady(): void {
+    public resolveServerReadyPromise(): void {
         this.serverReadyPromiseResolve(true);
     }
 }

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -116,5 +116,5 @@ export interface ExtensionAPI {
 	 * @since API version 0.7
 	 * @since extension version 1.7.0
 	 */
-	readonly waitForServerReady: () => Promise<boolean>;
+	readonly standardServerReady: () => Promise<boolean>;
 }

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -113,8 +113,9 @@ export interface ExtensionAPI {
 
 	/**
 	 * A promise that will be resolved when the standard language server is ready.
+	 * Note: The server here denotes for the standard server, not the lightweight.
 	 * @since API version 0.7
 	 * @since extension version 1.7.0
 	 */
-	readonly standardServerReady: () => Promise<boolean>;
+	readonly serverReady: () => Promise<boolean>;
 }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -109,7 +109,7 @@ export class StandardLanguageClient {
 					case 'ServiceReady':
 						apiManager.updateServerMode(ServerMode.STANDARD);
 						apiManager.fireDidServerModeChange(ServerMode.STANDARD);
-						apiManager.standardServerReady();
+						apiManager.resolveServerReadyPromise();
 						activationProgressNotification.hide();
 						if (!hasImported) {
 							showImportFinishNotification(context);

--- a/test/standard-mode-suite/publicApi.test.ts
+++ b/test/standard-mode-suite/publicApi.test.ts
@@ -163,9 +163,9 @@ suite('Public APIs - Standard', () => {
 		});
 	});
 
-	test('waitForServerReady() should work', async function () {
+	test('serverReady() should work', async function () {
 		const api: ExtensionAPI = extensions.getExtension('redhat.java').exports;
-		await api.standardServerReady();
+		await api.serverReady();
 	});
 
 	suiteTeardown(async function() {

--- a/test/standard-mode-suite/publicApi.test.ts
+++ b/test/standard-mode-suite/publicApi.test.ts
@@ -165,7 +165,7 @@ suite('Public APIs - Standard', () => {
 
 	test('waitForServerReady() should work', async function () {
 		const api: ExtensionAPI = extensions.getExtension('redhat.java').exports;
-		await api.waitForServerReady();
+		await api.standardServerReady();
 	});
 
 	suiteTeardown(async function() {


### PR DESCRIPTION
Previously `await waitForServerReady()` looks strange. So renaming it to `await serverReady()`

Signed-off-by: sheche <sheche@microsoft.com>