### PR TITLE
Synchronize bundles on demand

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -287,4 +287,15 @@ export namespace Commands {
      * The VS Code command to create module-info.java
      */
     export const CREATE_MODULE_INFO_COMMAND = "java.project.createModuleInfo.command";
+
+    /**
+     * The JDT.LS command to reload the bundle list (java extension contributions).
+     */
+    export const REFRESH_BUNDLES = "java.reloadBundles";
+
+    /**
+     * The VS Code command to reload the bundle list.
+     * JDT.LS will call this command before set the server to ready state.
+     */
+    export const REFRESH_BUNDLES_COMMAND = "_java.reloadBundles.command";
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import { workspace, extensions, ExtensionContext, window, commands, ViewColumn, Uri, languages, IndentAction, InputBoxOptions, EventEmitter, OutputChannel, TextDocument, RelativePattern, ConfigurationTarget, WorkspaceConfiguration, env, UIKind, CodeActionContext, Diagnostic, CodeActionTriggerKind, version } from 'vscode';
 import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClientOptions, RevealOutputChannelOn, ErrorHandler, Message, ErrorAction, CloseAction, DidChangeConfigurationNotification, CancellationToken, CodeActionRequest, CodeActionParams, Command } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
-import { collectJavaExtensions, isContributedPartUpdated } from './plugin';
+import { collectJavaExtensions, getBundlesToReload, isContributedPartUpdated } from './plugin';
 import { HEAP_DUMP_LOCATION, prepareExecutable } from './javaServerStarter';
 import * as requirements from './requirements';
 import { initialize as initializeRecommendation } from './recommendation';
@@ -382,6 +382,10 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_WORKSPACE, (force?: boolean) => cleanWorkspace(workspacePath, force)));
 
 			context.subscriptions.push(commands.registerCommand(Commands.GET_WORKSPACE_PATH, () => workspacePath));
+
+			context.subscriptions.push(commands.registerCommand(Commands.REFRESH_BUNDLES_COMMAND, () => {
+				return getBundlesToReload();
+			}));
 
 			context.subscriptions.push(onConfigurationChange(workspacePath, context));
 

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -111,6 +111,13 @@ export class StandardLanguageClient {
 						apiManager.updateServerMode(ServerMode.standard);
 						apiManager.fireDidServerModeChange(ServerMode.standard);
 						apiManager.resolveServerReadyPromise();
+
+						if (extensions.onDidChange) {// Theia doesn't support this API yet
+							extensions.onDidChange(async () => {
+								await onExtensionChange(extensions.all);
+							});
+						}
+
 						activationProgressNotification.hide();
 						if (!hasImported) {
 							showImportFinishNotification(context);
@@ -539,11 +546,6 @@ export class StandardLanguageClient {
 			refactorAction.registerCommands(this.languageClient, context);
 			pasteAction.registerCommands(this.languageClient, context);
 
-			if (extensions.onDidChange) {// Theia doesn't support this API yet
-				extensions.onDidChange(() => {
-					onExtensionChange(extensions.all);
-				});
-			}
 			excludeProjectSettingsFiles();
 
 			context.subscriptions.push(languages.registerCodeActionsProvider({ scheme: 'file', language: 'java' }, new RefactorDocumentProvider(), RefactorDocumentProvider.metadata));


### PR DESCRIPTION
- Allow server to ask bundles to synchronize before ready.
- When new bundle is detected, instead of asking user to reload window, we will try to let JDT.LS hot load the bundle first.

requires https://github.com/eclipse/eclipse.jdt.ls/pull/2267

### How to test
1. disable some extensions that have java extension contributions
2. launch redhat.java
3. after server is ready, enable an extension

https://user-images.githubusercontent.com/6193897/194814406-5f1925ee-df0a-40f3-905e-bb643c6c63fd.mp4

Signed-off-by: sheche <sheche@microsoft.com>