### PR TITLE
Make the setting 'java.import.gradle.java.home' to be machine-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "java.jdt.ls.java.home",
         "java.home",
         "java.jdt.ls.vmargs",
-        "java.configuration.runtimes"
+        "java.configuration.runtimes",
+        "java.import.gradle.java.home"
       ]
     },
     "virtualWorkspaces": false
@@ -284,7 +285,7 @@
           "type": "string",
           "default": null,
           "description": "The location to the JVM used to run the Gradle daemon.",
-          "scope": "machine"
+          "scope": "machine-overridable"
         },
         "java.import.gradle.offline.enabled": {
           "type": "boolean",


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

We have an enterprise partner that is trying to adopt VS Code as their Java development tool. To help their team to on board to VS Code more smoothly, they developed an internal command line tool to generate Java settings in .vscode/settings.json by one-click. They hope all JDK related settings to be workspace changable. This is a reasonable idea since workspace-level settings are more easily customized by third-party tools.

In addition, we already do that for most JDK-related settings such as 'java.jdt.ls.java.home', 'java.configuration.runtimes', it makes sense for me to change `java.import.gradle.java.home` to machine-overridable.