### PR TITLE
Indicate whether the onWillRequestStart event is from syntax server

### DIFF
--- a/src/TracingLanguageClient.ts
+++ b/src/TracingLanguageClient.ts
@@ -110,6 +110,7 @@ export class TracingLanguageClient extends LanguageClient {
 	private fireRequestStartTraceEvent(type: string): void {
 		requestStartEventEmitter.fire({
 			type,
+			fromSyntaxServer: !!this.isSyntaxServer,
 		});
 	}
 


### PR DESCRIPTION
On previous PR https://github.com/redhat-developer/vscode-java/pull/3278, we have added a property **fromSyntaxServer** to the **onDidRequestEnd** event, we can do the same on the **onWillRequestStart** event.