### PR TITLE
Add missing import on paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "publisher": "redhat",
   "bugs": "https://github.com/redhat-developer/vscode-java/issues",
   "preview": false,
-  "enableProposedApi": false,
+  "enabledApiProposals": [
+    "documentPaste"
+  ],
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -177,6 +177,10 @@ export namespace Commands {
      */
     export const ORGANIZE_IMPORTS_SILENTLY = "java.edit.organizeImports";
     /**
+     * Add imports on paste.
+     */
+    export const ADD_IMPORTS_PASTE = "java.edit.addImportsOnPaste";
+    /**
      * Custom paste action (triggers auto-import)
      */
     export const CLIPBOARD_ONPASTE = 'java.action.clipboardPasteAction';

--- a/src/pasteEventHandler.ts
+++ b/src/pasteEventHandler.ts
@@ -1,0 +1,49 @@
+import { CancellationToken, commands, DataTransfer, DocumentPasteEdit, DocumentPasteEditProvider, DocumentPasteProviderMetadata, DocumentSelector, EndOfLine, ExtensionContext, languages, Range, TextDocument, TextEditor, window, WorkspaceEdit } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { Commands } from "./commands";
+import { JAVA_SELECTOR } from "./standardLanguageClient";
+
+const TEXT_MIMETYPE: string = "text/plain";
+
+const MIMETYPES: DocumentPasteProviderMetadata = {
+	pasteMimeTypes: [TEXT_MIMETYPE]
+};
+
+class StringPasteEditProvider implements DocumentPasteEditProvider {
+
+	private client: LanguageClient;
+	private copiedDocumentUri: string | undefined;
+	private copiedContent: string | undefined;
+
+	constructor(client: LanguageClient) {
+		this.client = client;
+	}
+
+	async prepareDocumentPaste(document: TextDocument, _ranges: readonly Range[], dataTransfer: DataTransfer, _token: CancellationToken): Promise<void> {
+		const copiedContent: string = await dataTransfer.get(TEXT_MIMETYPE).asString();
+		if (copiedContent) {
+			this.copiedContent = copiedContent;
+			this.copiedDocumentUri = document.uri.toString();
+		}
+	}
+
+	async provideDocumentPasteEdits(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, _token: CancellationToken): Promise<DocumentPasteEdit> {
+		const insertContent: string = await dataTransfer.get(TEXT_MIMETYPE).asString();
+		if (!insertContent) {
+			return new DocumentPasteEdit("");
+		}
+		const documentPasteEdit = new DocumentPasteEdit(insertContent);
+		const workspaceEdit = await commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.ADD_IMPORTS_PASTE, document.uri.toString(), JSON.stringify(this.client.code2ProtocolConverter.asRange(ranges[0])), insertContent, this.copiedContent === insertContent ? this.copiedDocumentUri : null);
+		if (workspaceEdit) {
+			documentPasteEdit.additionalEdit = this.client.protocol2CodeConverter.asWorkspaceEdit(workspaceEdit);
+		}
+		return documentPasteEdit;
+	}
+
+}
+
+export function registerPasteEventHandler(context: ExtensionContext, client: LanguageClient) {
+	if (languages["registerDocumentPasteEditProvider"]){
+		context.subscriptions.push(languages["registerDocumentPasteEditProvider"](JAVA_SELECTOR, new StringPasteEditProvider(client), MIMETYPES));
+	}
+}

--- a/vscode.proposed.documentPaste.d.ts
+++ b/vscode.proposed.documentPaste.d.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/30066/
+
+	/**
+	 * Provider invoked when the user copies and pastes code.
+	 */
+	interface DocumentPasteEditProvider {
+
+		/**
+		 * Optional method invoked after the user copies text in a file.
+		 *
+		 * During {@link prepareDocumentPaste}, an extension can compute metadata that is attached to
+		 * a {@link DataTransfer} and is passed back to the provider in {@link provideDocumentPasteEdits}.
+		 *
+		 * @param document Document where the copy took place.
+		 * @param ranges Ranges being copied in the `document`.
+		 * @param dataTransfer The data transfer associated with the copy. You can store additional values on this for later use in  {@link provideDocumentPasteEdits}.
+		 * @param token A cancellation token.
+		 */
+		prepareDocumentPaste?(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): void | Thenable<void>;
+
+		/**
+		 * Invoked before the user pastes into a document.
+		 *
+		 * In this method, extensions can return a workspace edit that replaces the standard pasting behavior.
+		 *
+		 * @param document Document being pasted into
+		 * @param ranges Currently selected ranges in the document.
+		 * @param dataTransfer The data transfer associated with the paste.
+		 * @param token A cancellation token.
+		 *
+		 * @return Optional workspace edit that applies the paste. Return undefined to use standard pasting.
+		 */
+		provideDocumentPasteEdits(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentPasteEdit>;
+	}
+
+	/**
+	 * An operation applied on paste
+	 */
+	class DocumentPasteEdit {
+		/**
+		 * The text or snippet to insert at the pasted locations.
+		 */
+		insertText: string | SnippetString;
+
+		/**
+		 * An optional additional edit to apply on paste.
+		 */
+		additionalEdit?: WorkspaceEdit;
+
+		/**
+		 * @param insertText The text or snippet to insert at the pasted locations.
+		 */
+		constructor(insertText: string | SnippetString);
+	}
+
+	interface DocumentPasteProviderMetadata {
+		/**
+		 * Mime types that `provideDocumentPasteEdits` should be invoked for.
+		 *
+		 * Use the special `files` mimetype to indicate the provider should be invoked if any files are present in the `DataTransfer`.
+		 */
+		readonly pasteMimeTypes: readonly string[];
+	}
+
+	namespace languages {
+		export function registerDocumentPasteEditProvider(selector: DocumentSelector, provider: DocumentPasteEditProvider, metadata: DocumentPasteProviderMetadata): Disposable;
+	}
+}


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

https://user-images.githubusercontent.com/45906942/201302153-f53d0a54-95ea-41e9-9f35-c5bd735e3321.mp4

related to https://github.com/eclipse/eclipse.jdt.ls/pull/2320
this PR requests VS Code proposed API (documentPaste).