### PR TITLE
fix type hierarchy regression since VS Code 1.75.1

### DIFF
--- a/src/typeHierarchy/model.ts
+++ b/src/typeHierarchy/model.ts
@@ -79,7 +79,7 @@ export class TypeHierarchyModel implements SymbolItemNavigation<TypeHierarchyIte
 	}
 
 	location(item: TypeHierarchyItem) {
-		return new vscode.Location(vscode.Uri.file(item.uri), item.range);
+		return new vscode.Location(vscode.Uri.parse(item.uri), item.range);
 	}
 
 	nearest(uri: vscode.Uri, _position: vscode.Position): TypeHierarchyItem | undefined {


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

fix https://github.com/eclipse/eclipse.jdt.ls/issues/2454

Root cause: 

- There was a bug in `TypeHierarchyModel.location()`, we should use `Uri.parse()` instead of `Uri.file()` since we're using `jdt` scheme to express class types. Before VS Code 1.75.1, this method will not be called since we bind correct Uri in the tree item command: https://github.com/redhat-developer/vscode-java/blob/a5a061fde0003b75629f7573fc9a097ea570d05e/src/typeHierarchy/model.ts#L122-L128
- VS Code 1.75.1 introduces a change to auto reveal the item when it's selected, see: https://github.com/microsoft/vscode/commit/a89b0e97a1a23de931694d7d87b3879c3b00fd1e, in this process, `TypeHierarchyModel.location()` will be called, causing this bug.