### PR TITLE
Share indexes among workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ The following settings are supported:
 * `java.cleanup.actionsOnSave`: The list of clean ups to be run on the current document when it's saved. Clean ups can automatically fix code style or programming mistakes. [Click here](document/_java.learnMoreAboutCleanUps.md#java-clean-ups) to learn more about what each clean up does.
 * `java.import.gradle.annotationProcessing.enabled`: Enable/disable the annotation processing on Gradle projects and delegate to JDT APT. Only works for Gradle 5.2 or higher.
 
+New in 1.14.0
+* `java.sharedIndexes.enabled`: [Experimental] Specify whether to share indexes between different workspaces. Defaults to `auto` and the shared indexes is automatically enabled in Visual Studio Code - Insiders.
+  - auto
+  - on
+  - off
+* `java.sharedIndexes.location`: Specifies a common index location for all workspaces. See default values as follows:  
+  - Windows: `"~\\.jdt\\index"`
+  - macOS: `"~/Library/Caches/.jdt/index"`
+  - Linux: `"~/.jdt/index"`
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ New in 1.14.0
   - on
   - off
 * `java.sharedIndexes.location`: Specifies a common index location for all workspaces. See default values as follows:  
-  - Windows: `"~\\.jdt\\index"`
+  - Windows: First use `"$APPDATA\\.jdt\\index"`, or `"~\\.jdt\\index"` if it does not exist
   - macOS: `"~/Library/Caches/.jdt/index"`
-  - Linux: `"~/.jdt/index"`
+  - Linux: First use `"$XDG_CACHE_HOME/.jdt/index"`, or `"~/.cache/.jdt/index"` if it does not exist
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -1040,10 +1040,21 @@
           "default": [],
           "scope": "window"
         },
+        "java.sharedIndexes.enabled": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "on",
+            "off"
+          ],
+          "default": "auto",
+          "markdownDescription": "[Experimental] Specify whether to share indexes between different workspaces. When set to `auto`, shared indexes will be enabled in Visual Studio Code - Insiders.",
+          "scope": "window"
+        },
         "java.sharedIndexes.location": {
           "type": "string",
-          "markdownDescription": "Specifies a common index location for all workspaces. The default value '`$DEFAULT_CACHE`' uses the extension global cache directory as the shared index location. And leaving it blank disables the shared indexes.",
-          "default": "$DEFAULT_CACHE",
+          "markdownDescription": "Specifies a common index location for all workspaces. See default values as follows:\n \nWindows: `~\\.jdt\\index`\n \nmacOS: `~/Library/Caches/.jdt/index`\n \nLinux: `~/.jdt/index`",
+          "default": "",
           "scope": "window"
         }
       }
@@ -1181,6 +1192,11 @@
       {
         "command": "_java.learnMoreAboutCleanUps",
         "title": "Learn more about Java Clean Ups",
+        "category": "Java"
+      },
+      {
+        "command": "java.clean.sharedIndexes",
+        "title": "%java.clean.sharedIndexes%",
         "category": "Java"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1053,7 +1053,7 @@
         },
         "java.sharedIndexes.location": {
           "type": "string",
-          "markdownDescription": "Specifies a common index location for all workspaces. See default values as follows:\n \nWindows: `~\\.jdt\\index`\n \nmacOS: `~/Library/Caches/.jdt/index`\n \nLinux: `~/.jdt/index`",
+          "markdownDescription": "Specifies a common index location for all workspaces. See default values as follows:\n \nWindows: First use `\"$APPDATA\\\\.jdt\\\\index\"`, or `\"~\\\\.jdt\\\\index\"` if it does not exist\n \nmacOS: `\"~/Library/Caches/.jdt/index\"`\n \nLinux: First use `\"$XDG_CACHE_HOME/.jdt/index\"`, or `\"~/.cache/.jdt/index\"` if it does not exist",
           "default": "",
           "scope": "window"
         }

--- a/package.json
+++ b/package.json
@@ -1039,6 +1039,12 @@
           },
           "default": [],
           "scope": "window"
+        },
+        "java.sharedIndexes.location": {
+          "type": "string",
+          "markdownDescription": "Specifies a common index location for all workspaces. The default value '`$DEFAULT_CACHE`' uses the extension global cache directory as the shared index location. And leaving it blank disables the shared indexes.",
+          "default": "$DEFAULT_CACHE",
+          "scope": "window"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,5 +22,6 @@
 	"java.action.showSupertypeHierarchy": "Show Supertype Hierarchy",
 	"java.action.showSubtypeHierarchy": "Show Subtype Hierarchy",
 	"java.action.changeBaseType": "Base on this Type",
-	"java.project.createModuleInfo.command": "Create module-info.java"
+	"java.project.createModuleInfo.command": "Create module-info.java",
+	"java.clean.sharedIndexes": "Clean Shared Indexes"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -22,5 +22,6 @@
 	"java.action.showSupertypeHierarchy": "显示父类层次结构",
 	"java.action.showSubtypeHierarchy": "显示子类层次结构",
 	"java.action.changeBaseType": "基于此类型",
-	"java.project.createModuleInfo.command": "创建 module-info.java"
+	"java.project.createModuleInfo.command": "创建 module-info.java",
+	"java.clean.sharedIndexes": "清理共享的索引文件"
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -315,4 +315,9 @@ export namespace Commands {
      * JDT.LS will call this command before set the server to ready state.
      */
     export const REFRESH_BUNDLES_COMMAND = "_java.reloadBundles.command";
+
+    /**
+     * Clean everything in the shared index directory.
+     */
+    export const CLEAN_SHARED_INDEXES = "java.clean.sharedIndexes";
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -304,7 +304,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			}));
 
 			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_WORKSPACE, (force?: boolean) => cleanWorkspace(workspacePath, force)));
