### PR TITLE
Rename 'Attach Source' menu to 'Attach Source…'

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -11,7 +11,7 @@
 	"java.project.build": "Rebuild Projects",
 	"java.open.formatter.settings": "Open Java Formatter Settings",
 	"java.clean.workspace": "Clean Java Language Server Workspace",
-	"java.project.updateSourceAttachment": "Attach Source",
+	"java.project.updateSourceAttachment": "Attach Source...",
 	"java.project.addToSourcePath": "Add Folder to Java Source Path",
 	"java.project.removeFromSourcePath": "Remove Folder from Java Source Path",
 	"java.project.listSourcePaths": "List All Java Source Paths",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -11,7 +11,7 @@
 	"java.project.build": "프로젝트 다시 빌드",
 	"java.open.formatter.settings": "Java Formatter 설정 열기",
 	"java.clean.workspace": "Java Language Server 작업 영역 정리",
-	"java.project.updateSourceAttachment": "Attach Source",
+	"java.project.updateSourceAttachment": "Attach Source...",
 	"java.project.addToSourcePath": "Java Source 경로에 폴더 추가",
 	"java.project.removeFromSourcePath": "Java Source 경로에서 폴더 제거",
 	"java.project.listSourcePaths": "모든 Java Source 경로를 나열",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -11,7 +11,7 @@
 	"java.project.build": "重新构建项目",
 	"java.open.formatter.settings": "打开 Java 格式设置",
 	"java.clean.workspace": "清理 Java 语言服务器工作区",
-	"java.project.updateSourceAttachment": "附加源代码",
+	"java.project.updateSourceAttachment": "附加源代码...",
 	"java.project.addToSourcePath": "将文件夹加入 Java 源代码路径",
 	"java.project.removeFromSourcePath": "将文件夹从 Java 源代码路径中删除",
 	"java.project.listSourcePaths": "列出所有 Java 源代码路径",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -11,7 +11,7 @@
 	"java.project.build": "重新建置專案",
 	"java.open.formatter.settings": "開啟 Java 格式設定",
 	"java.clean.workspace": "清理 Java 語言伺服器工作區",
-	"java.project.updateSourceAttachment": "附加原始碼",
+	"java.project.updateSourceAttachment": "附加原始碼...",
 	"java.project.addToSourcePath": "將資料夾加入 Java 原始碼路徑",
 	"java.project.removeFromSourcePath": "從 Java 始碼路徑中移除資料夾",
 	"java.project.listSourcePaths": "列出所有 Java 始碼路徑",


### PR DESCRIPTION
Since "Attach Source" operation requires further user interaction to pick the source location, it's a common way to add an ellipsis (…) at the end of the menu item.