### PR TITLE
Enable no-response bot to auto close inactive issues

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -7,8 +7,7 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # every morning at 00:00 am
-    - cron: '0 0 * * *'
+    - cron: '0 10 * * *'
 
 jobs:
   noResponse:
@@ -17,7 +16,7 @@ jobs:
       - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb #v0.5.0
         with:
           token: ${{ github.token }}
-          daysUntilClose: 14 # Number of days of inactivity before an Issue is closed for lack of response
+          daysUntilClose: 30 # Number of days of inactivity before an Issue is closed for lack of response
           responseRequiredLabel: "need info" # Label indicating that a response from the original author is required
           closeComment: >
             This issue has been closed automatically because it needs more information and has not had recent activity. Please reach out if you have or find the answers we need so that we can investigate further.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,24 @@
+name: No Response
+
+# **What it does**: Closes issues where the original author doesn't respond to a request for information.
+# **Why we have it**: To remove the need for maintainers to remember to check back on issues periodically to see if contributors have responded.
+# **Who does it impact**: Everyone that works on docs or docs-internal.
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # every morning at 00:00 am
+    - cron: '0 0 * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          daysUntilClose: 14 # Number of days of inactivity before an Issue is closed for lack of response
+          responseRequiredLabel: "need info" # Label indicating that a response from the original author is required
+          closeComment: >
+            This issue has been closed automatically because it needs more information and has not had recent activity. Please reach out if you have or find the answers we need so that we can investigate further.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -2,7 +2,6 @@ name: No Response
 
 # **What it does**: Closes issues where the original author doesn't respond to a request for information.
 # **Why we have it**: To remove the need for maintainers to remember to check back on issues periodically to see if contributors have responded.
-# **Who does it impact**: Everyone that works on docs or docs-internal.
 
 on:
   issue_comment:
@@ -15,7 +14,7 @@ jobs:
   noResponse:
     runs-on: ubuntu-latest
     steps:
-      - uses: lee-dohm/no-response@v0.5.0
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb #v0.5.0
         with:
           token: ${{ github.token }}
           daysUntilClose: 14 # Number of days of inactivity before an Issue is closed for lack of response


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It auto closes those inactive issues:
- Marked as `"need info"`
- Inactive for 14 days