### PR TITLE
Fix moving refactoring not working in standard mode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -427,9 +427,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 
 			apiManager.getApiInstance().onDidServerModeChange((event: ServerMode) => {
 				if (event === ServerMode.STANDARD) {
-					syntaxClient.getClient().stop().then(client => {
-						syntaxClient.stop();
-					});
+					syntaxClient.stop();
 					fileEventHandler.setServerStatus(true);
 					runtimeStatusBarProvider.initialize(context);
 				}
@@ -635,16 +633,17 @@ export function getJavaConfig(javaHome: string) {
 	return javaConfig;
 }
 
-export function deactivate(): Promise<void> {
-	return getActiveLanguageClient().then(client => {
-		standardClient.stop();
-		syntaxClient.stop();
-		if (!client) {
-			return undefined;
-		} else {
-			return client.stop();
-		}
-	});
+export function deactivate(): Promise<void[]> {
+	const promises: Promise<void>[] = [];
+	const standardStopPromise = standardClient.stop();
+	if (standardStopPromise) {
+		promises.push(standardStopPromise);
+	}
+	const syntaxStopPromise = syntaxClient.stop();
+	if (syntaxStopPromise) {
+		promises.push(syntaxStopPromise);
+	}
+	return Promise.all<void>(promises);
 }
 
 export async function getActiveLanguageClient(): Promise<LanguageClient | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -634,16 +634,10 @@ export function getJavaConfig(javaHome: string) {
 }
 
 export function deactivate(): Promise<void[]> {
-	const promises: Promise<void>[] = [];
-	const standardStopPromise = standardClient.stop();
-	if (standardStopPromise) {
-		promises.push(standardStopPromise);
-	}
-	const syntaxStopPromise = syntaxClient.stop();
-	if (syntaxStopPromise) {
-		promises.push(syntaxStopPromise);
-	}
-	return Promise.all<void>(promises);
+	return Promise.all<void>([
+		standardClient.stop(),
+		syntaxClient.stop(),
+	]);
 }
 
 export async function getActiveLanguageClient(): Promise<LanguageClient | undefined> {

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -527,6 +527,7 @@ export class StandardLanguageClient {
 				this.languageClient = null;
 			}
 		}
+		return Promise.resolve();
 	}
 
 	public getClient(): LanguageClient {

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -518,9 +518,14 @@ export class StandardLanguageClient {
 		}
 	}
 
-	public stop() {
+	public stop(): Promise<void> {
+		this.status = ClientStatus.Stopping;
 		if (this.languageClient) {
-			this.status = ClientStatus.Stopping;
+			try {
+				return this.languageClient.stop();
+			} finally {
+				this.languageClient = null;
+			}
 		}
 	}
 

--- a/src/syntaxLanguageClient.ts
+++ b/src/syntaxLanguageClient.ts
@@ -98,6 +98,7 @@ export class SyntaxLanguageClient {
 				this.languageClient = null;
 			}
 		}
+		return Promise.resolve();
 	}
 
 	public isAlive(): boolean {

--- a/src/syntaxLanguageClient.ts
+++ b/src/syntaxLanguageClient.ts
@@ -89,10 +89,14 @@ export class SyntaxLanguageClient {
 		}
 	}
 
-	public stop() {
+	public stop(): Promise<void> {
 		this.status = ClientStatus.Stopping;
 		if (this.languageClient) {
-			this.languageClient = null;
+			try {
+				return this.languageClient.stop();
+			} finally {
+				this.languageClient = null;
+			}
 		}
 	}
 


### PR DESCRIPTION
fix #2503 

Did some refactoring for each language client's stop() method. They still do the real stop stuff as the method name suggests, and the returned promise can be combined in the deactivated() function via `Promise.all`

Signed-off-by: sheche <sheche@microsoft.com>