### PR TITLE
Translate `jdt://` links in Hover to a command link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bin/
 .project
 test/resources/projects/**/.vscode
 test/resources/projects/maven/salut/testGradle
+test-temp

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -118,6 +118,12 @@ export namespace Commands {
      * Open Java formatter settings
      */
     export const OPEN_FORMATTER = 'java.open.formatter.settings';
+
+	/**
+	 * Open a file given the URI
+	 */
+	export const OPEN_FILE = 'java.open.file';
+
     /**
      * Clean the Java language server workspace
      */

--- a/src/goToDefinition.ts
+++ b/src/goToDefinition.ts
@@ -1,11 +1,9 @@
 'use strict';
 
 import {
-	CancellationToken,
-	Location,
-	LocationLink,
-	DefinitionParams,
-	DefinitionRequest
+	CancellationToken, DefinitionParams,
+	DefinitionRequest, Location,
+	LocationLink
 } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { getActiveLanguageClient } from './extension';

--- a/src/syntaxLanguageClient.ts
+++ b/src/syntaxLanguageClient.ts
@@ -1,14 +1,14 @@
 'use strict';
 
 import * as net from "net";
-import { LanguageClientOptions, DidChangeConfigurationNotification } from "vscode-languageclient";
-import { LanguageClient, StreamInfo, ServerOptions } from "vscode-languageclient/node";
-import { OutputInfoCollector, ClientErrorHandler, getJavaConfig } from "./extension";
-import { logger } from "./log";
-import { ServerMode } from "./settings";
-import { StatusNotification } from "./protocol";
+import { DidChangeConfigurationNotification, LanguageClientOptions } from "vscode-languageclient";
+import { LanguageClient, ServerOptions, StreamInfo } from "vscode-languageclient/node";
 import { apiManager } from "./apiManager";
-import { ExtensionAPI, ClientStatus } from "./extension.api";
+import { ClientErrorHandler, getJavaConfig, OutputInfoCollector } from "./extension";
+import { ClientStatus, ExtensionAPI } from "./extension.api";
+import { logger } from "./log";
+import { StatusNotification } from "./protocol";
+import { ServerMode } from "./settings";
 import { snippetCompletionProvider } from "./snippetCompletionProvider";
 
 const extensionName = "Language Support for Java (Syntax Server)";

--- a/test/lightweight-mode-suite/extension.test.ts
+++ b/test/lightweight-mode-suite/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { Commands } from '../../src/commands';
 import { extensions } from 'vscode';
+import { Commands } from '../../src/commands';
 
 suite('Java Language Extension - LightWeight', () => {
 
@@ -22,6 +22,7 @@ suite('Java Language Extension - LightWeight', () => {
 				Commands.OPEN_FORMATTER,
 				Commands.CLEAN_WORKSPACE,
 				Commands.SWITCH_SERVER_MODE,
+				Commands.OPEN_FILE,
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -1,12 +1,12 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as plugin from '../../src/plugin';
-import * as java from '../../src/javaServerStarter';
-import * as requirements from '../../src/requirements';
-import { Commands } from '../../src/commands';
 import { env } from 'process';
+import * as vscode from 'vscode';
+import { Commands } from '../../src/commands';
+import * as java from '../../src/javaServerStarter';
+import * as plugin from '../../src/plugin';
+import * as requirements from '../../src/requirements';
 
 suite('Java Language Extension - Standard', () => {
 
@@ -87,6 +87,7 @@ suite('Java Language Extension - Standard', () => {
 				Commands.SHOW_SUPERTYPE_HIERARCHY,
 				Commands.SHOW_CLASS_HIERARCHY,
 				Commands.LEARN_MORE_ABOUT_CLEAN_UPS,
+				Commands.OPEN_FILE,
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Translate all links to `jdt://` in hover documentation to a `command://` link that opens the corresponding document. This gets around a limitation of hover Markdown in VS Code, where custom schemes aren't supported in links.

Closes #2810

Signed-off-by: David Thompson <davthomp@redhat.com>
