### PR TITLE
Update provenance of the Java language TextMate grammar.

### DIFF
--- a/language-support/java/java.tmLanguage.json
+++ b/language-support/java/java.tmLanguage.json
@@ -1,10 +1,8 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/atom/language-java/blob/master/grammars/java.cson",
-		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
-		"Once accepted there, we are happy to receive an update request."
+		"This file has been copied from https://github.com/microsoft/vscode/blob/b37252c18238fffcebdc9fd7680f1dabea3a50a0/extensions/java/syntaxes/java.tmLanguage.json",
+		"The source location lists https://github.com/atom/language-java/blob/29f977dc42a7e2568b39bb6fb34c4ef108eb59b3/LICENSE.md as the original repository. It is therefore licensed under MIT."
 	],
-	"version": "https://github.com/atom/language-java/commit/29f977dc42a7e2568b39bb6fb34c4ef108eb59b3",
 	"name": "Java",
 	"scopeName": "source.java",
 	"patterns": [


### PR DESCRIPTION
Based on discussion from https://github.com/microsoft/vscode/pull/187725#issuecomment-1640413605 .