### PR TITLE
Clarify the README quick start instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Provides Java &trade; language support via
 Quick Start
 ============
 1. Install the Extension
-2. If you do not have a _Java_ Development Kit correctly [set](#setting-the-jdk)
-    * Download and install a Java Development Kit for your project (Java 1.5 or above is supported)
-3. Extension is activated when you first access a Java file
+2. On the following platforms, the extension should activate without any setup : `win32-x64`, `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`.\
+If on another platform, or using the "universal" version, you can [set](#setting-the-jdk) a _Java_ Development Kit. It must be Java 17 or above.
+3. Optionally, download and install a Java Development Kit for your project (Java 1.5 or above is supported). See [Project JDKs](#project-jdks) for more details
+4. Extension is activated when you first access a Java file
     * Recognizes projects with *Maven* or *Gradle* build files in the directory hierarchy.
 
 Features
@@ -59,7 +60,7 @@ Now that Java extension will publish platform specific versions, it will embed a
 
 The following part is only kept for the universal version without embedded JRE.
 
->The tooling JDK will be used to launch the Language Server for Java. And by default, will also be used to compile your projects.\
+>The tooling JDK will be used to launch the Language Server for Java. And by default, will also be used to compile your projects. Java 17 is the minimum required version.\
 \
 The path to the Java Development Kit can be specified by the `java.jdt.ls.java.home` setting in VS Code settings (workspace/user settings). If not specified, it is searched in the following order until a JDK meets current minimum requirement.
 >- the `JDK_HOME` environment variable


### PR DESCRIPTION
- Be more clear about when the extension is expected to work without any setup, and when setting a JDK is required
- Make it more clear that configuring a project JDK is optional

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

In https://github.com/redhat-developer/vscode-java/issues/2837#issuecomment-1386325035, @phaumer mentioned that our instructions don't mention anything about the universal vsix requiring Java 17 as a minimum to start up.

I've reworded the quick start to make it a bit more clear. The tricky part is it's a "quick start" so it's not meant to go into too much detail on every possible scenario.