### PR TITLE
Using extension's lombok version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ undefined
 target
 dist
 jre
+lombok
 bin/
 .settings
 .classpath

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,11 @@ def buildVscodeExtension(){
 	sh "npm run vscode:prepublish"
 }
 
+def downloadLombokJar(){
+	stage "Download lombok.jar"
+	sh "npx gulp download_lombok"
+}
+
 def packageSpecificExtensions() {
 	stage "Package platform specific vscode-java"
 	def platforms = ["win32-x64", "linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"]
@@ -158,6 +163,8 @@ node('rhel8'){
 		env.SKIP_COMMANDS_TEST="true"
 		sh "npm test --silent"
 	}
+
+	downloadLombokJar()
 
 	packageExtensions()
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Supported VS Code settings
 The following settings are supported:
 
 * `java.home` : **Deprecated, please use 'java.jdt.ls.java.home' instead.** Absolute path to JDK home folder used to launch the Java Language Server. Requires VS Code restart.
-* `java.jdt.ls.lombokSupport.enabled`: Whether to load lombok processors from project classpath. Defaults to `true`.
+* `java.jdt.ls.lombokSupport.enabled`: Whether to enable lombok support. Defaults to `true`.
 * `java.jdt.ls.vmargs` : Extra VM arguments used to launch the Java Language Server. Requires VS Code restart.
 * `java.errors.incompleteClasspath.severity` : Specifies the severity of the message when the classpath is incomplete for a Java file. Supported values are `ignore`, `info`, `warning`, `error`.
 * `java.trace.server` : Traces the communication between VS Code and the Java language server.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -120,8 +120,9 @@ gulp.task('download_lombok', function(done) {
 	if (fse.existsSync('./lombok')) {
 		fse.removeSync('./lombok');
 	}
-	const lombokVersion = `1.18.24`
-	const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`
+	const lombokVersion = '1.18.24';
+	// The latest lombok version can be found on the website https://projectlombok.org/downloads
+	const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`;
 	download(lombokUrl)
 		.pipe(gulp.dest('./lombok/'))
 	done();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,6 +116,17 @@ gulp.task('download_jre', async function(done) {
 	done();
 });
 
+gulp.task('download_lombok', function(done) {
+	if (fse.existsSync('./lombok')) {
+		fse.removeSync('./lombok');
+	}
+	const lombokVersion = `1.18.24`
+	const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`
+	download(lombokUrl)
+		.pipe(gulp.dest('./lombok/'))
+	done();
+});
+
 gulp.task('download_server', function(done) {
 	fse.removeSync('./server');
 	download("http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { runtimeStatusBarProvider } from './runtimeStatusBarProvider';
 import { serverStatusBarProvider } from './serverStatusBarProvider';
 import { markdownPreviewProvider } from "./markdownPreviewProvider";
 import * as chokidar from 'chokidar';
+import { cleanupLombokCache } from "./lombokSupport";
 
 const syntaxClient: SyntaxLanguageClient = new SyntaxLanguageClient();
 const standardClient: StandardLanguageClient = new StandardLanguageClient();
@@ -359,6 +360,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			const cleanWorkspaceExists = fs.existsSync(path.join(workspacePath, cleanWorkspaceFileName));
 			if (cleanWorkspaceExists) {
 				try {
+					cleanupLombokCache(context);
 					deleteDirectory(workspacePath);
 					deleteDirectory(syntaxServerWorkspacePath);
 				} catch (error) {

--- a/src/lombokSupport.ts
+++ b/src/lombokSupport.ts
@@ -2,6 +2,7 @@
 
 import * as fse from "fs-extra";
 import * as path from "path";
+import * as semver from 'semver';
 import * as vscode from "vscode";
 import { ExtensionContext, window, commands, Uri, Position, Location, Selection, env, Extension } from "vscode";
 import { Commands } from "./commands";
@@ -9,7 +10,6 @@ import { apiManager } from "./apiManager";
 import { supportsLanguageStatus } from "./languageStatusItemFactory";
 import { runtimeStatusBarProvider } from './runtimeStatusBarProvider';
 import { logger } from './log';
-import semver = require('semver');
 
 export const JAVA_LOMBOK_PATH = "java.lombokPath";
 
@@ -128,10 +128,8 @@ export async function checkLombokDependency(context: ExtensionContext) {
 	let currentLombokClasspath: string = undefined;
 	const projectUris: string[] = await commands.executeCommand<string[]>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_ALL_JAVA_PROJECTS);
 	for (const projectUri of projectUris) {
-		const classpathRuntime = await apiManager.getApiInstance().getClasspaths(projectUri, {scope: 'runtime'});
-		const classpathTest = await apiManager.getApiInstance().getClasspaths(projectUri, {scope: 'test'});
-		const classpathResult = classpathRuntime.classpaths.concat(classpathTest.classpaths);
-		for (const classpath of classpathResult) {
+		const classpathResult = await apiManager.getApiInstance().getClasspaths(projectUri, {scope: 'test'});
+		for (const classpath of classpathResult.classpaths) {
 			if (lombokJarRegex.test(classpath)) {
 				currentLombokClasspath = classpath;
 				if (context.workspaceState.get(JAVA_LOMBOK_PATH)) {

--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -11,7 +11,7 @@ import { ACTIVE_BUILD_TOOL_STATE } from "./settings";
 import { BuildFileStatusItemFactory, RuntimeStatusItemFactory, StatusCommands, supportsLanguageStatus } from "./languageStatusItemFactory";
 import { getJavaConfiguration } from "./utils";
 import { hasBuildToolConflicts } from "./extension";
-import { registerLombokConfigureCommand, LombokVersionItemFactory, getLombokVersion, isLombokActive } from "./lombokSupport";
+import { registerLombokConfigureCommand, LombokVersionItemFactory, getLombokVersion, isLombokImported } from "./lombokSupport";
 
 class RuntimeStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
@@ -86,6 +86,11 @@ class RuntimeStatusBarProvider implements Disposable {
 		}));
 
 		await this.updateItem(context, window.activeTextEditor);
+	}
+
+	public initializeLombokStatusBar(context: ExtensionContext) {
+		registerLombokConfigureCommand(context);
+		this.lombokVersionItem = LombokVersionItemFactory.create(getLombokVersion());
 	}
 
 	private hideRuntimeStatusItem(): void {
@@ -174,10 +179,6 @@ class RuntimeStatusBarProvider implements Disposable {
 			return;
 		}
 
-		if (isLombokActive(context)) {
-			registerLombokConfigureCommand(context);
-		}
-
 		const uri: Uri = textEditor.document.uri;
 		const projectPath: string = this.findOwnerProject(uri);
 		if (!projectPath) {
@@ -211,16 +212,19 @@ class RuntimeStatusBarProvider implements Disposable {
 				if (buildFilePath) {
 					this.buildFileStatusItem = BuildFileStatusItemFactory.create(buildFilePath);
 				}
-				if (isLombokActive(context)) {
-					this.lombokVersionItem = LombokVersionItemFactory.create(getLombokVersion(context), buildFilePath);
-				}
 			} else {
 				RuntimeStatusItemFactory.update(this.runtimeStatusItem, text, projectInfo.vmInstallPath);
 				if (buildFilePath) {
 					BuildFileStatusItemFactory.update(this.buildFileStatusItem, buildFilePath);
 				}
-				if (isLombokActive(context)) {
-					LombokVersionItemFactory.update(this.lombokVersionItem, getLombokVersion(context), buildFilePath);
+			}
+			if (!this.lombokVersionItem) {
+				if (isLombokImported()) {
+					this.lombokVersionItem = LombokVersionItemFactory.create(getLombokVersion());
+				}
+			} else {
+				if (isLombokImported()) {
+					LombokVersionItemFactory.update(this.lombokVersionItem, getLombokVersion());
 				}
 			}
 		} else {

--- a/src/runtimeStatusBarProvider.ts
+++ b/src/runtimeStatusBarProvider.ts
@@ -11,7 +11,7 @@ import { ACTIVE_BUILD_TOOL_STATE } from "./settings";
 import { BuildFileStatusItemFactory, RuntimeStatusItemFactory, StatusCommands, supportsLanguageStatus } from "./languageStatusItemFactory";
 import { getJavaConfiguration } from "./utils";
 import { hasBuildToolConflicts } from "./extension";
-import { registerLombokConfigureCommand, LombokVersionItemFactory, getLombokVersion, isLombokImported } from "./lombokSupport";
+import { LombokVersionItemFactory, getLombokVersion, isLombokImported } from "./lombokSupport";
 
 class RuntimeStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
@@ -88,9 +88,12 @@ class RuntimeStatusBarProvider implements Disposable {
 		await this.updateItem(context, window.activeTextEditor);
 	}
 
-	public initializeLombokStatusBar(context: ExtensionContext) {
-		registerLombokConfigureCommand(context);
+	public initializeLombokStatusBar() {
 		this.lombokVersionItem = LombokVersionItemFactory.create(getLombokVersion());
+	}
+
+	public destroyLombokStatusBar(): void {
+		this.hideLombokVersionItem();
 	}
 
 	private hideRuntimeStatusItem(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,19 +57,25 @@ export function onConfigurationChange(workspacePath: string, context: ExtensionC
 		}
 		if (hasConfigKeyChanged('jdt.ls.lombokSupport.enabled', oldConfig, newConfig)) {
 			if (newConfig.get("jdt.ls.lombokSupport.enabled")) {
-				checkLombokDependency(context);
+				const msg = `Lombok support is enabled, please restart ${env.appName}.`;
+				const action = 'Restart Now';
+				const restartId = Commands.RELOAD_WINDOW;
+				window.showWarningMessage(msg, action).then((selection) => {
+					if (action === selection) {
+						commands.executeCommand(restartId);
+					}
+				});
 			}
 			else {
-				if (cleanupLombokCache(context)) {
-					const msg = `Lombok support is disabled, please restart ${env.appName}.`;
-					const action = 'Restart Now';
-					const restartId = Commands.RELOAD_WINDOW;
-					window.showWarningMessage(msg, action).then((selection) => {
-						if (action === selection) {
-							commands.executeCommand(restartId);
-						}
-					});
-				}
+				cleanupLombokCache(context);
+				const msg = `Lombok support is disabled, please restart ${env.appName}.`;
+				const action = 'Restart Now';
+				const restartId = Commands.RELOAD_WINDOW;
+				window.showWarningMessage(msg, action).then((selection) => {
+					if (action === selection) {
+						commands.executeCommand(restartId);
+					}
+				});
 			}
 		}
 		// update old config


### PR DESCRIPTION
Add the feature of using extension's lombok version by default.
If the lombok support is enable, the extension always add the
latest version lombok.jar to start the JDT LS. It can avoid the
errors caused by old version lombok.

The user can select the extension's lombok version or the project's
lombok version.

Signed-off-by: Yuhao Xiao <t-yuhaoxiao@microsoft.com>