### PR TITLE
Suppress 'Opening Java Projects' pop-up upon OutOfMemory failure

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import glob = require('glob');
 import { Telemetry } from './telemetry';
 import { getMessage } from './errorUtils';
 import { TelemetryService } from '@redhat-developer/vscode-redhat-telemetry/lib';
+import { activationProgressNotification } from "./serverTaskPresenter";
 
 const syntaxClient: SyntaxLanguageClient = new SyntaxLanguageClient();
 const standardClient: StandardLanguageClient = new StandardLanguageClient();
@@ -971,6 +972,7 @@ function registerOutOfMemoryDetection(storagePath: string) {
 		}
 		showOOMMessage();
 		serverStatusBarProvider.setError();
+		activationProgressNotification.hide();
 	});
 }
 

--- a/src/syntaxLanguageClient.ts
+++ b/src/syntaxLanguageClient.ts
@@ -37,7 +37,11 @@ export class SyntaxLanguageClient {
 			errorHandler: new ClientErrorHandler(extensionName),
 			initializationFailedHandler: error => {
 				logger.error(`Failed to initialize ${extensionName} due to ${error && error.toString()}`);
-				return true;
+				if (error.toString().includes('Connection') && error.toString().includes('disposed')) {
+					return false;
+				} else {
+					return true;
+				}
 			},
 			outputChannel: new OutputInfoCollector(extensionName),
 			outputChannelName: extensionName


### PR DESCRIPTION
Fixes residual problem after the larger fix in #3123 