### PR TITLE
Add separate tsconfig for webview

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,10 @@
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
 		"ecmaVersion": "latest",
-		"project": "tsconfig.json"
+		"project": [
+			"tsconfig.webview.json",
+			"tsconfig.json"
+		]
 	},
 	"plugins": [
 		"@typescript-eslint"
@@ -61,7 +64,9 @@
 		"no-var": "error",
 		"prefer-arrow-callback": [
 			"error",
-			{ "allowNamedFunctions": true }
+			{
+				"allowNamedFunctions": true
+			}
 		],
 		"prefer-const": "error",
 		"prefer-template": "error",

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,8 @@ images/**
 .gitignore
 .github/**
 tsconfig.json
+tsconfig.webview.json
+tsconfig.base.json
 vsc-extension-quickstart.md
 undefined/**
 CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -1390,7 +1390,7 @@
     "build-server": "./node_modules/.bin/gulp build_server",
     "fast-build-server": "./node_modules/.bin/gulp dev_server",
     "watch-server": "./node_modules/.bin/gulp watch_server",
-    "eslint": "eslint --ignore-path .eslintignore --ext .js,.ts ."
+    "eslint": "eslint --ignore-path .eslintignore --ext .js,.ts,.tsx ."
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,5 @@
 import { createLogger, format, transports } from 'winston';
-import DailyRotateFile from 'winston-daily-rotate-file';
+import * as DailyRotateFile from 'winston-daily-rotate-file';
 
 export function initializeLogFile(filename: string) {
 	logger.add(new DailyRotateFile({

--- a/src/webview/changeSignature/App.tsx
+++ b/src/webview/changeSignature/App.tsx
@@ -519,7 +519,7 @@ export class App extends React.Component<{}, State> {
 							</VSCodeDataGridRow>
 							{
 								(() => {
-									const options = [];
+									const options: JSX.Element[] = [];
 									for (let row = 0; row < this.state.parameters.length; row++) {
 										options.push(this.generateParameterDataGridRow(row));
 									}
@@ -539,7 +539,7 @@ export class App extends React.Component<{}, State> {
 							</VSCodeDataGridRow>
 							{
 								(() => {
-									const options = [];
+									const options: JSX.Element[] = [];
 									for (let row = 0; row < this.state.exceptions.length; row++) {
 										options.push(this.generateExceptionDataGridRow(row));
 									}
@@ -577,8 +577,8 @@ export class App extends React.Component<{}, State> {
 		return Number(idSplit[1]);
 	}
 
-	private getModifierString(accessType: string): string {
-		if (accessType === "package-private") {
+	private getModifierString(accessType: string | undefined): string {
+		if (!accessType || accessType === "package-private") {
 			return "";
 		}
 		return accessType;

--- a/test/lightweight-mode-suite/index.ts
+++ b/test/lightweight-mode-suite/index.ts
@@ -11,8 +11,8 @@
 // a possible error to the callback or null if none.
 
 import * as path from 'path';
-import Mocha from 'mocha';
-import glob from 'glob';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
 
 export function run(testsRoot: string): Promise<void> {
 	const mocha = new Mocha({

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import { env } from 'process';

--- a/test/standard-mode-suite/index.ts
+++ b/test/standard-mode-suite/index.ts
@@ -11,8 +11,8 @@
 // a possible error to the callback or null if none.
 
 import * as path from 'path';
-import Mocha from 'mocha';
-import glob from 'glob';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
 
 export function run(testsRoot: string): Promise<void> {
 	const mocha = new Mocha({

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "es6",
+		"moduleResolution": "node",
+		"outDir": "out",
+		"sourceMap": true,
+		"plugins": [
+			{
+				"name": "eslint"
+			}
+		],
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,15 @@
 {
+	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"target": "es6",
 		"lib": [
-			"es6",
-			"DOM"
+			"es6"
 		],
 		"module": "commonjs",
-		"moduleResolution": "node",
-		"outDir": "out",
-		"sourceMap": true,
-		"plugins": [
-			{
-				"name": "eslint"
-			}
-		],
-		/* Enabled for React */
-		"jsx": "react-jsx",
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"skipLibCheck": true,
 	},
 	"exclude": [
 		"node_modules",
 		"server",
-		".vscode-test"
+		".vscode-test",
+		"src/webview"
 	]
 }

--- a/tsconfig.webview.json
+++ b/tsconfig.webview.json
@@ -1,0 +1,17 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"lib": [
+			"DOM"
+		],
+		"module": "ES6",
+		/* Enabled for React */
+		"jsx": "react-jsx",
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"skipLibCheck": true,
+	},
+	"include": [
+		"src/webview"
+	]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,10 @@ const configAssets = {
 		rules: [{
 			test: /\.ts(x?)$/,
 			exclude: /node_modules/,
-			use: 'ts-loader'
+			loader: 'ts-loader',
+			options: {
+				configFile: 'tsconfig.webview.json'
+			}
 		}, {
 			test: /\.(css)$/,
 			use: [{


### PR DESCRIPTION
With this PR, we have a basic `tsconfig.base.json`, two configurations `tsconfig.json` (for extension) and `tsconfig.webview.json` (for webview) specifies the source configuration and source directories.

will address the side effects from #2967 , which might cause configuration problems related to tsconfig rule `esModuleInterop`.