### PR TITLE
Return the API before importing the projects

### DIFF
--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -11,7 +11,7 @@ import { apiManager } from "./apiManager";
 import * as buildPath from './buildpath';
 import { javaRefactorKinds, RefactorDocumentProvider } from "./codeActionProvider";
 import { Commands } from "./commands";
-import { ClientStatus, ExtensionAPI } from "./extension.api";
+import { ClientStatus } from "./extension.api";
 import * as fileEventHandler from './fileEventHandler';
 import { gradleCodeActionMetadata, GradleCodeActionProvider } from "./gradle/gradleCodeActionProvider";
 import { JavaInlayHintsProvider } from "./inlayHintsProvider";
@@ -56,7 +56,7 @@ export class StandardLanguageClient {
 	private languageClient: LanguageClient;
 	private status: ClientStatus = ClientStatus.uninitialized;
 
-	public async initialize(context: ExtensionContext, requirements: RequirementsData, clientOptions: LanguageClientOptions, workspacePath: string, jdtEventEmitter: EventEmitter<Uri>, resolve: (value: ExtensionAPI) => void): Promise<void> {
+	public async initialize(context: ExtensionContext, requirements: RequirementsData, clientOptions: LanguageClientOptions, workspacePath: string, jdtEventEmitter: EventEmitter<Uri>): Promise<void> {
 		if (this.status !== ClientStatus.uninitialized) {
 			return;
 		}
@@ -139,13 +139,11 @@ export class StandardLanguageClient {
 						serverStatus.updateServerStatus(ServerStatusKind.ready);
 						commands.executeCommand('setContext', 'javaLSReady', true);
 						apiManager.updateStatus(ClientStatus.started);
-						resolve(apiManager.getApiInstance());
 						break;
 					case 'Error':
 						this.status = ClientStatus.error;
 						serverStatus.updateServerStatus(ServerStatusKind.error);
 						apiManager.updateStatus(ClientStatus.error);
-						resolve(apiManager.getApiInstance());
 						break;
 					case 'ProjectStatus':
 						if (report.message === "WARNING") {

--- a/src/syntaxLanguageClient.ts
+++ b/src/syntaxLanguageClient.ts
@@ -5,10 +5,11 @@ import { DidChangeConfigurationNotification, LanguageClientOptions } from "vscod
 import { LanguageClient, ServerOptions, StreamInfo } from "vscode-languageclient/node";
 import { apiManager } from "./apiManager";
 import { ClientErrorHandler } from "./clientErrorHandler";
-import { ClientStatus, ExtensionAPI } from "./extension.api";
+import { ClientStatus } from "./extension.api";
 import { logger } from "./log";
 import { OutputInfoCollector } from "./outputInfoCollector";
 import { StatusNotification } from "./protocol";
+import { RequirementsData } from "./requirements";
 import { ServerMode } from "./settings";
 import { snippetCompletionProvider } from "./snippetCompletionProvider";
 import { getJavaConfig } from "./utils";
@@ -19,7 +20,7 @@ export class SyntaxLanguageClient {
 	private languageClient: LanguageClient;
 	private status: ClientStatus = ClientStatus.uninitialized;
 
-	public initialize(requirements, clientOptions: LanguageClientOptions, resolve: (value: ExtensionAPI) => void, serverOptions?: ServerOptions) {
+	public initialize(requirements: RequirementsData, clientOptions: LanguageClientOptions, serverOptions?: ServerOptions) {
 		const newClientOptions: LanguageClientOptions = Object.assign({}, clientOptions, {
 			middleware: {
 				workspace: {
@@ -75,7 +76,7 @@ export class SyntaxLanguageClient {
 							break;
 					}
 					if (apiManager.getApiInstance().serverMode === ServerMode.lightWeight) {
-						this.resolveApiOnReady(resolve);
+						apiManager.fireDidServerModeChange(ServerMode.lightWeight);
 					}
 				});
 			});
@@ -111,15 +112,4 @@ export class SyntaxLanguageClient {
 		return this.languageClient;
 	}
 
-	public resolveApi(resolve: (value: ExtensionAPI) => void): void {
-		apiManager.getApiInstance().serverMode = ServerMode.lightWeight;
-		apiManager.fireDidServerModeChange(ServerMode.lightWeight);
-		this.resolveApiOnReady(resolve);
-	}
-
-	private resolveApiOnReady(resolve: (value: ExtensionAPI) => void): void {
-		if ([ClientStatus.started, ClientStatus.error].includes(this.status)) {
-			resolve(apiManager.getApiInstance());
-		}
-	}
 }

--- a/test/lightweight-mode-suite/publicApi.test.ts
+++ b/test/lightweight-mode-suite/publicApi.test.ts
@@ -1,13 +1,13 @@
 'use strict';
 
 import * as assert from 'assert';
-import * as path from 'path';
-import { ExtensionAPI, extensionApiVersion, ClasspathResult } from '../../src/extension.api';
-import { Uri, DocumentSymbol, extensions, commands } from 'vscode';
-import { ServerMode } from '../../src/settings';
 import * as fse from 'fs-extra';
-import { getJavaConfiguration } from '../../src/utils';
+import * as path from 'path';
+import { commands, DocumentSymbol, extensions, Uri } from 'vscode';
 import { Commands } from '../../src/commands';
+import { ClasspathResult, ExtensionAPI, extensionApiVersion } from '../../src/extension.api';
+import { ServerMode } from '../../src/settings';
+import { getJavaConfiguration } from '../../src/utils';
 import { constants } from '../common';
 
 const pomPath: string = path.join(constants.projectFsPath, 'pom.xml');
@@ -31,7 +31,7 @@ suite('Public APIs - LightWeight', () => {
 
 	test('status should be correct', async function () {
 		const api: ExtensionAPI = extensions.getExtension('redhat.java').exports;
-		assert.equal(api.status, 'Started');
+		assert.equal(api.status, 'Starting');
 	});
 
 	test('registerHoverCommand should work', async function () {

--- a/test/standard-mode-suite/gotoSuperImplementation.test.ts
+++ b/test/standard-mode-suite/gotoSuperImplementation.test.ts
@@ -2,8 +2,9 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
-import { Uri, extensions, commands, TextDocument, workspace, window, Selection, Position } from 'vscode';
+import { commands, extensions, Position, Selection, TextDocument, Uri, window, workspace } from 'vscode';
 import { Commands } from '../../src/commands';
+import { ExtensionAPI } from '../../src/extension.api';
 
 const projectFsPath: string = path.join(__dirname, '..', '..', '..', 'test', 'resources', 'projects', 'maven', 'salut');
 const fileFsPath: string = path.join(projectFsPath, 'src', 'main', 'java', 'java', 'Foo3.java');
@@ -11,7 +12,8 @@ const fileFsPath: string = path.join(projectFsPath, 'src', 'main', 'java', 'java
 suite('Goto Super Implementation', () => {
 
 	suiteSetup(async function() {
-		await extensions.getExtension('redhat.java').activate();
+		const api: ExtensionAPI = await extensions.getExtension('redhat.java').activate();
+		await api.serverReady();
 	});
 
 	test('go to super implementation should work', async function () {

--- a/test/standard-mode-suite/publicApi.test.ts
+++ b/test/standard-mode-suite/publicApi.test.ts
@@ -1,15 +1,15 @@
 'use strict';
 
 import * as assert from 'assert';
-import * as path from 'path';
-import { ExtensionAPI, extensionApiVersion, ClasspathResult } from '../../src/extension.api';
-import { Uri, DocumentSymbol, extensions, commands } from 'vscode';
-import { ServerMode } from '../../src/settings';
 import * as fse from 'fs-extra';
-import { getJavaConfiguration } from '../../src/utils';
-import { Commands } from '../../src/commands';
-import { constants } from '../common';
+import * as path from 'path';
 import { env } from 'process';
+import { commands, DocumentSymbol, extensions, Uri } from 'vscode';
+import { Commands } from '../../src/commands';
+import { ClasspathResult, ExtensionAPI, extensionApiVersion } from '../../src/extension.api';
+import { ServerMode } from '../../src/settings';
+import { getJavaConfiguration } from '../../src/utils';
+import { constants } from '../common';
 
 const pomPath: string = path.join(constants.projectFsPath, 'pom.xml');
 const gradleTestFolder: string = path.join(constants.projectFsPath, 'testGradle');
@@ -34,6 +34,7 @@ suite('Public APIs - Standard', () => {
 
 	test('status should be correct', async function () {
 		const api: ExtensionAPI = extensions.getExtension('redhat.java').exports;
+		await api.serverReady();
 		assert.equal(api.status, 'Started');
 	});
 


### PR DESCRIPTION
This also has the side effect that extensions that depend on vscode-java can start up sooner.

Fixes #2900

Signed-off-by: David Thompson <davthomp@redhat.com>
