### PR TITLE
Fix recommendation popup

### DIFF
--- a/src/recommendation/handlerImpl.ts
+++ b/src/recommendation/handlerImpl.ts
@@ -52,7 +52,7 @@ export class HandlerImpl implements IHandler {
 			return;
 		}
 
-		const actions: Array<string> = Object.keys(UserChoice);
+		const actions: Array<string> = Object.values(UserChoice);
 		const answer = await vscode.window.showInformationMessage(message, ...actions);
 		if (answer === UserChoice.install) {
 			await installExtensionCmdHandler(extName, extName);


### PR DESCRIPTION
Fix Dependency Analytics recommendation keeps popping up

as a side effect of the [eslint](
https://github.com/redhat-developer/vscode-java/commit/d6a2fd53b97f8518ece92cbae4d4b580c1aafe69#diff-8379712af3f04ba5e3bab41e28487f9ef98b28639f471d3a573a44d7a9785085R19-R21) the 
recommendation logic failed to compare the stored value (Capitalized enum value) to the  enum key (lower case). This made the recommendation pop up eveery time a pom.xml is opened

Fixes #2892


Signed-off-by: Fred Bricon <fbricon@gmail.com>
