### PR TITLE
Add 'java.completion.constructors.resolveParameterNamesThreshold'

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ The following settings are supported:
  * `java.import.generatesMetadataFilesAtProjectRoot` : Specify whether the project metadata files(.project, .classpath, .factorypath, .settings/) will be generated at the project root. Defaults to `false`.
  * `java.inlayHints.parameterNames.enabled`: Enable/disable inlay hints for parameter names. Supported values are: `none`(disable parameter name hints), `literals`(Enable parameter name hints only for literal arguments) and `all`(Enable parameter name hints for literal and non-literal arguments). Defaults to `literals`.
 
+New in 1.8.0
+* `java.completion.constructors.resolveParameterNamesThreshold`: A threshold to control whether the parameter names will be resolved in the completion list. If the number of constructors in the completion list is larger than the threshold, parameter names will not be resolved. To make the parameter names always be resolved, please set it to `0`.
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/package.json
+++ b/package.json
@@ -477,6 +477,12 @@
           "markdownDescription": "Maximum number of completion results (not including snippets).\n`0` (the default value) disables the limit, all results are returned. In case of performance problems, consider setting a sensible limit.",
           "scope": "window"
         },
+        "java.completion.constructors.resolveParameterNamesThreshold": {
+          "type": "integer",
+          "default": "30",
+          "markdownDescription": "A threshold to control whether the parameter names will be resolved in the completion list. If the number of constructors in the completion list is larger than the threshold, parameter names will not be resolved.\n\nTo make the parameter names always be resolved, please set it to `0`.",
+          "scope": "window"
+        },
         "java.completion.enabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
requires https://github.com/eclipse/eclipse.jdt.ls/pull/2103

Signed-off-by: sheche <sheche@microsoft.com>