### PR TITLE
Fix java.completion.importOrder

### DIFF
--- a/package.json
+++ b/package.json
@@ -524,8 +524,8 @@
           "default": [
             "java",
             "javax",
-            "com",
-            "org"
+            "org",
+            "com"
           ],
           "scope": "window"
         },


### PR DESCRIPTION
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/2107

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>