### PR TITLE
Fix regression in API impacting Codespaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,8 @@ import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { CodeActionContext, CodeActionTriggerKind, commands, ConfigurationTarget, Diagnostic, env, EventEmitter, ExtensionContext, extensions, IndentAction, InputBoxOptions, languages, RelativePattern, TextDocument, UIKind, Uri, ViewColumn, window, workspace, WorkspaceConfiguration } from 'vscode';
-import { CancellationToken, CodeActionParams, CodeActionRequest, Command, DidChangeConfigurationNotification, ExecuteCommandParams, ExecuteCommandRequest, LanguageClientOptions, RevealOutputChannelOn, State } from 'vscode-languageclient';
+import { CodeActionContext, commands, ConfigurationTarget, Diagnostic, env, EventEmitter, ExtensionContext, extensions, IndentAction, InputBoxOptions, languages, RelativePattern, TextDocument, UIKind, Uri, ViewColumn, window, workspace, WorkspaceConfiguration } from 'vscode';
+import { CancellationToken, CodeActionParams, CodeActionRequest, Command, DidChangeConfigurationNotification, ExecuteCommandParams, ExecuteCommandRequest, LanguageClientOptions, RevealOutputChannelOn } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { apiManager } from './apiManager';
 import { ClientErrorHandler } from './clientErrorHandler';
@@ -379,8 +379,12 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 				const importOnStartup = config.get(importOnStartupSection);
 				if (importOnStartup === "disabled" ||
 					env.uiKind === UIKind.Web && env.appName.includes("Visual Studio Code")) {
+					apiManager.getApiInstance().serverMode = ServerMode.lightWeight;
+					apiManager.fireDidServerModeChange(ServerMode.lightWeight);
 					requireStandardServer = false;
 				} else if (importOnStartup === "interactive" && await workspaceContainsBuildFiles()) {
+					apiManager.getApiInstance().serverMode = ServerMode.lightWeight;
+					apiManager.fireDidServerModeChange(ServerMode.lightWeight);
 					requireStandardServer = await promptUserForStandardServer(config);
 				} else {
 					requireStandardServer = true;


### PR DESCRIPTION
The API wouldn't report lightweight mode correctly when it was forced to start in lightweight due to vscode-java detecting it was being run in Codespaces. This broke the mechanism to switch to standard mode in Codespaces.

Fixes #2968

Signed-off-by: David Thompson <davthomp@redhat.com>
