### PR TITLE
Avoid repeatedly setting busy and ready for language server status

### DIFF
--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -63,6 +63,9 @@ export namespace ServerStatusItemFactory {
 	}
 
 	export function setBusy(item: any): void {
+		if (item.busy === true) {
+			return;
+		}
 		item.text = "Building";
 		item.busy = true;
 	}
@@ -91,6 +94,9 @@ export namespace ServerStatusItemFactory {
 	}
 
 	export function setReady(item: any): void {
+		if (item.text === StatusIcon.Ready) {
+			return;
+		}
 		item.busy = false;
 		item.severity = vscode.LanguageStatusSeverity?.Information;
 		item.command = StatusCommands.showServerStatusCommand;

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -60,9 +60,7 @@ class ServerStatusBarProvider implements Disposable {
 
 	public setBusy(): void {
 		if (supportsLanguageStatus()) {
-			if (!this.languageStatusItem.busy) {
-				ServerStatusItemFactory.setBusy(this.languageStatusItem);
-			}
+			ServerStatusItemFactory.setBusy(this.languageStatusItem);
 		} else {
 			this.statusBarItem.text = StatusIcon.Busy;
 		}

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -60,7 +60,9 @@ class ServerStatusBarProvider implements Disposable {
 
 	public setBusy(): void {
 		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.setBusy(this.languageStatusItem);
+			if (!this.languageStatusItem.busy) {
+				ServerStatusItemFactory.setBusy(this.languageStatusItem);
+			}
 		} else {
 			this.statusBarItem.text = StatusIcon.Busy;
 		}


### PR DESCRIPTION
fix #2493 , for frequently invoking of `setBusy()`.

cc: @Eskibear 