### PR TITLE
Add support for surround with try_catch.

### DIFF
--- a/snippets/java.json
+++ b/snippets/java.json
@@ -21,7 +21,7 @@
 		"prefix": "try_catch",
 		"body": [
 			"try {",
-			"\t$1",
+			"\t${TM_SELECTED_TEXT:$1}",
 			"} catch (${2:Exception} ${3:e}) {",
 			"\t$0// TODO: handle exception",
 			"}"


### PR DESCRIPTION
The following changeset add a new snippet which will only available under Surround With Snippets for provide a try catch block surrounding the selected text.