### PR TITLE
React to vsce renaming to @vscode/vsce.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def installBuildRequirements(){
 	def nodeHome = tool 'nodejs-14.19.1'
 	env.PATH="${env.PATH}:${nodeHome}/bin"
 	sh "npm install -g typescript"
-	sh 'npm install -g "vsce"'
+	sh 'npm install -g --force "@vscode/vsce"'
 	sh 'npm install -g "ovsx"'
 }
 


### PR DESCRIPTION
- Use --force to override any older vsce provided by NodeJS tooling

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>