### PR TITLE
Format content pasted into string literals

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,22 @@
+# .gitignore
+out
+server
+node_modules
+*.vsix
+.DS_Store
+.vscode-test
+undefined
+target
+dist
+jre
+lombok
+bin/
+.settings
+.classpath
+.project
+test/resources/projects/**/.vscode
+test/resources/projects/maven/salut/testGradle
+test-temp
+
+# specific to eslint
+vscode*.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -315,9 +315,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+      "version": "1.73.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
+      "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
       "dev": true
     },
     "@types/winreg": {
@@ -1245,6 +1245,16 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.3",
@@ -3095,6 +3105,13 @@
       "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3476,7 +3493,11 @@
           "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "is-binary-path": {
           "version": "1.0.1",
@@ -5140,6 +5161,13 @@
       "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
       "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "publisher": "redhat",
   "bugs": "https://github.com/redhat-developer/vscode-java/issues",
   "preview": false,
-  "enableProposedApi": false,
+  "enabledApiProposals": [
+    "documentPaste"
+  ],
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
@@ -1345,7 +1347,7 @@
     "build-server": "./node_modules/.bin/gulp build_server",
     "fast-build-server": "./node_modules/.bin/gulp dev_server",
     "watch-server": "./node_modules/.bin/gulp watch_server",
-    "eslint": "eslint --ignore-path .gitignore --ext .js,.ts ."
+    "eslint": "eslint --ignore-path .eslintignore --ext .js,.ts ."
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -182,6 +182,10 @@ export namespace Commands {
      * Organize imports silently.
      */
     export const ORGANIZE_IMPORTS_SILENTLY = "java.edit.organizeImports";
+	/**
+	 * Handle a paste event.
+	 */
+	export const HANDLE_PASTE_EVENT = "java.edit.handlePasteEvent";
     /**
      * Custom paste action (triggers auto-import)
      */

--- a/src/pasteEventHandler.ts
+++ b/src/pasteEventHandler.ts
@@ -1,0 +1,102 @@
+import { CancellationToken, commands, DataTransfer, DocumentPasteEdit as VDocumentPasteEdit, DocumentPasteEditProvider, DocumentPasteProviderMetadata, ExtensionContext, languages, Range, TextDocument, window } from "vscode";
+import { FormattingOptions, Location, WorkspaceEdit as PWorkspaceEdit } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
+import { Commands } from "./commands";
+import { JAVA_SELECTOR } from "./standardLanguageClient";
+
+const TEXT_MIMETYPE: string = "text/plain";
+const MIMETYPES: DocumentPasteProviderMetadata = {
+	pasteMimeTypes: [TEXT_MIMETYPE]
+};
+
+/**
+ * Parameters for `Commands.HANDLE_PASTE_EVENT`
+ */
+interface PasteEventParams {
+	location: Location;
+	text: string;
+	formattingOptions: FormattingOptions;
+	copiedDocumentUri?: string;
+}
+
+/**
+ * Response from jdt.ls for `Commands.HANDLE_PASTE_EVENT` that's similar, but not identical, to VS Code's paste edit.
+ *
+ * @see VDocumentPasteEdit
+ */
+interface PDocumentPasteEdit {
+	insertText: string;
+	additionalEdit: PWorkspaceEdit;
+}
+
+/**
+ * Registers the vscode-java DocumentPasteEditProviders and sets them up to be disposed.
+ *
+ * @param context the extension context
+ */
+export function registerPasteEventHandler(context: ExtensionContext, languageClient: LanguageClient) {
+	if (languages["registerDocumentPasteEditProvider"]) {
+		context.subscriptions.push(languages["registerDocumentPasteEditProvider"](JAVA_SELECTOR, new PasteEditProvider(languageClient), MIMETYPES));
+	}
+}
+
+/**
+ * `DocumentPasteEditProvider` that delegates to jdt.ls to make any changes necessary to the pasted text and add any additional workspace edits.
+ */
+class PasteEditProvider implements DocumentPasteEditProvider {
+
+	private languageClient: LanguageClient;
+	private copiedContent: string | undefined;
+	private copiedDocumentUri: string | undefined;
+
+	constructor(languageClient: LanguageClient) {
+		this.languageClient = languageClient;
+	}
+
+	async prepareDocumentPaste?(document: TextDocument, _ranges: readonly Range[], dataTransfer: DataTransfer, _token: CancellationToken): Promise<void> {
+		const copiedContent: string = await dataTransfer.get(TEXT_MIMETYPE).asString();
+		if (copiedContent) {
+			this.copiedDocumentUri = document.uri.toString();
+			this.copiedContent = copiedContent;
+		}
+	}
+
+	async provideDocumentPasteEdits(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): Promise<VDocumentPasteEdit> {
+
+		const insertText: string = await dataTransfer.get(TEXT_MIMETYPE).asString();
+
+		// don't try to provide for multi character inserts; the implementation will get messy and the feature won't be that helpful
+		if (!insertText || token.isCancellationRequested || ranges.length !== 1) {
+			return null;
+		}
+
+		const range = ranges[0];
+
+		const location: Location = {
+			range: this.languageClient.code2ProtocolConverter.asRange(range),
+			uri: document.uri.toString(),
+		};
+
+		const activeTextEditor = window.activeTextEditor;
+
+		const pasteEventParams: PasteEventParams = {
+			location: location,
+			text: insertText,
+			copiedDocumentUri: this.copiedContent === insertText ? this.copiedDocumentUri : undefined,
+			formattingOptions: {
+				insertSpaces: <boolean>activeTextEditor.options.insertSpaces,
+				tabSize: <number>activeTextEditor.options.tabSize
+			}
+		};
+
+		const pasteResponse: PDocumentPasteEdit = await commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.HANDLE_PASTE_EVENT, JSON.stringify(pasteEventParams));
+
+		if (pasteResponse) {
+			return {
+				insertText: pasteResponse.insertText,
+				additionalEdit: pasteResponse.additionalEdit ? this.languageClient.protocol2CodeConverter.asWorkspaceEdit(pasteResponse.additionalEdit) : undefined
+			} as VDocumentPasteEdit;
+		}
+	}
+
+}

--- a/vscode.proposed.documentPaste.d.ts
+++ b/vscode.proposed.documentPaste.d.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/30066/
+
+	/**
+	 * Provider invoked when the user copies and pastes code.
+	 */
+	interface DocumentPasteEditProvider {
+
+		/**
+		 * Optional method invoked after the user copies text in a file.
+		 *
+		 * During {@link prepareDocumentPaste}, an extension can compute metadata that is attached to
+		 * a {@link DataTransfer} and is passed back to the provider in {@link provideDocumentPasteEdits}.
+		 *
+		 * @param document Document where the copy took place.
+		 * @param ranges Ranges being copied in the `document`.
+		 * @param dataTransfer The data transfer associated with the copy. You can store additional values on this for later use in  {@link provideDocumentPasteEdits}.
+		 * @param token A cancellation token.
+		 */
+		prepareDocumentPaste?(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): void | Thenable<void>;
+
+		/**
+		 * Invoked before the user pastes into a document.
+		 *
+		 * In this method, extensions can return a workspace edit that replaces the standard pasting behavior.
+		 *
+		 * @param document Document being pasted into
+		 * @param ranges Currently selected ranges in the document.
+		 * @param dataTransfer The data transfer associated with the paste.
+		 * @param token A cancellation token.
+		 *
+		 * @return Optional workspace edit that applies the paste. Return undefined to use standard pasting.
+		 */
+		provideDocumentPasteEdits(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentPasteEdit>;
+	}
+
+	/**
+	 * An operation applied on paste
+	 */
+	class DocumentPasteEdit {
+		/**
+		 * The text or snippet to insert at the pasted locations.
+		 */
+		insertText: string | SnippetString;
+
+		/**
+		 * An optional additional edit to apply on paste.
+		 */
+		additionalEdit?: WorkspaceEdit;
+
+		/**
+		 * @param insertText The text or snippet to insert at the pasted locations.
+		 */
+		constructor(insertText: string | SnippetString);
+	}
+
+	interface DocumentPasteProviderMetadata {
+		/**
+		 * Mime types that `provideDocumentPasteEdits` should be invoked for.
+		 *
+		 * Use the special `files` mimetype to indicate the provider should be invoked if any files are present in the `DataTransfer`.
+		 */
+		readonly pasteMimeTypes: readonly string[];
+	}
+
+	namespace languages {
+		export function registerDocumentPasteEditProvider(selector: DocumentSelector, provider: DocumentPasteEditProvider, metadata: DocumentPasteProviderMetadata): Disposable;
+	}
+}


### PR DESCRIPTION
Testing this PR requires using `vscode-insiders` (until VS Code 1.74.0 is released).

Uses the proposed API to modify pasted strings. It invokes jdt.ls's `java.edit.handlePasteEvent` command when vscode-java receives a paste event. When pasting into a string literal, jdt.ls modifies the content that's inserted so that the string content reflects the original value of the copied text. It uses string concatenation instead of the newer Java multiline string feature to represent multiline text.

Requires https://github.com/eclipse/eclipse.jdt.ls/pull/2349
Closes https://github.com/redhat-developer/vscode-java/issues/1249