### PR TITLE
Feature discovery - Provide quick fix to 'Configure static import...'

### DIFF
--- a/src/clientCodeActionProvider.ts
+++ b/src/clientCodeActionProvider.ts
@@ -1,0 +1,32 @@
+import { CancellationToken, CodeAction, CodeActionContext, CodeActionKind, CodeActionProvider, Command, ExtensionContext, ProviderResult, Range, Selection, TextDocument, commands } from "vscode";
+import { apiManager } from "./apiManager";
+
+const configureStaticImportsCommand = "java.action.configureFavoriteStaticMembers";
+const UNDEFINED_METHOD = "67108964";
+export class ClientCodeActionProvider implements CodeActionProvider<CodeAction> {
+	constructor(readonly context: ExtensionContext) {
+		context.subscriptions.push(commands.registerCommand(configureStaticImportsCommand, async () => {
+			commands.executeCommand("workbench.action.openSettings", "java.completion.favoriteStaticMembers");
+			apiManager.fireTraceEvent({
+				name: "java.ls.command",
+				properties: {
+					command: configureStaticImportsCommand,
+				},
+			});
+		}));
+	}
+
+	provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<(CodeAction | Command)[]> {
+		const codeActions = [];
+		if (context.diagnostics?.some(diagnostic => diagnostic.code === UNDEFINED_METHOD)
+			|| document.lineAt(range.start.line)?.text?.startsWith("import ")) {
+			const action = new CodeAction("Configure static import...", CodeActionKind.QuickFix);
+			action.command = {
+				title: "Configure static import...",
+				command: configureStaticImportsCommand,
+			};
+			codeActions.push(action);
+		}
+		return codeActions;
+	}
+}

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -39,6 +39,7 @@ import { Telemetry } from "./telemetry";
 import { TelemetryEvent } from "@redhat-developer/vscode-redhat-telemetry/lib";
 import { registerDocumentValidationListener } from './diagnostic';
 import { listJdks, sortJdksBySource, sortJdksByVersion } from './jdkUtils';
+import { ClientCodeActionProvider } from './clientCodeActionProvider';
 
 const extensionName = 'Language Support for Java';
 const GRADLE_CHECKSUM = "gradle/checksum/prompt";
@@ -618,6 +619,10 @@ export class StandardLanguageClient {
 			pattern: "**/{gradle/wrapper/gradle-wrapper.properties,build.gradle,build.gradle.kts,settings.gradle,settings.gradle.kts}"
 		}, new GradleCodeActionProvider(), gradleCodeActionMetadata);
 
+		languages.registerCodeActionsProvider({
+			scheme: 'file',
+			language: 'java'
+		}, new ClientCodeActionProvider(context));
 	}
 
 	private showGradleCompatibilityIssueNotification(message: string, options: string[], projectUri: string, gradleVersion: string, newJavaHome: string) {


### PR DESCRIPTION
static import is one of the popular missing features that users report to us, but it is already supported by the Java extension. You can enable it by specifying a whitelist setting `java.completion.favoriteStaticMembers`. However, this feature is not easy to discover. To make it more accessible, we propose to add a quickfix option called “Configure static import...” on import statements or undefined methods. When you click on this option, it will open the settings page where you can adjust the static import preferences.