### PR TITLE
update vscode engine to 1.74.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -301,7 +301,7 @@
     },
     "@types/sinon": {
       "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
       "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
       "dev": true,
       "requires": {
@@ -315,9 +315,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.73.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
-      "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
+      "version": "1.75.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
+      "integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
       "dev": true
     },
     "@types/winreg": {
@@ -871,7 +871,7 @@
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true
     },
@@ -1453,7 +1453,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "requires": {
@@ -2140,7 +2140,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
           "dev": true
         }
@@ -2325,7 +2325,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
@@ -3685,7 +3685,7 @@
       "dependencies": {
         "request": {
           "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/request/-/request-2.88.2.tgz",
           "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
           "dev": true,
           "requires": {
@@ -3713,7 +3713,7 @@
         },
         "request-progress": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
           "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
           "dev": true,
           "requires": {
@@ -3730,7 +3730,7 @@
     },
     "gulp-util": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha512-q5oWPc12lwSFS9h/4VIjG+1NuNDlJ48ywV2JKItY4Ycc/n1fXJeYPVQsfu5ZrhQi7FGSDBalwUCLar/GyHXKGw==",
       "dev": true,
       "requires": {
@@ -3756,19 +3756,19 @@
       "dependencies": {
         "clone": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/clone/-/clone-1.0.4.tgz",
           "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
           "dev": true
         },
         "clone-stats": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
           "integrity": "sha512-dhUqc57gSMCo6TX85FLfe51eC/s+Im2MLkAgJwfaRRexR2tA4dd3eLEW4L6efzHc2iNorrRRXITifnDLlRrhaA==",
           "dev": true
         },
         "lodash.template": {
           "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "integrity": "sha512-0B4Y53I0OgHUJkt+7RmlDFWKjVAI/YUpWNiL9GQz5ORDr4ttgfQGo+phBWKFLJbBdtOwgMuUkdOHOnPg45jKmQ==",
           "dev": true,
           "requires": {
@@ -3785,19 +3785,19 @@
         },
         "object-assign": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
           "dev": true
         },
         "replace-ext": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "integrity": "sha512-AFBWBy9EVRTa/LhEcG8QDP3FvpwZqmvN2QFDuJswFeaVhWnZMp8q3E6Zd90SR04PlIwfGdyVjNyLPyen/ek5CQ==",
           "dev": true
         },
         "vinyl": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha512-P5zdf3WB9uzr7IFoVQ2wZTmUwHL8cMZWJGzLBNCHNZ3NB6HTMsYABtt7z8tAGIINLXyAob9B9a1yzVGMFOYKEA==",
           "dev": true,
           "requires": {
@@ -3844,7 +3844,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "requires": {
@@ -4869,7 +4869,7 @@
     },
     "minimist": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
@@ -6580,7 +6580,7 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true
     },
@@ -7637,7 +7637,7 @@
     },
     "yargs-parser": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
       "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "virtualWorkspaces": false
   },
   "engines": {
-    "vscode": "^1.65.0"
+    "vscode": "^1.74.0"
   },
   "repository": {
     "type": "git",
@@ -1400,7 +1400,7 @@
     "@types/node": "^8.10.51",
     "@types/semver": "^7.3.8",
     "@types/sinon": "^10.0.12",
-    "@types/vscode": "^1.65.0",
+    "@types/vscode": "^1.74.0",
     "@types/winreg": "^1.2.30",
     "@types/winston": "^2.4.4",
     "@vscode/test-electron": "^2.1.5",


### PR DESCRIPTION
Since we're using proposed `documentPaste` API in #2703, which is only available since VS Code 1.74, we should update the require VS Code version to keep the compatibility.

fix #2950

@rgrunber could you please verify if there is any compatibility issue in Theia?