### PR TITLE
Revert PR#3031: Revert lombok@1.18.27 edge release to 1.18.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
  * enhancement - Add support for telemetry notifications. See [#2289](https://github.com/redhat-developer/vscode-java/issues/2289), [#3042](https://github.com/redhat-developer/vscode-java/pull/3042), [#3058](https://github.com/redhat-developer/vscode-java/pull/3058).
  * enhancement - Trace API should give indicator of response success status. See [#3010](https://github.com/redhat-developer/vscode-java/pull/3010).
  * bug fix - Single double quote should be matched appropriately. See [#3037](https://github.com/redhat-developer/vscode-java/issues/3037).
- * bug fix - Lombok ignores `lombok.config`. See [#2887](https://github.com/redhat-developer/vscode-java/issues/2887).
  * bug fix - Increase relevance of "Create enum". See [#2940](https://github.com/redhat-developer/vscode-java/issues/2940).
  * bug fix - Recover when `documentPaste` API is not properly registered. See [#3028](https://github.com/redhat-developer/vscode-java/pull/3028).
  * bug fix - Ensure we do not return duplicate search results for workspace symbols. See [JLS#2547](https://github.com/eclipse/eclipse.jdt.ls/pull/2547).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,24 +122,13 @@ gulp.task('download_lombok', async function (done) {
 	}
 
 	await new Promise(function (resolve, reject) {
-		// Adopt lombok-1.18.27 edge release for the issue https://github.com/redhat-developer/vscode-java/issues/2887
-		download("https://projectlombok.org/lombok-edge.jar")
+		const lombokVersion = '1.18.24';
+		// The latest lombok version can be found on the website https://projectlombok.org/downloads
+		const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`;
+		download(lombokUrl)
 			.pipe(gulp.dest('./lombok/'))
 			.on("error", reject)
-			.on('end', () => {
-				fse.renameSync("./lombok/lombok-edge.jar", "./lombok/lombok-1.18.27.jar");
-				resolve();
-			});
-
-		// TODO: Switch to stable version once lombok 1.18.28 is released.
-
-		// const lombokVersion = '1.18.24';
-		// // The latest lombok version can be found on the website https://projectlombok.org/downloads
-		// const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`;
-		// download(lombokUrl)
-		// 	.pipe(gulp.dest('./lombok/'))
-		// 	.on("error", reject)
-		// 	.on('end', resolve);
+			.on('end', resolve);
 	});
 	done();
 });


### PR DESCRIPTION
Due to a new regression #3046 in the lombok edge version, which seems to happen more frequently than the old regression #2887, I would like to revert to the previous version 1.18.24 until the issue is resolved.