### PR TITLE
update deps: jdk-utils@0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3316,9 +3316,9 @@
       "dev": true
     },
     "jdk-utils": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.3.tgz",
-      "integrity": "sha512-6d4tEkaBfpbQy32TF8lt+CFYaaWicBQEekWO5HozSzSMY4Y2ufsdNhpUbza0r2cuGEzoScE1r8vd9wkuUgypAA=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.4.tgz",
+      "integrity": "sha512-QSwVdPtwdHRvY6zDD0GOZo5Fu7AdgfNDyizZWhk16jnrcLTPbmsww4WLDC+5wyxCWm8izZZfmjTVcicdreuJLw=="
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -1241,7 +1241,7 @@
     "fs-extra": "^8.1.0",
     "glob": "^7.1.3",
     "htmlparser2": "6.0.1",
-    "jdk-utils": "^0.4.3",
+    "jdk-utils": "^0.4.4",
     "semver": "^7.3.5",
     "vscode-languageclient": "7.1.0-next.5",
     "winreg-utf8": "^0.1.1",


### PR DESCRIPTION
v0.4.4 has better support for JDKs installed by asdf-vm, covering those who have customized `ASDF_DATA_DIR` configured.

Corresponding changes in https://github.com/Eskibear/node-jdk-utils/pull/8 by a vscode-java user.