### PR TITLE
Clean `jre` folder before publishing generic version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,9 @@ def publishExtensions() {
 	if (publishPreRelease.equals('true')) {
 		stage "publish generic version"
 		withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
+			// Clean up embedded jre folder from previous build
+			sh 'npx gulp clean_jre'
+			// Publish a generic version
 			sh 'vsce publish --pre-release -p ${TOKEN} --target win32-ia32 win32-arm64 linux-armhf alpine-x64 alpine-arm64'
 		}
 


### PR DESCRIPTION
fix #2559 

Currently the last jre folder (containing platform JRE for macos_arm64, see https://github.com/redhat-developer/vscode-java/blob/6c000d33fc51ba3041c6452b4879b532a43f1dae/Jenkinsfile#L17) will be included for generic version, this fix will clean ./jre folder before publishing generic version. The platform-specific versions have been packaged correctly before and are unaffected.

Signed-off-by: Shi Chen <chenshi@microsoft.com>