### PR TITLE
Turn off text edit lazy resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The following settings are supported:
 * `java.refactoring.extract.interface.replace`: Specify whether to replace all the occurrences of the subtype with the new extracted interface. Defaults to `true`.
 * `java.import.maven.disableTestClasspathFlag` : Enable/disable test classpath segregation. When enabled, this permits the usage of test resources within a Maven project as dependencies within the compile scope of other projects. Defaults to `false`.
 * `java.configuration.maven.defaultMojoExecutionAction` : Specifies default mojo execution action when no associated metadata can be detected. Defaults to `ignore`.
-* `java.completion.lazyResolveTextEdit.enabled`: [Experimental] Enable/disable lazily resolving text edits for code completion. Defaults to `true`.
+* `java.completion.lazyResolveTextEdit.enabled`: [Experimental] Enable/disable lazily resolving text edits for code completion. Defaults to `false`.
 
 New in 1.19.0
 * `java.edit.validateAllOpenBuffersOnChanges`: Specifies whether to recheck all open Java files for diagnostics when editing a Java file. Defaults to `false`.

--- a/package.json
+++ b/package.json
@@ -619,7 +619,7 @@
         },
         "java.completion.lazyResolveTextEdit.enabled": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "[Experimental] Enable/disable lazily resolving text edits for code completion.",
           "scope": "window"
         },


### PR DESCRIPTION
Turn off the lazy resolve flag due to https://github.com/microsoft/vscode/pull/183224.

@rgrunber, I suggest that we arrange a pre-release only containing this change. Then we can observe the impact on the perf using that specific version. The data can also be used for some analysis and discussion.

