### PR TITLE
Support project update selection

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -116,6 +116,11 @@ export namespace ClassFileContentsRequest {
 
 export namespace ProjectConfigurationUpdateRequest {
     export const type = new NotificationType<TextDocumentIdentifier> ('java/projectConfigurationUpdate');
+    export const typeV2 = new NotificationType<ProjectConfigurationsUpdateParam> ('java/projectConfigurationsUpdate');
+}
+
+export interface ProjectConfigurationsUpdateParam {
+    identifiers: TextDocumentIdentifier[];
 }
 
 export namespace ActionableNotification {

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -642,31 +642,29 @@ async function askForProjectToUpdate(): Promise<Uri[]> {
 
 	if (projectPicks.length === 0) {
 		return [];
-	}
-
-	// pre-select an active project based on the uri candidate.
-	if (uriCandidate) {
-		const candidatePath = uriCandidate.fsPath;
-		let belongingIndex = -1;
-		for (let i = 0; i < projectPicks.length; i++) {
-			if (candidatePath.startsWith(projectPicks[i].detail)) {
-				if (belongingIndex < 0
-						|| projectPicks[i].detail.length > projectPicks[belongingIndex].detail.length) {
-					belongingIndex = i;
-				}
-			}
-		}
-		if (belongingIndex >= 0) {
-			projectPicks[belongingIndex].picked = true;
-		}
-	}
-
-	if (projectPicks.length === 1) {
+	} else if (projectPicks.length === 1) {
 		return [Uri.file(projectPicks[0].detail)];
 	} else {
+		// pre-select an active project based on the uri candidate.
+		if (uriCandidate) {
+			const candidatePath = uriCandidate.fsPath;
+			let belongingIndex = -1;
+			for (let i = 0; i < projectPicks.length; i++) {
+				if (candidatePath.startsWith(projectPicks[i].detail)) {
+					if (belongingIndex < 0
+							|| projectPicks[i].detail.length > projectPicks[belongingIndex].detail.length) {
+						belongingIndex = i;
+					}
+				}
+			}
+			if (belongingIndex >= 0) {
+				projectPicks[belongingIndex].picked = true;
+			}
+		}
+
 		const choices: QuickPickItem[] | undefined = await window.showQuickPick(projectPicks, {
 			matchOnDetail: true,
-			placeHolder: "Select the project to update.",
+			placeHolder: "Please select the project(s) to update.",
 			ignoreFocusOut: true,
 			canPickMany: true,
 		});


### PR DESCRIPTION
- If no uri is passed into the projectConfigurationUpdate() function,
  show a quick pick list and let user select which projects to update.
- If there is only one project in the workspace, project update request
  for that project will directly send to server without asking.

part of #2473, requires https://github.com/eclipse/eclipse.jdt.ls/pull/2131

Signed-off-by: sheche <sheche@microsoft.com>