### PR TITLE
Allow rebuild selected projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following commands are available:
 - `Java: Open Java Extension Log File`: opens the Java extension log file, useful for troubleshooting problems.
 - `Java: Open All Log Files`: opens both the Java Language Server log file and the Java extension log file.
 - `Java: Force Java Compilation` (`Shift+Alt+B`): manually triggers compilation of the workspace.
+- `Java: Rebuild Projects`: manually triggers a full build of the selected projects.
 - `Java: Open Java Formatter Settings`: opens the Eclipse formatter settings. Creates a new settings file if none exists.
 - `Java: Clean Java Language Server Workspace`: cleans the Java language server workspace.
 - `Java: Attach Source`: attaches a jar/zip source to the currently opened binary class file. This command is only available in the editor context menu.

--- a/package.json
+++ b/package.json
@@ -949,6 +949,11 @@
         "category": "Java"
       },
       {
+        "command": "java.project.build",
+        "title": "%java.project.build%",
+        "category": "Java"
+      },
+      {
         "command": "java.open.formatter.settings",
         "title": "%java.open.formatter.settings%",
         "category": "Java"
@@ -1092,6 +1097,10 @@
         },
         {
           "command": "java.workspace.compile",
+          "when": "javaLSReady"
+        },
+        {
+          "command": "java.project.build",
           "when": "javaLSReady"
         },
         {

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
 	"java.project.import": "Import Java Projects into Workspace",
 	"java.open.logs": "Open All Log Files",
 	"java.workspace.compile": "Force Java Compilation",
+	"java.project.build": "Rebuild Projects",
 	"java.open.formatter.settings": "Open Java Formatter Settings",
 	"java.clean.workspace": "Clean Java Language Server Workspace",
 	"java.project.updateSourceAttachment": "Attach Source",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -4,6 +4,7 @@
 	"java.project.import": "将 Java 项目导入工作区",
 	"java.open.logs": "打开所有日志文件",
 	"java.workspace.compile": "强制编译",
+	"java.project.build": "重新构建项目",
 	"java.open.formatter.settings": "打开 Java 格式设置",
 	"java.clean.workspace": "清理 Java 语言服务器工作区",
 	"java.project.updateSourceAttachment": "附加源代码",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -80,6 +80,11 @@ export namespace Commands {
     export const COMPILE_WORKSPACE = 'java.workspace.compile';
 
     /**
+     * Execute build for projects
+     */
+    export const REBUILD_PROJECT = 'java.project.build';
+
+    /**
     * Open Java Language Server Log file
     */
     export const OPEN_SERVER_LOG = 'java.open.serverLog';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -82,7 +82,7 @@ export namespace Commands {
     /**
      * Execute build for projects
      */
-    export const REBUILD_PROJECT = 'java.project.build';
+    export const BUILD_PROJECT = 'java.project.build';
 
     /**
     * Open Java Language Server Log file

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -135,6 +135,15 @@ export namespace CompileWorkspaceRequest {
     export const type = new RequestType<boolean, CompileWorkspaceStatus, void>('java/buildWorkspace');
 }
 
+export namespace BuildProjectRequest {
+    export const type = new RequestType<BuildProjectParams, CompileWorkspaceStatus, void>('java/buildProjects');
+}
+
+export interface BuildProjectParams {
+    identifiers: TextDocumentIdentifier[];
+    isFullBuild: boolean;
+}
+
 export namespace ExecuteClientCommandRequest {
     export const type = new RequestType<ExecuteCommandParams, any, void>('workspace/executeClientCommand');
 }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -429,7 +429,7 @@ export class StandardLanguageClient {
 							}
 							reject(error);
 						}
-	
+
 						const elapsed = new Date().getTime() - start;
 						const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
 						setTimeout(() => { // set a timeout so user would still see the message when build time is short

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -445,11 +445,7 @@ export class StandardLanguageClient {
 						const elapsed = new Date().getTime() - start;
 						const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
 						setTimeout(() => { // set a timeout so user would still see the message when build time is short
-							if (res === CompileWorkspaceStatus.SUCCEED) {
-								resolve(res);
-							} else {
-								reject(res);
-							}
+							resolve(res);
 						}, humanVisibleDelay);
 					});
 				});


### PR DESCRIPTION
part of https://github.com/redhat-developer/vscode-java/issues/2510, requires https://github.com/eclipse/eclipse.jdt.ls/pull/2138

- Add a new extended LSP request: BuildProjectRequest.
- the request param has two fields: `identifiers` - uri and `isFullBuild` - boolean.

Currently, `isFullBuild` is always set to true. Since we enable auto-build by default, triggering an incremental build does not make much sense. But a clean full build is helpful when the build status is out of sync. In the future, if users ask for incremental build support, we can expose this param.

The name of the command is called `Rebuild Projects` now, indicates it will clean and do a full build.

Signed-off-by: sheche <sheche@microsoft.com>