### PR TITLE
Add a setting to control whether 'textEdit' of completion items can be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,16 @@ The following settings are supported:
   - auto
   - on
   - off
-* `java.sharedIndexes.location`: Specifies a common index location for all workspaces. See default values as follows:  
+* `java.sharedIndexes.location`: Specifies a common index location for all workspaces. See default values as follows:
   - Windows: First use `"$APPDATA\\.jdt\\index"`, or `"~\\.jdt\\index"` if it does not exist
   - macOS: `"~/Library/Caches/.jdt/index"`
   - Linux: First use `"$XDG_CACHE_HOME/.jdt/index"`, or `"~/.cache/.jdt/index"` if it does not exist
 * `java.refactoring.extract.interface.replace`: Specify whether to replace all the occurrences of the subtype with the new extracted interface. Defaults to `true`.
 * `java.import.maven.disableTestClasspathFlag` : Enable/disable test classpath segregation. When enabled, this permits the usage of test resources within a Maven project as dependencies within the compile scope of other projects. Defaults to `false`.
 * `java.configuration.maven.defaultMojoExecutionAction` : Specifies default mojo execution action when no associated metadata can be detected. Defaults to `ignore`.
+
+New in 1.18.0
+* `java.completion.lazyResolveTextEdit.enabled`: [Experimental] Enable/disable lazily resolving text edits for code completion. Defaults to `true`.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -617,6 +617,12 @@
           "markdownDescription": "Specify whether to match case for code completion.",
           "scope": "window"
         },
+        "java.completion.lazyResolveTextEdit.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "[Experimental] Enable/disable lazily resolving text edits for code completion.",
+          "scope": "window"
+        },
         "java.foldingRange.enabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Use a setting to control whether to append `textEdit` to the `resolveSupport` of completion.

This allows us to have a fallback when lazy-resolving textEdit no longer works in the future, while still comply with the protocol.

Requires https://github.com/eclipse/eclipse.jdt.ls/pull/2600


