### PR TITLE
Update to lombok 1.18.30

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,7 +127,7 @@ gulp.task('download_lombok', async function (done) {
 	}
 
 	await new Promise(function (resolve, reject) {
-		const lombokVersion = '1.18.28';
+		const lombokVersion = '1.18.30';
 		// The latest lombok version can be found on the website https://projectlombok.org/downloads
 		const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`;
 		download(lombokUrl)


### PR DESCRIPTION
This goes hand in hand with #3314 (but does not depend on it). Lombok 1.18.28 is broken by java 21. 1.18.30 is the first version to support 21.