### PR TITLE
For internal debug, use the JDTLS_SERVER_PORT environment variable instead of SERVER_PORT

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
 			"env": {
-				"SERVER_PORT": "3333",
+				"JDTLS_SERVER_PORT": "3333",
 				"DEBUG_VSCODE_JAVA":"true",
 				"VSCODE_REDHAT_TELEMETRY_DEBUG":"true"
 			},

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ While developing the language server and the extension, you don't need to deploy
 - In the debug console of VSCode you can see if the connection was successful.
 - When the server is running breakpoints can be reached and hot code replace can be used to make fixes without restarting the server.
 - You can modify `launch.json` to use a different port:
-    - Modify `SERVER_PORT` to specify the port the JDT LS server should connect to.
+    - Modify `JDTLS_SERVER_PORT` to specify the port the JDT LS server should connect to.
 
 ## C-2) The language server opens the connection first, and waits the extension to connect to it.
 - Start the language server via `jdt.ls.socket-stream` launch configuration in VS Code or Eclipse

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -86,7 +86,7 @@ export class StandardLanguageClient {
 		});
 
 		let serverOptions;
-		const port = process.env['SERVER_PORT'];
+		const port = process.env['JDTLS_SERVER_PORT'];
 		if (!port) {
 			const lsPort = process.env['JDTLS_CLIENT_PORT'];
 			if (!lsPort) {


### PR DESCRIPTION
Fixes #3256, Fixes #2507

The `SERVER_PORT` environment variable is used for internal debugging with launch.json. However, it can conflict with the user’s application environment, such as Spring Boot. To avoid this issue, a more private name, such as `JDTLS_SERVER_PORT`, should be used for internal purposes.