### PR TITLE
Remove the workaround to show the refactoring document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -534,9 +534,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.75.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
-      "integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
       "dev": true
     },
     "@types/vscode-webview": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "virtualWorkspaces": false
   },
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.77.0"
   },
   "repository": {
     "type": "git",
@@ -1424,7 +1424,7 @@
     "@types/vscode-webview": "^1.57.0",
     "@types/semver": "^7.3.8",
     "@types/sinon": "^10.0.12",
-    "@types/vscode": "^1.74.0",
+    "@types/vscode": "^1.77.0",
     "@types/winreg": "^1.2.30",
     "@types/winston": "^2.4.4",
     "@vscode/test-electron": "^2.1.5",

--- a/src/codeActionProvider.ts
+++ b/src/codeActionProvider.ts
@@ -32,9 +32,7 @@ export class RefactorDocumentProvider implements CodeActionProvider {
                 command: {
                     command: Commands.LEARN_MORE_ABOUT_REFACTORING,
                     title: 'Learn more about Java refactorings...',
-                    // comment out due to https://github.com/microsoft/vscode/issues/175737.
-                    // TODO: revert the change once the issue is fixed.
-                    // arguments: [kind]
+                    arguments: [kind]
                 }
             };
         }),


### PR DESCRIPTION
fix https://github.com/redhat-developer/vscode-java/issues/2974

Now the document can go to the related section automatically.

![refactor-doc](https://user-images.githubusercontent.com/6193897/230849542-d092a4e9-f488-44ac-8e34-bf0784dbac9a.gif)