-			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_SHARED_INDEXES, () => cleanSharedIndexes()));
+			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_SHARED_INDEXES, () => cleanSharedIndexes(context)));
 
 			context.subscriptions.push(commands.registerCommand(Commands.GET_WORKSPACE_PATH, () => workspacePath));
 
@@ -604,8 +604,8 @@ async function cleanWorkspace(workspacePath, force?: boolean) {
 	commands.executeCommand(Commands.RELOAD_WINDOW);
 }
 
-async function cleanSharedIndexes() {
-	const sharedIndexLocation: string = getSharedIndexCache();
+async function cleanSharedIndexes(context: ExtensionContext) {
+	const sharedIndexLocation: string = getSharedIndexCache(context);
 	if (sharedIndexLocation && fs.existsSync(sharedIndexLocation)) {
 		const doIt = 'Clean and Reload';
 		const ans = await window.showWarningMessage('The shared indexes might be in use by other workspaces, do you want to clear it? New indexes will be built after reloading.',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ import { ClientErrorHandler } from './clientErrorHandler';
 import { Commands } from './commands';
 import { ClientStatus, ExtensionAPI } from './extension.api';
 import * as fileEventHandler from './fileEventHandler';
-import { HEAP_DUMP_LOCATION, prepareExecutable } from './javaServerStarter';
+import { getSharedIndexCache, HEAP_DUMP_LOCATION, prepareExecutable } from './javaServerStarter';
 import { initializeLogFile, logger } from './log';
 import { cleanupLombokCache } from "./lombokSupport";
 import { markdownPreviewProvider } from "./markdownPreviewProvider";
@@ -304,6 +304,7 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 			}));
 
 			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_WORKSPACE, (force?: boolean) => cleanWorkspace(workspacePath, force)));
+			context.subscriptions.push(commands.registerCommand(Commands.CLEAN_SHARED_INDEXES, () => cleanSharedIndexes()));
 
 			context.subscriptions.push(commands.registerCommand(Commands.GET_WORKSPACE_PATH, () => workspacePath));
 
@@ -601,6 +602,19 @@ async function cleanWorkspace(workspacePath, force?: boolean) {
 	const file = path.join(workspacePath, cleanWorkspaceFileName);
 	fs.closeSync(fs.openSync(file, 'w'));
 	commands.executeCommand(Commands.RELOAD_WINDOW);
+}
+
+async function cleanSharedIndexes() {
+	const sharedIndexLocation: string = getSharedIndexCache();
+	if (sharedIndexLocation && fs.existsSync(sharedIndexLocation)) {
+		const doIt = 'Clean and Reload';
+		const ans = await window.showWarningMessage('The shared indexes might be in use by other workspaces, do you want to clear it? New indexes will be built after reloading.',
+			doIt, "Cancel");
+		if (ans === doIt) {
+			deleteDirectory(sharedIndexLocation);
+			commands.executeCommand(Commands.RELOAD_WINDOW);
+		}
+	}
 }
 
 function openServerLogFile(workspacePath, column: ViewColumn = ViewColumn.Active): Thenable<boolean> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -132,7 +132,8 @@ function hasJavaConfigChanged(oldConfig: WorkspaceConfiguration, newConfig: Work
 		|| hasConfigKeyChanged('home', oldConfig, newConfig)
 		|| hasConfigKeyChanged('jdt.ls.vmargs', oldConfig, newConfig)
 		|| hasConfigKeyChanged('progressReports.enabled', oldConfig, newConfig)
-		|| hasConfigKeyChanged('server.launchMode', oldConfig, newConfig);
+		|| hasConfigKeyChanged('server.launchMode', oldConfig, newConfig)
+		|| hasConfigKeyChanged('sharedIndexes.location', oldConfig, newConfig);;
 }
 
 function hasConfigKeyChanged(key, oldConfig, newConfig) {

--- a/test/lightweight-mode-suite/extension.test.ts
+++ b/test/lightweight-mode-suite/extension.test.ts
@@ -23,6 +23,7 @@ suite('Java Language Extension - LightWeight', () => {
 				Commands.CLEAN_WORKSPACE,
 				Commands.SWITCH_SERVER_MODE,
 				Commands.OPEN_FILE,
+				Commands.CLEAN_SHARED_INDEXES,
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -88,6 +88,7 @@ suite('Java Language Extension - Standard', () => {
 				Commands.SHOW_CLASS_HIERARCHY,
 				Commands.LEARN_MORE_ABOUT_CLEAN_UPS,
 				Commands.OPEN_FILE,
+				Commands.CLEAN_SHARED_INDEXES,
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Requires https://github.com/eclipse/eclipse.jdt.ls/pull/2341

Provide a setting to control the shared index location, by default, it uses the global extension cache as the common index location.