### PR TITLE
Revert "Turn off text edit lazy resolving"

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The following settings are supported:
 * `java.refactoring.extract.interface.replace`: Specify whether to replace all the occurrences of the subtype with the new extracted interface. Defaults to `true`.
 * `java.import.maven.disableTestClasspathFlag` : Enable/disable test classpath segregation. When enabled, this permits the usage of test resources within a Maven project as dependencies within the compile scope of other projects. Defaults to `false`.
 * `java.configuration.maven.defaultMojoExecutionAction` : Specifies default mojo execution action when no associated metadata can be detected. Defaults to `ignore`.
-* `java.completion.lazyResolveTextEdit.enabled`: [Experimental] Enable/disable lazily resolving text edits for code completion. Defaults to `false`.
+* `java.completion.lazyResolveTextEdit.enabled`: [Experimental] Enable/disable lazily resolving text edits for code completion. Defaults to `true`.
 
 New in 1.19.0
 * `java.edit.validateAllOpenBuffersOnChanges`: Specifies whether to recheck all open Java files for diagnostics when editing a Java file. Defaults to `false`.

--- a/package.json
+++ b/package.json
@@ -619,7 +619,7 @@
         },
         "java.completion.lazyResolveTextEdit.enabled": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "[Experimental] Enable/disable lazily resolving text edits for code completion.",
           "scope": "window"
         },


### PR DESCRIPTION
Reverts redhat-developer/vscode-java#3114

As mentioned in microsoft/vscode#183426, VS Code team has reverted the change that disallowed textEdit in resolveCompletion. We plan to revert our change as well and keep the textEdit lazy resolve behavior enabled by default in Java extension. This is because we observe disabling it causes a significant performance downgrade for code completion. We don’t want users to experience a noticeable performance degradation with 1.19.0 release. We will ask VS Code team to maintain the current behavior until we find a better alternative solution for completion optimization.

Meanwhile, for the follow-up, we will continue to look for alternative improvements, such as:
- Adopting the https://github.com/eclipse-jdt/eclipse.jdt.core/pull/939  to optimize the new Object completion case.
- Using the signature help to simplify the textEdit calculation for method completion. For example, only insert an empty parameter list `method()` in textEdit, and let the signature help to hint the parameter list later.
- Working with VS Code team to relax the restriction that the additionalTextEdit cannot overlap with the primary edit.

I suggest adding this revert in the upcoming 1.19 release, @fbricon @rgrunber @jdneo WDYT?