### PR TITLE
Fixed language server crashing because of wrong Lombok jar

### DIFF
--- a/src/lombokSupport.ts
+++ b/src/lombokSupport.ts
@@ -20,6 +20,8 @@ const languageServerDocumentSelector = [
 	{ pattern: '**/{build,settings}.gradle.kts'}
 ];
 
+const lombokJarRegex = /lombok-\d+.*\.jar/;
+
 let activeLombokPath: string = undefined;
 let isLombokCommandInitialized: boolean = false;
 
@@ -46,8 +48,7 @@ export function cleanupLombokCache(context: ExtensionContext): boolean {
 }
 
 export function getLombokVersion(context: ExtensionContext): string {
-	const reg = /lombok-.*\.jar/;
-	const lombokVersion = reg.exec(activeLombokPath)[0].split('.jar')[0];
+	const lombokVersion = lombokJarRegex.exec(activeLombokPath)[0].split('.jar')[0];
 	return lombokVersion;
 }
 
@@ -75,7 +76,6 @@ export async function checkLombokDependency(context: ExtensionContext) {
 	if (!isLombokSupportEnabled()) {
 		return;
 	}
-	const reg = /lombok-.*\.jar/;
 	let needReload = false;
 	let versionChange = false;
 	let currentLombokVersion = "";
@@ -85,11 +85,11 @@ export async function checkLombokDependency(context: ExtensionContext) {
 	for (const projectUri of projectUris) {
 		const classpathResult = await apiManager.getApiInstance().getClasspaths(projectUri, {scope: 'runtime'});
 		for (const classpath of classpathResult.classpaths) {
-			if (reg.test(classpath)) {
+			if (lombokJarRegex.test(classpath)) {
 				currentLombokClasspath = classpath;
 				if (isLombokImported(context)) {
-					currentLombokVersion = reg.exec(classpath)[0];
-					previousLombokVersion = reg.exec(context.workspaceState.get(JAVA_LOMBOK_PATH))[0];
+					currentLombokVersion = lombokJarRegex.exec(classpath)[0];
+					previousLombokVersion = lombokJarRegex.exec(context.workspaceState.get(JAVA_LOMBOK_PATH))[0];
 					if (currentLombokVersion!==previousLombokVersion) {
 						needReload = true;
 						versionChange = true;


### PR DESCRIPTION
vscode-java: 1.8.0
running on macos with java 17 from zulu.

First time the workspace is opened, the extension detects that lombok is used and propose to reload. The subsequent execution will start the language server correctly using the right Lombok jar from the dependencies:
```
message: 'Starting Java server with: Users/fortinma.sdkman/candidates/java/17.0.3-zulu/zulu-17.jdk/Contents/Home/bin/java ... -javaagent:/Users/fortinma/.m2/repository/org/projectlombok/lombok/1.18.24/lombok-1.18.24.jar
```

At the end of the project importation, the extension seems to pickup a wrong lombok jar and pops up a message saying that lombok version was changed from `1.18.24` to `utils/1.18.12/lombok`. The language server is then unable to start:
```
{
       message: 'Starting Java server with: ... -javaagent:/Users/fortinma/.m2/repository/org/projectlombok/lombok-utils/1.18.12/lombok-utils-1.18.12.jar <===== this is a wrong jar!!
       level: 'info',
       timestamp: '2022-07-05 21:21:57.084'
     }
     {
       message: 'Failed to find Premain-Class manifest attribute in Users/fortinma.m2/repository/org/projectlombok/lombok-utils/1.18.12/lombok-utils-1.18.12.jar\n',
       level: 'info',
       timestamp: '2022-07-05 21:21:57.239'
     }
     {
       message: 'Language Support for Java server encountered error and will shut down: undefined, Error: write EPIPE',
       level: 'error',
       timestamp: '2022-07-05 21:21:57.240'
     }
```

Following this error, the workspace is pretty much dead, and needs to be hard deleted.

The reason is that the regex used to find the lombok jar from the dependencies is too loose. `/lombok-.*\.jar/` matches both `lombok-1.18.24` and `lombok-utils-1.18.12`. Dont ask me why we are using `lombok-utils`, i have no idea. Will look into that later.

By having a more strict regex, ie `/lombok-\d+.*\.jar/`, we make sure we only matches `lombok-111-222-333.jar`, while not falling into really complicated semver matches (maybe that would be better?)

Tested in my environment and this works fine. Please point me to the right way to add tests for this, if needed.

Thanks!.