### PR TITLE
Add API to track lsp perf on language client level

### DIFF
--- a/src/TracingLanguageClient.ts
+++ b/src/TracingLanguageClient.ts
@@ -53,7 +53,7 @@ export class TracingLanguageClient extends LanguageClient {
 	}
 
 	private sendRequest0(method: any, ...args) {
-		if (!args) {
+		if (!args || !args.length) {
 			return super.sendRequest(method);
 		}
 

--- a/src/TracingLanguageClient.ts
+++ b/src/TracingLanguageClient.ts
@@ -1,3 +1,4 @@
+import { performance } from "perf_hooks";
 import { Event, EventEmitter } from "vscode";
 import { CancellationToken, LanguageClient, LanguageClientOptions, ProtocolRequestType, ProtocolRequestType0, RequestType, RequestType0, ServerOptions } from "vscode-languageclient/node";
 import { TraceEvent } from "./extension.api";
@@ -15,7 +16,7 @@ export class TracingLanguageClient extends LanguageClient {
 	start(): Promise<void> {
 		const isFirstTimeStart: boolean = !this.isStarted;
 		this.isStarted = true;
-		const startAt: number = Date.now();
+		const startAt: number = performance.now();
 		return super.start().then(value => {
 			if (isFirstTimeStart) {
 				this.fireTraceEvent("initialize", startAt);
@@ -41,7 +42,7 @@ export class TracingLanguageClient extends LanguageClient {
 	sendRequest<R>(method: string, token?: CancellationToken): Promise<R>;
 	sendRequest<R>(method: string, param: any, token?: CancellationToken): Promise<R>;
 	sendRequest(method: any, ...args) {
-		const startAt: number = Date.now();
+		const startAt: number = performance.now();
 		const requestType: string = this.getRequestType(method, ...args);
 		return this.sendRequest0(method, ...args).then(value => {
 			this.fireTraceEvent(requestType, startAt);
@@ -88,7 +89,7 @@ export class TracingLanguageClient extends LanguageClient {
 	}
 
 	private fireTraceEvent(type: string, startAt: number, reason?: any): void {
-		const duration: number = Date.now() - startAt;
+		const duration: number = performance.now() - startAt;
 		requestEventEmitter.fire({
 			type,
 			duration,

--- a/src/TracingLanguageClient.ts
+++ b/src/TracingLanguageClient.ts
@@ -79,7 +79,7 @@ export class TracingLanguageClient extends LanguageClient {
 		}
 
 		if (requestType === "workspace/executeCommand") {
-			if (args && args[0]?.command) {
+			if (args?.[0]?.command) {
 				requestType = `workspace/executeCommand/${args[0].command}`;
 			}
 		}

--- a/src/TracingLanguageClient.ts
+++ b/src/TracingLanguageClient.ts
@@ -1,0 +1,98 @@
+import { Event, EventEmitter } from "vscode";
+import { CancellationToken, LanguageClient, LanguageClientOptions, ProtocolRequestType, ProtocolRequestType0, RequestType, RequestType0, ServerOptions } from "vscode-languageclient/node";
+import { TraceEvent } from "./extension.api";
+
+const requestEventEmitter = new EventEmitter<TraceEvent>();
+export const onDidRequestEnd: Event<TraceEvent> = requestEventEmitter.event;
+
+export class TracingLanguageClient extends LanguageClient {
+	private isStarted: boolean = false;
+
+	constructor(id: string, name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions, forceDebug?: boolean) {
+		super(id, name, serverOptions, clientOptions, forceDebug);
+	}
+
+	start(): Promise<void> {
+		const isFirstTimeStart: boolean = !this.isStarted;
+		this.isStarted = true;
+		const startAt: number = Date.now();
+		return super.start().then(value => {
+			if (isFirstTimeStart) {
+				this.fireTraceEvent("initialize", startAt);
+			}
+			return value;
+		}, reason => {
+			if (isFirstTimeStart) {
+				this.fireTraceEvent("initialize", startAt, reason);
+			}
+			throw reason;
+		});
+	}
+
+	stop(timeout?: number): Promise<void> {
+		this.isStarted = false;
+		return super.stop(timeout);
+	}
+
+	sendRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, token?: CancellationToken): Promise<R>;
+	sendRequest<P, R, PR, E, RO>(type: ProtocolRequestType<P, R, PR, E, RO>, params: P, token?: CancellationToken): Promise<R>;
+	sendRequest<R, E>(type: RequestType0<R, E>, token?: CancellationToken): Promise<R>;
+	sendRequest<P, R, E>(type: RequestType<P, R, E>, params: P, token?: CancellationToken): Promise<R>;
+	sendRequest<R>(method: string, token?: CancellationToken): Promise<R>;
+	sendRequest<R>(method: string, param: any, token?: CancellationToken): Promise<R>;
+	sendRequest(method: any, ...args) {
+		const startAt: number = Date.now();
+		const requestType: string = this.getRequestType(method, ...args);
+		return this.sendRequest0(method, ...args).then(value => {
+			this.fireTraceEvent(requestType, startAt);
+			return value;
+		}, reason => {
+			this.fireTraceEvent(requestType, startAt, reason);
+			throw reason;
+		});
+	}
+
+	private sendRequest0(method: any, ...args) {
+		if (!args) {
+			return super.sendRequest(method);
+		}
+
+		const first = args[0];
+		const last = args[args.length - 1];
+		if (CancellationToken.is(last)) {
+			if (first === last) {
+				return super.sendRequest(method, last);
+			} else {
+				return super.sendRequest(method, first, last);
+			}
+		}
+
+		return super.sendRequest(method, first);
+	}
+
+	private getRequestType(method: any, ...args): string {
+		let requestType: string;
+		if (typeof method === 'string' || method instanceof String) {
+			requestType = String(method);
+		} else {
+			requestType = method?.method;
+		}
+
+		if (requestType === "workspace/executeCommand") {
+			if (args && args[0]?.command) {
+				requestType = `workspace/executeCommand/${args[0].command}`;
+			}
+		}
+
+		return requestType;
+	}
+
+	private fireTraceEvent(type: string, startAt: number, reason?: any): void {
+		const duration: number = Date.now() - startAt;
+		requestEventEmitter.fire({
+			type,
+			duration,
+			error: reason,
+		});
+	}
+}

--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -9,6 +9,7 @@ import { Commands } from "./commands";
 import { Emitter } from "vscode-languageclient";
 import { ServerMode } from "./settings";
 import { registerHoverCommand } from "./hoverAction";
+import { onDidRequestEnd } from "./TracingLanguageClient";
 
 class ApiManager {
 
@@ -60,6 +61,7 @@ class ApiManager {
             onDidServerModeChange,
             onDidProjectsImport,
             serverReady,
+            onDidRequestEnd,
         };
     }
 

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -83,9 +83,9 @@ export interface TraceEvent {
 	 */
 	duration: number;
 	/**
-	 * Error message that occurs while processing a request.
+	 * Error that occurs while processing a request.
 	 */
-	error?: string;
+	error?: any;
 }
 
 export const extensionApiVersion = '0.8';

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -73,7 +73,22 @@ export enum ClientStatus {
 	stopping = "Stopping",
 }
 
-export const extensionApiVersion = '0.7';
+export interface TraceEvent {
+	/**
+	 * Request type.
+	 */
+	type: string;
+	/**
+	 * Time (in milliseconds) taken to process a request.
+	 */
+	duration: number;
+	/**
+	 * Error message that occurs while processing a request.
+	 */
+	error?: string;
+}
+
+export const extensionApiVersion = '0.8';
 
 export interface ExtensionAPI {
 	readonly apiVersion: string;
@@ -118,4 +133,11 @@ export interface ExtensionAPI {
 	 * @since extension version 1.7.0
 	 */
 	readonly serverReady: () => Promise<boolean>;
+
+	/**
+	 * An event that's fired when a request has been responded.
+	 * @since API version 0.8
+	 * @since extension version 1.16.0
+	 */
+	readonly onDidRequestEnd: Event<TraceEvent>;
 }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -33,6 +33,7 @@ import { excludeProjectSettingsFiles, ServerMode, setGradleWrapperChecksum } fro
 import { snippetCompletionProvider } from "./snippetCompletionProvider";
 import * as sourceAction from './sourceAction';
 import { askForProjects, projectConfigurationUpdate, upgradeGradle } from "./standardLanguageClientUtils";
+import { TracingLanguageClient } from './TracingLanguageClient';
 import { TypeHierarchyDirection, TypeHierarchyItem } from "./typeHierarchy/protocol";
 import { typeHierarchyTree } from "./typeHierarchy/typeHierarchyTree";
 import { getAllJavaProjects, getJavaConfig, getJavaConfiguration } from "./utils";
@@ -103,7 +104,7 @@ export class StandardLanguageClient {
 		}
 
 		// Create the language client and start the client.
-		this.languageClient = new LanguageClient('java', extensionName, serverOptions, clientOptions);
+		this.languageClient = new TracingLanguageClient('java', extensionName, serverOptions, clientOptions);
 
 		this.registerCommandsForStandardServer(context, jdtEventEmitter);
 		fileEventHandler.registerFileEventHandlers(this.languageClient, context);


### PR DESCRIPTION
This PR provides an API to easily trace the lsp request performance.
- Track `initialize` request on languageClient.start()
- Track common requests on `sendRequest(...)`

Here is a sample code on how to use this API:

```typescript
 const javaExt = vscode.extensions.getExtension("redhat.java");
 if (javaExt.exports.onDidRequestEnd) {
    javaExt.exports.onDidRequestEnd((traceEvent: any) => {
      console.log(`${traceEvent.type} - ${traceEvent.duration} ms - ${traceEvent.error}`);
    });
  }
```