### PR TITLE
deprecate 'java.saveActions.organizeImports'

### DIFF
--- a/package.json
+++ b/package.json
@@ -447,6 +447,7 @@
           "type": "boolean",
           "default": false,
           "description": "Enable/disable auto organize imports on save action",
+          "deprecationMessage": "This setting is deprecated, please configure 'editor.codeActionsOnSave' instead.",
           "scope": "window"
         },
         "java.import.exclusions": {


### PR DESCRIPTION
fix #2207, #659 

A recommended way to organize imports in VS Code should be configuring generic `editor.codeActionsOnSave`. In this way, the java specific configuration can be deprecated to avoid any misunderstanding (it also seems to not work now).