### PR TITLE
Add an option to enable/disable null analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,16 @@ The following settings are supported:
 * `java.configuration.workspaceCacheLimit` : The number of days (if enabled) to keep unused workspace cache data. Beyond this limit, cached workspace data may be removed.
 * `java.import.generatesMetadataFilesAtProjectRoot` : Specify whether the project metadata files(.project, .classpath, .factorypath, .settings/) will be generated at the project root. Defaults to `false`.
 * `java.inlayHints.parameterNames.enabled`: Enable/disable inlay hints for parameter names. Supported values are: `none`(disable parameter name hints), `literals`(Enable parameter name hints only for literal arguments) and `all`(Enable parameter name hints for literal and non-literal arguments). Defaults to `literals`.
-* `java.compile.nullAnalysis.nonnull`: Specify the Nonnull annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies.
-* `java.compile.nullAnalysis.nullable`: Specify the Nullable annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies.
+* `java.compile.nullAnalysis.nonnull`: Specify the Nonnull annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies. This setting will be ignored if `java.compile.nullAnalysis.enabled` is set to `disabled`.
+* `java.compile.nullAnalysis.nullable`: Specify the Nullable annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies. This setting will be ignored if `java.compile.nullAnalysis.enabled` is set to `disabled`.
 * `java.import.maven.offline.enabled`: Enable/disable the Maven offline mode. Defaults to `false`.
 * `java.codeAction.sortMembers.avoidVolatileChanges`: Reordering of fields, enum constants, and initializers can result in semantic and runtime changes due to different initialization and persistence order. This setting prevents this from occurring. Defaults to `true`.
 * `java.jdt.ls.protobufSupport.enabled`: Specify whether to automatically add Protobuf output source directories to the classpath. **Note:** Only works for Gradle `com.google.protobuf` plugin `0.8.4` or higher. Defaults to `true`.
 * `java.jdt.ls.androidSupport.enabled`: [Experimental] Specify whether to enable Android project importing. When set to `auto`, the Android support will be enabled in Visual Studio Code - Insiders. **Note:** Only works for Android Gradle Plugin `3.2.0` or higher. Defaults to `auto`.
 * `java.completion.postfix.enabled`: Enable/disable postfix completion support. Defaults to `true`.
+
+New in 1.13.0
+* `java.compile.nullAnalysis.mode`: Specify how to enable the annotation-based null analysis. Supported values are `disabled` (disable the null analysis), `interactive` (asks when null annotation types are detected), `automatic` (automatically enable null analysis when null annotation types are detected). Defaults to `disabled`.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -974,7 +974,7 @@
             "org.eclipse.jdt.annotation.NonNull",
             "org.springframework.lang.NonNull"
           ],
-          "markdownDescription": "Specify the Nonnull annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies.",
+          "markdownDescription": "Specify the Nonnull annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in project dependencies. This setting will be ignored if `java.compile.nullAnalysis.enabled` is set to `disabled`",
           "scope": "window"
         },
         "java.compile.nullAnalysis.nullable": {
@@ -984,7 +984,18 @@
             "org.eclipse.jdt.annotation.Nullable",
             "org.springframework.lang.Nullable"
           ],
-          "markdownDescription": "Specify the Nullable annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies.",
+          "markdownDescription": "Specify the Nullable annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in project dependencies. This setting will be ignored if `java.compile.nullAnalysis.enabled` is set to `disabled`",
+          "scope": "window"
+        },
+        "java.compile.nullAnalysis.mode": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "interactive",
+            "automatic"
+          ],
+          "default": "disabled",
+          "markdownDescription": "Specify how to enable the annotation-based null analysis.",
           "scope": "window"
         }
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -65,6 +65,11 @@ export namespace Commands {
     export const PROJECT_CONFIGURATION_STATUS = 'java.projectConfiguration.status';
 
     /**
+     * Set null analysis mode
+     */
+    export const NULL_ANALYSIS_SET_MODE = 'java.compile.nullAnalysis.setMode';
+
+    /**
      * Apply Workspace Edit
      */
     export const APPLY_WORKSPACE_EDIT = 'java.apply.workspaceEdit';

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -330,6 +330,8 @@ export class StandardLanguageClient {
 
 			context.subscriptions.push(commands.registerCommand(Commands.PROJECT_CONFIGURATION_STATUS, (uri, status) => setProjectConfigurationUpdate(this.languageClient, uri, status)));
 
+			context.subscriptions.push(commands.registerCommand(Commands.NULL_ANALYSIS_SET_MODE, (status) => setNullAnalysisStatus(status)));
+
 			context.subscriptions.push(commands.registerCommand(Commands.APPLY_WORKSPACE_EDIT, (obj) => {
 				applyWorkspaceEdit(obj, this.languageClient);
 			}));
@@ -682,6 +684,17 @@ function setProjectConfigurationUpdate(languageClient: LanguageClient, uri: Uri,
 	if (status !== FeatureStatus.disabled) {
 		projectConfigurationUpdate(languageClient, uri);
 	}
+}
+
+function setNullAnalysisStatus(status: FeatureStatus) {
+	const config = getJavaConfiguration();
+	const section = 'compile.nullAnalysis.mode';
+
+	const st = FeatureStatus[status];
+	config.update(section, st).then(
+		() => logger.info(`${section} set to ${st}`),
+		(error) => logger.error(error)
+	);
 }
 
 function decodeBase64(text: string): string {


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

requires https://github.com/eclipse/eclipse.jdt.ls/pull/2279

add new preference java.compile.nullAnalysis.mode.

- When set to interactive, a notification will show once null annotation types are detected when project is imported or null analysis related configuration changed.
- When set to automatic, the null analysis will be enabled.
- When set to disabled (default), the null analysis will be disabled.