### PR TITLE
Remove 'resolveAdditionalTextEditsSupport' from extended client capabilities

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,7 +169,6 @@ export function activate(context: ExtensionContext): Promise<ExtensionAPI> {
 						clientHoverProvider: true,
 						clientDocumentSymbolProvider: true,
 						gradleChecksumWrapperPromptSupport: true,
-						resolveAdditionalTextEditsSupport: true,
 						advancedIntroduceParameterRefactoringSupport: true,
 						actionableRuntimeNotificationSupport: true,
 						onCompletionItemSelectedCommand: "editor.action.triggerParameterHints",


### PR DESCRIPTION
Related with https://github.com/eclipse/eclipse.jdt.ls/pull/2598