### PR TITLE
Adjust usage data document in response to language server changes.

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -11,7 +11,7 @@ vscode-java has opt-in telemetry collection, provided by [vscode-redhat-telemetr
  * The total number of Java projects within the workspace
  * The lowest and highest Java compiler source level used (eg. 11 & 17)
  * Whether the project(s) are being imported for the first time (eg. true)
- * The current time (in milliseconds) at which the language server started, initialized the workspace project(s), and completed building the project(s)
+ * The elapsed time (in milliseconds) at which the language server initialized the workspace project(s), declared as ready for requests, and completed building the project(s)
  * The number of libraries that were indexed after project initialization
  * The total size (in bytes) of libraries that were indexed after project initialization
  * Information about the following settings. In the case of settings that store a well defined value (eg. path/url/string), we simply collect whether the setting has been set.


### PR DESCRIPTION
Based on changes to https://github.com/eclipse/eclipse.jdt.ls/pull/2567 .