### PR TITLE
Disable ';' key binding when smart semicolon detection is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.22.1 (September 14th, 2023)
  * bug fix - Removed some improvements to JDK detection as they were causing issues on MacOS. See [#3287](https://github.com/redhat-developer/vscode-java/issues/3287).
  * bug fix - Log errors from project importer. See [JLS#2843](https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2843).
+ * bug fix - Disable `;` key binding when smart semicolon detection is disabled. See [#3290](https://github.com/redhat-developer/vscode-java/issues/3290).
 
 ## 1.22.0 (September 12th, 2023)
  * performance - Stale code actions should be cancellable and paste actions should have higher priority. See [#3199](https://github.com/redhat-developer/vscode-java/issues/3199).

--- a/package.json
+++ b/package.json
@@ -1322,7 +1322,7 @@
       {
         "command": "java.edit.smartSemicolonDetection.command",
         "key": ";",
-        "when": "editorTextFocus && !editorReadonly && javaLSReady && editorLangId == java"
+        "when": "config.java.edit.smartSemicolonDetection.enabled && editorTextFocus && !editorReadonly && javaLSReady && editorLangId == java"
       }
     ],
     "menus": {


### PR DESCRIPTION
Mitigates #3290 