### PR TITLE
Recover when 'documentPaste' API is not properly registered.

### DIFF
--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -128,8 +128,12 @@ export class StandardLanguageClient {
 							await onExtensionChange(extensions.all);
 						});
 					}
-
-					registerPasteEventHandler(context, this.languageClient);
+					try {
+						registerPasteEventHandler(context, this.languageClient);
+					} catch (error) {
+						// clients may not have properly configured documentPaste
+						logger.error(error);
+					}
 					activationProgressNotification.hide();
 					if (!hasImported) {
 						showImportFinishNotification(context);


### PR DESCRIPTION
Certain VS Code based clients (eg. VSCodium, or any rebuild of VSCode with different product file) may not have registered the document paste event API, so we should continue gracefully.

```
2023-03-28 18:12:57.959 [error] [Extension Host] Notification handler 'language/status' failed with message: Extension 'redhat.java' CANNOT use API proposal: documentPaste.
Its package.json#enabledApiProposals-property declares: [] but NOT documentPaste.
 The missing proposal MUST be added and you must start in extension development mode or use the following command line switch: --enable-proposed-api redhat.java
```

CC: @CsCherrYY let me know if this makes sense.