### PR TITLE
Add API onWillRequestStart to track request send event

### DIFF
--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -9,7 +9,7 @@ import { Commands } from "./commands";
 import { Emitter } from "vscode-languageclient";
 import { ServerMode } from "./settings";
 import { registerHoverCommand } from "./hoverAction";
-import { onDidRequestEnd } from "./TracingLanguageClient";
+import { onDidRequestEnd, onWillRequestStart } from "./TracingLanguageClient";
 
 class ApiManager {
 
@@ -64,6 +64,7 @@ class ApiManager {
             onDidServerModeChange,
             onDidProjectsImport,
             serverReady,
+            onWillRequestStart,
             onDidRequestEnd,
             trackEvent: traceEvent,
             onDidSourceInvalidate: this.sourceInvalidatedEventEmitter.event,

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -81,7 +81,7 @@ export interface TraceEvent {
 	/**
 	 * Time (in milliseconds) taken to process a request.
 	 */
-	duration: number;
+	duration?: number;
 	/**
 	 * Error that occurs while processing a request.
 	 */
@@ -107,7 +107,7 @@ export interface SourceInvalidatedEvent {
 	affectedEditorDocuments?: Uri[];
 }
 
-export const extensionApiVersion = '0.11';
+export const extensionApiVersion = '0.12';
 
 export interface ExtensionAPI {
 	readonly apiVersion: string;
@@ -152,6 +152,13 @@ export interface ExtensionAPI {
 	 * @since extension version 1.7.0
 	 */
 	readonly serverReady: () => Promise<boolean>;
+
+	/**
+	 * An event that's fired when a request is about to send to language server.
+	 * @since API version 0.12
+	 * @since extension version 1.23.0
+	 */
+	readonly onWillRequestStart: Event<TraceEvent>;
 
 	/**
 	 * An event that's fired when a request has been responded.


### PR DESCRIPTION
The `onWillRequestStart` and `onDidRequestEnd` pair can help us understand how many requests don't get a response back. This can be an indicator about the server status.