### PR TITLE
Track the completion kinds of completion request

### DIFF
--- a/src/TracingLanguageClient.ts
+++ b/src/TracingLanguageClient.ts
@@ -44,14 +44,18 @@ export class TracingLanguageClient extends LanguageClient {
 	sendRequest(method: any, ...args) {
 		const startAt: number = performance.now();
 		const requestType: string = this.getRequestType(method, ...args);
-		let data: any;
-		if (args?.[0]?.context?.triggerKind) {
+		let data: any = undefined;
+		if (args?.[0]?.context?.triggerKind !== undefined) {
 			data = {
 				triggerKind: args[0].context.triggerKind,
 				triggerCharacter: args[0].context.triggerCharacter,
 			};
 		}
-		return this.sendRequest0(method, ...args).then(value => {
+		return this.sendRequest0(method, ...args).then((value: any) => {
+			if (data && value?.itemDefaults?.data?.completionKinds) {
+				// Include the completionKinds from the completion response.
+				data.completionKinds = value.itemDefaults.data.completionKinds;
+			}
 			this.fireSuccessTraceEvent(requestType, startAt, this.getResultLength(value), data);
 			return value;
 		}, reason => {


### PR DESCRIPTION
this requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2857.

We can use the completion kinds to evaluate whether the empty completion response is acceptable or not. For example, when we type a class declaration, the completion engine may return no items. We can mark this as OK for the declaration scenario.