### PR TITLE
Disable JVM logging by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,8 +213,8 @@
             "string",
             "null"
           ],
-          "default": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:jni+resolve=off",
-          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:jni+resolve=off` to optimize memory usage with the parallel garbage collector",
+          "default": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:disable",
+          "description": "Specifies extra VM arguments used to launch the Java Language Server. Eg. use `-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:disable` to optimize memory usage with the parallel garbage collector",
           "scope": "machine-overridable"
         },
         "java.errors.incompleteClasspath.severity": {

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -112,8 +112,8 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
 			params.push(`${watchParentProcess}false`);
 		}
 	}
-	if (vmargs.indexOf('-Xlog:jni+resolve=') < 0) {
-		params.push('-Xlog:jni+resolve=off');
+	if (vmargs.indexOf('-Xlog:') < 0) {
+		params.push('-Xlog:disable');
 	}
 
 	parseVMargs(params, vmargs);


### PR DESCRIPTION
- Since any JVM component may invoke logging, it may be best to disable all logging
- Related #2577
- Fixes #2292

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

Prompted again by https://github.com/redhat-developer/vscode-microprofile/issues/110#issuecomment-1255150646 , but also noticed it would fix the above opened issue.