### PR TITLE
Trace API: give indicator of response success status

### DIFF
--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -86,6 +86,10 @@ export interface TraceEvent {
 	 * Error that occurs while processing a request.
 	 */
 	error?: any;
+	/**
+	 * The number of results returned by a response.
+	 */
+	resultLength?: number | undefined;
 }
 
 export const extensionApiVersion = '0.8';


### PR DESCRIPTION
One use case for this API is to trace completion performance. 

To support the feature [Auto complete after new keyword #2010](https://github.com/eclipse/eclipse.jdt.ls/pull/2010) ("new |"), we enabled completion trigger characters on whitespace. However, this also triggers many completion requests when typing whitespace for indentation. These requests are invalid and jdtls returns an empty array. We need a way to distinguish such noise data during tracing.
