### PR TITLE
Enable 'java.signatureHelp.enabled' and 'java.completion.guessMethodArguments'

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
         },
         "java.signatureHelp.enabled": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable/disable the signature help.",
           "scope": "window"
         },
@@ -498,7 +498,7 @@
         },
         "java.completion.guessMethodArguments": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "When set to true, method arguments are guessed when a method is selected from as list of code assist proposals.",
           "scope": "window"
         },


### PR DESCRIPTION
address https://github.com/redhat-developer/vscode-java/issues/2621, https://github.com/redhat-developer/vscode-java/issues/2063

As discussed before, let's enable them and see any feedbacks from pre-release channel.

Signed-off-by: sheche <sheche@microsoft.com>