### PR TITLE
Support quickfix for gradle jpms projects

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -291,7 +291,7 @@ export namespace Commands {
 
     export const GET_WORKSPACE_PATH = '_java.workspace.path';
 
-    export const UPGRADE_GRADLE_WRAPPER = '_java.gradle.upgradeWrapper';
+    export const UPGRADE_GRADLE_WRAPPER = 'java.project.upgradeGradle';
 
     export const LOMBOK_CONFIGURE = "java.lombokConfigure";
 

--- a/src/gradle/gradleCodeActionProvider.ts
+++ b/src/gradle/gradleCodeActionProvider.ts
@@ -13,12 +13,6 @@ const GRADLE_INVALID_TYPE_CODE_ID = GRADLE_PROBLEM_ID + 1;
 
 export class GradleCodeActionProvider implements CodeActionProvider<CodeAction> {
 
-	constructor(context: ExtensionContext) {
-		context.subscriptions.push(commands.registerCommand(Commands.UPGRADE_GRADLE_WRAPPER, (projectUri: string) => {
-			upgradeGradle(projectUri);
-		}));
-	}
-
 	public provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<(CodeAction | Command)[]> {
 		if (context?.diagnostics?.length && context.diagnostics[0].source === "Java") {
 			return this.provideGradleCodeActions(document, context.diagnostics);

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -581,6 +581,10 @@ export class StandardLanguageClient {
 				}
 			}));
 
+			context.subscriptions.push(commands.registerCommand(Commands.UPGRADE_GRADLE_WRAPPER, (projectUri: string, version?: string) => {
+				upgradeGradle(projectUri, version);
+			}));
+
 			languages.registerCodeActionsProvider({
 				language: "xml",
 				scheme: "file",
@@ -590,7 +594,7 @@ export class StandardLanguageClient {
 			languages.registerCodeActionsProvider({
 				scheme: "file",
 				pattern: "**/{gradle/wrapper/gradle-wrapper.properties,build.gradle,build.gradle.kts,settings.gradle,settings.gradle.kts}"
-			}, new GradleCodeActionProvider(context), gradleCodeActionMetadata);
+			}, new GradleCodeActionProvider(), gradleCodeActionMetadata);
 
 			if (languages.registerInlayHintsProvider) {
 				context.subscriptions.push(languages.registerInlayHintsProvider(JAVA_SELECTOR, new JavaInlayHintsProvider(this.languageClient)));

--- a/src/standardLanguageClientUtils.ts
+++ b/src/standardLanguageClientUtils.ts
@@ -133,15 +133,14 @@ export async function upgradeGradle(projectUri: string, version?: string): Promi
 		title: "Upgrading Gradle wrapper...",
 		cancellable: true,
 	}, (_progress, token) => {
-		return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, "java.project.upgradeGradle", projectUri, version, token);
+		return commands.executeCommand<string>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.UPGRADE_GRADLE_WRAPPER, projectUri, version, token);
 	});
 	if (result) {
-		const propertiesFile = path.join(Uri.parse(projectUri).fsPath, "gradle", "wrapper", "gradle-wrapper.properties");
-		if (fse.pathExists(propertiesFile)) {
-			const content = await fse.readFile(propertiesFile);
+		if (await fse.pathExists(result)) {
+			const content = await fse.readFile(result);
 			const offset = content.toString().indexOf("distributionUrl");
 			if (offset >= 0) {
-				const document = await workspace.openTextDocument(propertiesFile);
+				const document = await workspace.openTextDocument(result);
 				const position = document.positionAt(offset);
 				const distributionUrlRange = document.getWordRangeAtPosition(position);
 				window.showTextDocument(document, {selection: new Range(distributionUrlRange.start, new Position(distributionUrlRange.start.line + 1, 0))});


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

related to https://github.com/eclipse/eclipse.jdt.ls/pull/2304

this PR removes unnecessary client command `_java.gradle.upgradeWrapper`, and for all upgrade gradle command, we use `java.project.upgradeGradle` instead, at the server side, we also have such delegate command for use.

This PR provides a quick fix to upgrade Gradle version to 7.0.1, it can mitigate some Gradle compability issues in JPMS projects (see: https://github.com/microsoft/vscode-java-pack/issues/1080). The following steps will help to reproduce these issues:

1. given sample project https://github.com/HanSolo/tilesfx.git
> Note: the Gradle plugin `biz.aQute.bnd.builder` introduced in that sample project does not support Gradle 7, so we might need to disable it first
2. open it in VS Code with auto-build enabled, you can find several errors telling some types is not accessable.
3. Since we detect the problems in classpath indicator and Gradle version, we provide a Quickfix to help you update the Gradle version
![image](https://user-images.githubusercontent.com/45906942/218023947-938e912d-2acc-4fdf-ba2e-3702df2977a5.png)
4. when you click the button, the extension will help you update the Gradle version defined in the wrapper file and re-import the project, after that the above errors get disappear.





