### PR TITLE
Add Github action to detect potential duplicate issues

### DIFF
--- a/.github/workflows/duplicate-issues-detector.yaml
+++ b/.github/workflows/duplicate-issues-detector.yaml
@@ -1,0 +1,34 @@
+name: Potential Duplicate Issues
+on:
+  issues:
+    types: [opened, edited] #edited means the issue title changed
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/potential-duplicates@4d4ea0352e0383859279938e255179dd1dbb67b5 #v1.1.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Issue title filter work with anymatch https://www.npmjs.com/package/anymatch.
+          # Any matched issue will stop detection immediately.
+          # You can specify multi filters in each line.
+          filter: ''
+          # Exclude keywords in title before detecting.
+          exclude: 'regression'
+          # Label to set, when potential duplicates are detected.
+          label: potential-duplicate
+          # Get issues with state to compare. Supported state: 'all', 'closed', 'open'.
+          state: all
+          # If similarity is higher than this threshold([0,1]), issue will be marked as duplicate.
+          threshold: 0.6
+          # Reactions to be add to comment when potential duplicates are detected.
+          # Available reactions: "-1", "+1", "confused", "laugh", "heart", "hooray", "rocket", "eyes"
+          reactions: 'confused'
+          # Comment to post when potential duplicates are detected.
+          comment: |
+            We have found issues that are potential duplicates: {{#issues}}
+              - #{{ number }} ({{ accuracy }}%)
+            {{/issues}}
+
+            If any of the issues listed above are a duplicate, please consider closing this issue & upvoting/commenting the original one.
+            Alternatively, if neither of the listed issues addresses your feature/bug, keep this issue open.


### PR DESCRIPTION
- Duplicate detection is only performed against the issue title.
- it's only triggered on new issues or when the issue title is edited

Signed-off-by: Fred Bricon <fbricon@gmail.com>
