### PR TITLE
Rename 'Update Project' to 'Reload Project'

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Available commands
 ==========================
 The following commands are available:
 - `Switch to Standard Mode`: switches the Java Language Server to `Standard` mode. This command is only available when the Java Language Server is in `LightWeight` mode.
-- `Java: Update Project` (`Shift+Alt+U`): is available when the editor is focused on a Maven pom.xml or a Gradle file. It forces project configuration / classpath updates (eg. dependency changes or Java compilation level), according to the project build descriptor.
+- `Java: Reload Project` (`Shift+Alt+U`): It forces project configuration / classpath updates (eg. dependency changes or Java compilation level), according to the project build descriptor.
 - `Java: Import Java Projects into Workspace`: detects and imports all the Java projects into the Java Language Server workspace.
 - `Java: Open Java Language Server Log File`: opens the Java Language Server log file, useful for troubleshooting problems.
 - `Java: Open Java Extension Log File`: opens the Java extension log file, useful for troubleshooting problems.

--- a/document/_java.notCoveredExecution.md
+++ b/document/_java.notCoveredExecution.md
@@ -42,7 +42,7 @@ Some Maven projects use 3rd party Maven plugins to generate sources or resources
 
 For example, add [a processing instruction in the pom.xml](https://www.eclipse.org/m2e/documentation/release-notes-17.html#new-syntax-for-specifying-lifecycle-mapping-metadata) like `<?m2e execute onConfiguration?>` to execute it on every project configuration update.
 
-You can use quick fixes to generate the inline lifecycle mapping in pom.xml, or manually configure it in pom.xml. If it's yourself that manually configure it, you have to let VS Code update the project configuration as well. The command is `"Java: Update Project"`.
+You can use quick fixes to generate the inline lifecycle mapping in pom.xml, or manually configure it in pom.xml. If it's yourself that manually configure it, you have to let VS Code update the project configuration as well. The command is `"Java: Reload Project"`.
 
 ```xml
 <project>

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,6 @@
 {
 	"java.server.mode.switch": "Switch to Standard Mode",
-	"java.projectConfiguration.update": "Update Project",
+	"java.projectConfiguration.update": "Reload Project",
 	"java.project.import": "Import Java Projects into Workspace",
 	"java.open.logs": "Open All Log Files",
 	"java.workspace.compile": "Force Java Compilation",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,6 +1,6 @@
 {
 	"java.server.mode.switch": "切换到标准模式",
-	"java.projectConfiguration.update": "更新项目",
+	"java.projectConfiguration.update": "重新加载项目",
 	"java.project.import": "将 Java 项目导入工作区",
 	"java.open.logs": "打开所有日志文件",
 	"java.workspace.compile": "强制编译",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -40,7 +40,7 @@ export namespace Commands {
     export const MARKDOWN_API_RENDER = 'markdown.api.render';
 
     /**
-     * Update project configuration
+     * Reload project
      */
     export const CONFIGURATION_UPDATE = 'java.projectConfiguration.update';
 

--- a/src/pom/pomCodeActionProvider.ts
+++ b/src/pom/pomCodeActionProvider.ts
@@ -26,9 +26,9 @@ export class PomCodeActionProvider implements CodeActionProvider<CodeAction> {
 			if (diagnostic.message?.startsWith("Plugin execution not covered by lifecycle configuration")) {
 				const indentation = this.getNewTextIndentation(document, diagnostic);
 				const saveAndUpdateConfigCommand: Command = {
-					title: "Save and update project configuration",
+					title: "Save and reload project",
 					command: "_java.projectConfiguration.saveAndUpdate",
-					arguments: [ document.uri ],
+					arguments: [document.uri],
 				};
 
 				const action1 = new CodeAction("Enable this execution in project configuration phase", CodeActionKind.QuickFix.append("pom"));


### PR DESCRIPTION
last remaining work of #2473 

To make users still can find the command and know its functionality, I reserved `Update Project` in the name. We can consider to totally remove it after several iterations.

Following are some screenshots of the appearance

#### Context Menu
![WeChat Screenshot_20220624112536](https://user-images.githubusercontent.com/6193897/175456450-967e3a75-957b-45fc-adb1-7828067f36e0.png)


#### Command Palette
![WeChat Screenshot_20220624112608](https://user-images.githubusercontent.com/6193897/175456460-ec0f7ab1-2d4c-4d7f-9d08-b1f478df7382.png)



Signed-off-by: Sheng Chen <sheche@microsoft.com>