### PR TITLE
Reload the cached classfile sources when new source attachment is updated for them

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ The following settings are supported:
 * `java.completion.lazyResolveTextEdit.enabled`: [Experimental] Enable/disable lazily resolving text edits for code completion. Defaults to `true`.
 * `java.edit.validateAllOpenBuffersOnChanges`: Specifies whether to recheck all open Java files for diagnostics when editing a Java file. Defaults to `false`.
 
+New in 1.21.0
+* `java.editor.reloadChangedSources`: Specifies whether to reload the sources of the open class files when their source jar files are changed. Defaults to `ask`.
+  - `ask`: Ask to reload the sources of the open class files
+  - `auto`: Automatically reload the sources of the open class files
+  - `manual`: Manually reload the sources of the open class files
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/package.json
+++ b/package.json
@@ -1139,6 +1139,22 @@
           "default": false,
           "markdownDescription": "Specifies whether to recheck all open Java files for diagnostics when editing a Java file.",
           "scope": "window"
+        },
+        "java.editor.reloadChangedSources": {
+          "type": "string",
+          "enum": [
+            "ask",
+            "auto",
+            "manual"
+          ],
+          "enumDescriptions": [
+            "Ask to reload the sources of the open class files",
+            "Automatically reload the sources of the open class files",
+            "Manually reload the sources of the open class files"
+          ],
+          "default": "ask",
+          "markdownDescription": "Specifies whether to reload the sources of the open class files when their source jar files are changed.",
+          "scope": "window"
         }
       }
     },

--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { ExtensionAPI, ClasspathQueryOptions, ClasspathResult, extensionApiVersion, ClientStatus } from "./extension.api";
+import { ExtensionAPI, ClasspathQueryOptions, ClasspathResult, extensionApiVersion, ClientStatus, SourceInvalidatedEvent } from "./extension.api";
 import { RequirementsData } from "./requirements";
 import { GetDocumentSymbolsCommand, getDocumentSymbolsProvider } from "./documentSymbols";
 import { GoToDefinitionCommand, goToDefinitionProvider } from "./goToDefinition";
