### PR TITLE
Provide reload project code action on demand

### DIFF
--- a/src/pom/pomCodeActionProvider.ts
+++ b/src/pom/pomCodeActionProvider.ts
@@ -14,13 +14,13 @@ export class PomCodeActionProvider implements CodeActionProvider<CodeAction> {
 
 	provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<(Command | CodeAction)[]> {
 		if (context?.diagnostics?.length && context.diagnostics[0].source === "Java") {
-			return this.collectCodeActionsForNotCoveredExecutions(document, context.diagnostics);
+			return this.collectCodeActions(document, context.diagnostics);
 		}
 
 		return undefined;
 	}
 
-	private collectCodeActionsForNotCoveredExecutions(document: TextDocument, diagnostics: readonly Diagnostic[]): CodeAction[] {
+	private collectCodeActions(document: TextDocument, diagnostics: readonly Diagnostic[]): CodeAction[] {
 		const codeActions: CodeAction[] = [];
 		for (const diagnostic of diagnostics) {
 			if (diagnostic.message?.startsWith("Plugin execution not covered by lifecycle configuration")) {
@@ -48,6 +48,14 @@ export class PomCodeActionProvider implements CodeActionProvider<CodeAction> {
 				action3.edit.insert(document.uri, diagnostic.range.end, indentation + "<?m2e ignore?>");
 				action3.command = saveAndUpdateConfigCommand;
 				codeActions.push(action3);
+			} else if (diagnostic.message?.startsWith("The build file has been changed")) {
+				const reloadProjectAction = new CodeAction("Reload project", CodeActionKind.QuickFix);
+				reloadProjectAction.command = {
+					title: "Reload Project",
+					command: Commands.CONFIGURATION_UPDATE,
+					arguments: [document.uri],
+				};
+				codeActions.push(reloadProjectAction);
 			}
 		}
 

--- a/test/standard-mode-suite/codeActionProvider.test.ts
+++ b/test/standard-mode-suite/codeActionProvider.test.ts
@@ -1,0 +1,60 @@
+'use strict';
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { CodeAction, CodeActionContext, CodeActionKind, CodeActionTriggerKind, DiagnosticSeverity, ExtensionContext, Position, Range, Uri, window } from "vscode";
+import { Commands } from '../../src/commands';
+import { GradleCodeActionProvider } from '../../src/gradle/gradleCodeActionProvider';
+import { PomCodeActionProvider } from "../../src/pom/pomCodeActionProvider";
+
+// tslint:disable: only-arrow-functions
+const mavenProjectFsPath: string = path.join(__dirname, '..', '..', '..', 'test', 'resources', 'projects', 'maven', 'salut');
+const gradleProjectFsPath: string = path.join(__dirname, '..', '..', '..', 'test', 'resources', 'projects', 'gradle', 'simple-gradle');
+
+suite('Code Action Provider Test', () => {
+
+	test('Provide reload project action on demand for pom file', async function () {
+		const contextMock = {
+			subscriptions: []
+		};
+		const provider = new PomCodeActionProvider(contextMock as ExtensionContext);
+
+		const codeActionContext: CodeActionContext = {
+			triggerKind: CodeActionTriggerKind.Invoke,
+			diagnostics: [{
+				range: new Range(new Position(0, 0), new Position(0, 0)),
+				message: 'The build file has been changed and may need reload to make it effective.',
+				severity: DiagnosticSeverity.Information,
+				source: 'Java'
+			}],
+			only: CodeActionKind.QuickFix
+		};
+		const editor = await window.showTextDocument(Uri.file(path.join(mavenProjectFsPath, 'pom.xml')));
+		const codeActions = provider.provideCodeActions(editor.document, null, codeActionContext, null) as CodeAction[];
+		assert.equal(codeActions.length, 1);
+		assert.equal(codeActions[0].command.command, Commands.CONFIGURATION_UPDATE);
+	});
+
+	test('Provide reload project action on demand for gradle file', async function () {
+		const contextMock = {
+			subscriptions: []
+		};
+		const provider = new GradleCodeActionProvider(contextMock as ExtensionContext);
+
+		const codeActionContext: CodeActionContext = {
+			triggerKind: CodeActionTriggerKind.Invoke,
+			diagnostics: [{
+				range: new Range(new Position(0, 0), new Position(0, 0)),
+				message: 'The build file has been changed and may need reload to make it effective.',
+				severity: DiagnosticSeverity.Information,
+				source: 'Java'
+			}],
+			only: CodeActionKind.QuickFix
+		};
+		const editor = await window.showTextDocument(Uri.file(path.join(gradleProjectFsPath, 'build.gradle')));
+		const codeActions = (await provider.provideCodeActions(editor.document, null, codeActionContext, null)) as CodeAction[];
+		assert.equal(codeActions.length, 1);
+		assert.equal(codeActions[0].command.command, Commands.CONFIGURATION_UPDATE);
+	});
+
+});


### PR DESCRIPTION
requires https://github.com/eclipse/eclipse.jdt.ls/pull/2164

gif for illustration:

https://user-images.githubusercontent.com/6193897/179648872-51e2ca64-100c-41ed-bbfc-f8f91d6ac6f4.mp4

1. At first since the file content is not changed, so the save action won't make the reload notification appear.
2. User can click the yes button or the quick fix action to fix the diagnostic.

Signed-off-by: Sheng Chen <sheche@microsoft.com>