### PR TITLE
Set the default value of 'java.completion.matchCase' to 'firstLetter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The following settings are supported:
 * `java.jdt.ls.protobufSupport.enabled`: Specify whether to automatically add Protobuf output source directories to the classpath. **Note:** Only works for Gradle `com.google.protobuf` plugin `0.8.4` or higher. Defaults to `true`.
 * `java.jdt.ls.androidSupport.enabled`: [Experimental] Specify whether to enable Android project importing. When set to `auto`, the Android support will be enabled in Visual Studio Code - Insiders. **Note:** Only works for Android Gradle Plugin `3.2.0` or higher. Defaults to `auto`.
 * `java.completion.postfix.enabled`: Enable/disable postfix completion support. Defaults to `true`.
+* `java.completion.matchCase`: Specify whether to match case for code completion. Defaults to `firstLetter`.
 * `java.compile.nullAnalysis.mode`: Specify how to enable the annotation-based null analysis. Supported values are `disabled` (disable the null analysis), `interactive` (asks when null annotation types are detected), `automatic` (automatically enable null analysis when null annotation types are detected). Defaults to `interactive`.
 * `java.cleanup.actionsOnSave`: The list of clean ups to be run on the current document when it's saved. Clean ups can automatically fix code style or programming mistakes. [Click here](document/_java.learnMoreAboutCleanUps.md#java-clean-ups) to learn more about what each clean up does.
 * `java.import.gradle.annotationProcessing.enabled`: Enable/disable the annotation processing on Gradle projects and delegate to JDT APT. Only works for Gradle 5.2 or higher.

--- a/package.json
+++ b/package.json
@@ -604,16 +604,14 @@
         "java.completion.matchCase": {
           "type": "string",
           "enum": [
-            "auto",
             "firstLetter",
             "off"
           ],
           "enumDescriptions": [
-            "Only match case for the first letter when using Visual Studio Code - Insiders.",
             "Match case for the first letter when doing completion.",
             "Do not match case when doing completion."
           ],
-          "default": "auto",
+          "default": "firstLetter",
           "markdownDescription": "Specify whether to match case for code completion.",
           "scope": "window"
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,6 +205,11 @@ export function getJavaConfig(javaHome: string) {
 			break;
 	}
 
+	const completionCaseMatching = javaConfig.completion.matchCase;
+	if (completionCaseMatching === "auto") {
+		javaConfig.completion.matchCase = isInsider ? "firstLetter" : "off";
+	}
+
 	javaConfig.telemetry = { enabled: workspace.getConfiguration('redhat.telemetry').get('enabled', false) };
 	return javaConfig;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,11 +205,6 @@ export function getJavaConfig(javaHome: string) {
 			break;
 	}
 
-	const completionCaseMatching = javaConfig.completion.matchCase;
-	if (completionCaseMatching === "auto") {
-		javaConfig.completion.matchCase = isInsider ? "firstLetter" : "off";
-	}
-
 	javaConfig.telemetry = { enabled: workspace.getConfiguration('redhat.telemetry').get('enabled', false) };
 	return javaConfig;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,9 +205,8 @@ export function getJavaConfig(javaHome: string) {
 			break;
 	}
 
-	const completionCaseMatching = javaConfig.completion.matchCase;
-	if (completionCaseMatching === "auto") {
-		javaConfig.completion.matchCase = isInsider ? "firstLetter" : "off";
+	if (javaConfig.completion.matchCase === "auto") {
+		javaConfig.completion.matchCase = "firstLetter";
 	}
 
 	javaConfig.telemetry = { enabled: workspace.getConfiguration('redhat.telemetry').get('enabled', false) };


### PR DESCRIPTION
At the meantime, I removed the option `auto` due to there is no need to do further experiments for this setting in Insider. Let me know if we want to persist it.