### PR TITLE
GH2577: Add '-Xlog:jni+resolve=off' to the default vmargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,8 +196,8 @@
             "string",
             "null"
           ],
-          "default": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m",
-          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m ` to optimize memory usage with the parallel garbage collector",
+          "default": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:jni+resolve=off",
+          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:jni+resolve=off` to optimize memory usage with the parallel garbage collector",
           "scope": "machine-overridable"
         },
         "java.errors.incompleteClasspath.severity": {

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -111,6 +111,9 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 			params.push(watchParentProcess + 'false');
 		}
 	}
+	if (vmargs.indexOf('-Xlog:jni+resolve=') < 0) {
+		params.push('-Xlog:jni+resolve=off');
+	}
 
 	parseVMargs(params, vmargs);
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Mitigate the issue https://github.com/redhat-developer/vscode-java/issues/2577#issuecomment-1208922149. The parameter `-Xlog:jni+resolve=off` is used to prevent some unexpected jni logs from being logged to stdout, because Java language server uses stdio as the jsonrpc channel by default.