### PR TITLE
Work around vsce refusal to publish extensions with proposed API

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
   "publisher": "redhat",
   "bugs": "https://github.com/redhat-developer/vscode-java/issues",
   "preview": false,
-  "enabledApiProposals": [
-    "documentPaste"
-  ],
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",


### PR DESCRIPTION
- enabledApiProposals is removed, and enablement can be controlled at the platform level

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

We haven't been publishing the paste feature in pre-releases because :

```
03:16:03   ERROR  Extensions using proposed API (enabledApiProposals: [...]) can't be published to the Marketplace
```
See https://github.com/microsoft/vscode-vsce/blob/8b49e9dfdf909ad3af2b9ec9c825f5b501f6d75e/src/publish.ts#L137-L142

@datho7561, @CsCherrYY  can you verify that with this change, it still works ? I would guess that even if the extension declares no proposed api, as long as the platform declares the extension is permitted, it should be fine. (ie. this exists anyways..

**product.json**
```
"extensionEnabledApiProposals": {
...
...
"redhat.java": ["documentPaste"]
...
...
}
```
)