### PR TITLE
Use choice syntax as placeholder for method/field snippets.

### DIFF
--- a/snippets/java.json
+++ b/snippets/java.json
@@ -38,50 +38,14 @@
 			"}"
 		]
 	},
-	"private_method": {
-		"prefix": "private_method",
+	"method": {
+		"prefix": "method",
 		"body": [
-			"private ${1:void} ${2:name}($3) {",
+			"${1|public,protected,private|}${2| , static |}${3:void} ${4:name}($5) {",
 			"\t$0",
 			"}"
 		],
-		"description": "private method"
-	},
-	"Public method": {
-		"prefix": "public_method",
-		"body": [
-			"public ${1:void} ${2:name}(${3}) {",
-			"\t$0",
-			"}"
-		],
-		"description": "public method"
-	},
-	"Private static method": {
-		"prefix": "private_static_method",
-		"body": [
-			"private static ${1:Type} ${2:name}(${3}) {",
-			"\t$0",
-			"}"
-		],
-		"description": "private static method"
-	},
-	"Public static method": {
-		"prefix": "public_static_method",
-		"body": [
-			"public static ${1:void} ${2:name}(${3}) {",
-			"\t$0",
-			"}"
-		],
-		"description": "public static method"
-	},
-	"Protected Method": {
-		"prefix": "protected_method",
-		"body": [
-			"protected ${1:void} ${2:name}(${3}) {",
-			"\t$0",
-			"}"
-		],
-		"description": "Protected method"
+		"description": "Method"
 	},
 	"Switch Statement": {
 		"prefix": "switch",
@@ -105,11 +69,11 @@
 		],
 		"description": "Create new Object"
 	},
-	"Private field": {
-		"prefix": "prf",
+	"Field": {
+		"prefix": "field",
 		"body": [
-			"private ${1:String} ${2:name};"
+			"${1|public,protected,private|} ${2:String} ${3:name};"
 		],
-		"description": "Private field"
+		"description": "Field"
 	}
 }


### PR DESCRIPTION
Gets rid of the individual `public_method`, `private_method`, `protected_method`, `public_static_method`, and `private_static_method` snippets and instead replaces them with a single `method` snippet, with choices for public/private/protected and static/non-static.

![Peek 2023-06-07 14-10](https://github.com/redhat-developer/vscode-java/assets/115827695/1165212c-c0f4-4835-b2de-4f438aac6562)

Additionally, `prf` snippet is removed and replaced with `field` snippet, with options for public/private/protected.

![Peek 2023-06-07 14-28](https://github.com/redhat-developer/vscode-java/assets/115827695/0f8d2659-984b-47ae-a58a-939e956dab58)
