### PR TITLE
Support 'off' mode when fill the argument during completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,11 @@ The following settings are supported:
 * `java.autobuild.enabled` : Enable/disable the 'auto build'.
 * `java.maxConcurrentBuilds`: Set max simultaneous project builds.
 * `java.completion.enabled` : Enable/disable code completion support.
-* `java.completion.guessMethodArguments` : When set to true, method arguments are guessed when a method is selected from as list of code assist proposals.
+* `java.completion.guessMethodArguments` : Specify how the arguments will be filled during completion. Defaults to `auto`.
+  - `auto`: Use `off` only when using Visual Studio Code - Insiders, other platform will defaults to `insertBestGuessedArguments`.
+  - `off`: Method arguments will not be inserted during completion.
+  - `insertParameterNames`: The parameter names will be inserted during completion.
+  - `insertBestGuessedArguments`: The best guessed arguments will be inserted during completion according to the code context.
 * `java.completion.filteredTypes`: Defines the type filters. All types whose fully qualified name matches the selected filter strings will be ignored in content assist or quick fix proposals and when organizing imports. For example 'java.awt.*' will hide all types from the awt packages.
 * `java.completion.favoriteStaticMembers` : Defines a list of static members or types with static members.
 * `java.completion.importOrder` : Defines the sorting order of import statements.

--- a/package.json
+++ b/package.json
@@ -548,9 +548,24 @@
           "scope": "window"
         },
         "java.completion.guessMethodArguments": {
-          "type": "boolean",
-          "default": true,
-          "description": "When set to true, method arguments are guessed when a method is selected from as list of code assist proposals.",
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "auto",
+            "off",
+            "insertParameterNames",
+            "insertBestGuessedArguments"
+          ],
+          "enumDescriptions": [
+            "Use 'off' only when using Visual Studio Code - Insiders, other platform will defaults to 'insertBestGuessedArguments'.",
+            "Method arguments will not be inserted during completion.",
+            "The parameter names will be inserted during completion.",
+            "The best guessed arguments will be inserted during completion according to the code context."
+          ],
+          "default": "auto",
+          "description": "Specify how the arguments will be filled during completion.",
           "scope": "window"
         },
         "java.completion.favoriteStaticMembers": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,6 +210,11 @@ export function getJavaConfig(javaHome: string) {
 		javaConfig.completion.matchCase = isInsider ? "firstLetter" : "off";
 	}
 
+	const guessMethodArguments = javaConfig.completion.guessMethodArguments;
+	if (guessMethodArguments === "auto") {
+		javaConfig.completion.guessMethodArguments = isInsider ? "off" : "insertBestGuessedArguments";
+	}
+
 	javaConfig.telemetry = { enabled: workspace.getConfiguration('redhat.telemetry').get('enabled', false) };
 	return javaConfig;
 }


### PR DESCRIPTION
- Change the option of 'java.completion.guessMethodArguments' from boolean to four options: "auto", "off", "insertParameterNames" and "insertBestGuessedArguments". Defaults to "auto", means that for VS Code Insiders, it will use "off", other platforms will use "insertBestGuessedArguments".

requires https://github.com/eclipse/eclipse.jdt.ls/pull/2694

fix https://github.com/redhat-developer/vscode-java/issues/2903