### PR TITLE
auto-select field when generating constructors

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -187,6 +187,7 @@ export interface VariableBinding {
     name: string;
     type: string;
     isField: boolean;
+    isSelected?: boolean;
 }
 
 export interface CheckHashCodeEqualsResponse {

--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -298,6 +298,7 @@ function registerGenerateConstructorsCommand(languageClient: LanguageClient, con
                 return {
                     label: `${field.name}: ${field.type}`,
                     originalField: field,
+                    picked: field.isSelected
                 };
             });
             const selectedFieldItems = await window.showQuickPick(fieldItems, {


### PR DESCRIPTION
requires https://github.com/eclipse/eclipse.jdt.ls/pull/2125

Signed-off-by: Shi Chen <chenshi@microsoft.com>

![constructor](https://user-images.githubusercontent.com/45906942/173501112-717b1b3d-52e2-46ff-8866-1d1497351805.gif)