@@ -18,6 +18,7 @@ class ApiManager {
     private onDidServerModeChangeEmitter: Emitter<ServerMode> = new Emitter<ServerMode>();
     private onDidProjectsImportEmitter: Emitter<Uri[]> = new Emitter<Uri[]>();
     private traceEventEmitter: Emitter<any> = new Emitter<any>();
+    private sourceInvalidatedEventEmitter: Emitter<SourceInvalidatedEvent> = new Emitter<SourceInvalidatedEvent>();
     private serverReadyPromiseResolve: (result: boolean) => void;
 
     public initialize(requirements: RequirementsData, serverMode: ServerMode): void {
@@ -65,6 +66,7 @@ class ApiManager {
             serverReady,
             onDidRequestEnd,
             trackEvent: traceEvent,
+            onDidSourceInvalidate: this.sourceInvalidatedEventEmitter.event,
         };
     }
 
@@ -90,6 +92,10 @@ class ApiManager {
 
     public fireTraceEvent(event: any): void {
         this.traceEventEmitter.fire(event);
+    }
+
+    public fireSourceInvalidatedEvent(event: SourceInvalidatedEvent): void {
+        this.sourceInvalidatedEventEmitter.fire(event);
     }
 
     public updateServerMode(mode: ServerMode): void {

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -92,7 +92,18 @@ export interface TraceEvent {
 	resultLength?: number | undefined;
 }
 
-export const extensionApiVersion = '0.9';
+export interface SourceInvalidatedEvent {
+	/**
+	 * The paths of the jar files that are linked to new source attachments.
+	 */
+	affectedRootPaths: string[];
+	/**
+	 * whether the new source attachments affect the class files opened in the editors.
+	 */
+	hasAffectedEditors?: boolean;
+}
+
+export const extensionApiVersion = '0.10';
 
 export interface ExtensionAPI {
 	readonly apiVersion: string;
@@ -152,4 +163,14 @@ export interface ExtensionAPI {
 	 * @since extension version 1.20.0
 	 */
 	readonly trackEvent: Event<any>;
+
+	/**
+	 * An event that occurs when the package fragment roots have updated source attachments.
+	 * The client should refresh the new source if it has previously requested the source
+	 * from them.
+	 *
+	 * @since API version 0.10
+	 * @since extension version 1.21.0
+	 */
+	readonly onDidSourceInvalidate: Event<SourceInvalidatedEvent>;
 }

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -98,9 +98,9 @@ export interface SourceInvalidatedEvent {
 	 */
 	affectedRootPaths: string[];
 	/**
-	 * whether the new source attachments affect the class files opened in the editors.
+	 * The opened editors with updated source.
 	 */
-	hasAffectedEditors?: boolean;
+	affectedEditorDocuments?: Uri[];
 }
 
 export const extensionApiVersion = '0.10';

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -59,7 +59,8 @@ export enum EventType {
     classpathUpdated = 100,
     projectsImported = 200,
     incompatibleGradleJdkIssue = 300,
-	upgradeGradleWrapper = 400,
+    upgradeGradleWrapper = 400,
+    sourceInvalidated = 500,
 }
 
 export enum CompileWorkspaceStatus {
@@ -76,25 +77,25 @@ export enum AccessorKind {
 }
 
 export interface StatusReport {
-	message: string;
-	type: string;
+    message: string;
+    type: string;
 }
 
 export interface ProgressReport {
-	id: string;
-	task: string;
-	subTask: string;
-	status: string;
-	workDone: number;
-	totalWork: number;
-	complete: boolean;
+    id: string;
+    task: string;
+    subTask: string;
+    status: string;
+    workDone: number;
+    totalWork: number;
+    complete: boolean;
 }
 
 export interface ActionableMessage {
-	severity: MessageType;
-	message: string;
-	data?: any;
-	commands?: Command[];
+    severity: MessageType;
+    message: string;
+    data?: any;
+    commands?: Command[];
 }
 
 export interface EventNotification {
@@ -103,11 +104,11 @@ export interface EventNotification {
 }
 
 export namespace StatusNotification {
-	export const type = new NotificationType<StatusReport>('language/status');
+    export const type = new NotificationType<StatusReport>('language/status');
 }
 
 export namespace ProgressReportNotification {
-	export const type = new NotificationType<ProgressReport>('language/progressReport');
+    export const type = new NotificationType<ProgressReport>('language/progressReport');
 }
 
 export namespace ClassFileContentsRequest {
@@ -179,8 +180,8 @@ export interface OverridableMethod {
 }
 
 export interface OverridableMethodsResponse {
-	type: string;
-	methods: OverridableMethod[];
+    type: string;
+    methods: OverridableMethod[];
 }
 
 export namespace ListOverridableMethodsRequest {
@@ -443,9 +444,9 @@ export interface GradleCompatibilityInfo {
 }
 
 export interface UpgradeGradleWrapperInfo {
-	projectUri: string;
-	message: string;
-	recommendedGradleVersion: string;
+    projectUri: string;
+    message: string;
+    recommendedGradleVersion: string;
 }
 
 export interface Member {
@@ -470,5 +471,14 @@ export interface ValidateDocumentParams {
 }
 
 export namespace ValidateDocumentNotification {
-	export const type = new NotificationType<ValidateDocumentParams>('java/validateDocument');
+    export const type = new NotificationType<ValidateDocumentParams>('java/validateDocument');
+}
+
+export interface SourceInvalidatedEvent {
+    /**
+     * The package fragment roots that get new source attachments.
+     * The key is its root path, the value means if its source is
+     * automatically downloaded.
+     */
+    affectedRootPaths: { [key: string]: boolean };
 }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -708,14 +708,10 @@ export class StandardLanguageClient {
 						return;
 					}
 				}
-				affectedDocumentUris.forEach(classFileUri => {
-					jdtContentProviderEventEmitter.fire(classFileUri);
-				});
-			} else {
-				affectedDocumentUris.forEach(classFileUri => {
-					jdtContentProviderEventEmitter.fire(classFileUri);
-				});
 			}
+			affectedDocumentUris.forEach(classFileUri => {
+				jdtContentProviderEventEmitter.fire(classFileUri);
+			});
 		}
 		apiManager.fireSourceInvalidatedEvent({
 			affectedRootPaths: jars,

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -719,7 +719,7 @@ export class StandardLanguageClient {
 		}
 		apiManager.fireSourceInvalidatedEvent({
 			affectedRootPaths: jars,
-			hasAffectedEditors: !!affectedDocumentUris.length,
+			affectedEditorDocuments: affectedDocumentUris,
 		});
 	}
 }


### PR DESCRIPTION
This requires jdt.ls PR https://github.com/eclipse/eclipse.jdt.ls/pull/2764.

What this PR does:
- Respond to SourceInvalidatedEvent notification. If the event is triggered by user operation such as "Attach Source", then refresh the open editors for new source directly. If it's triggered by auto downloading maven source, then ask user whether to reload the new source. This refresh behavior is controlled by a setting `java.editor.reloadChangedSources`. Defaults to `ask`, you can change it to `auto` for refreshing automatically.
- Expose the SourceInvalidatedEvent as an extension API `onDidSourceInvalidate`. This will let other source consumers (e.g. Debugger) to refresh their cache as well. The debugger should update the line numbers of the relevant stack frames when the new source jar is available.

- Ask to refresh open editors for new maven source

https://github.com/redhat-developer/vscode-java/assets/14052197/39786781-cf14-4f2a-a152-66e3a069cb18

- Auto refresh open editors for manually attached source

https://github.com/redhat-developer/vscode-java/assets/14052197/930a1512-6848-4f77-8656-2da7d774d27c

