### PR TITLE
Add contribution point to store other extension settings to the JDT.LS preferences

### DIFF
--- a/schemas/package.schema.json
+++ b/schemas/package.schema.json
@@ -21,6 +21,14 @@
 						"type": "string",
 						"description": "Regular expressions for specifying build file"
 					}
+				},
+				"javaSettings": {
+					"type": "array",
+					"markdownDescription": "Settings that are contributed by other extensions and need to be used by the Java language server",
+					"items": {
+						"type": "string",
+						"description": "The fully qualified setting name"
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- Allow extensions to contribute settings to the JDT.LS, so that the server side can get the contributed settings and do stuffs when necessary.

requires https://github.com/eclipse/eclipse.jdt.ls/pull/2667

Usage example:

We have some extensions that contribute project importers to JDT.LS (i.e. JBang, Bazel,...), with this contribution point added, they can declare a setting to enable/disable the importer, the setting will be cached inside the preferences in JDT.LS. Then the importer (Java implementation of the OSGi bundle) can check that flag in [applies()](https://github.com/eclipse/eclipse.jdt.ls/blob/3da8b2f11ac5a681d6bf32e8768ad5262e4cb966/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/AbstractProjectImporter.java#L45)