### PR TITLE
Exclude `**/node_modules/**` from `.java` files search

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -918,7 +918,10 @@ async function getTriggerFiles(): Promise<string[]> {
 			}
 		}
 
-		const javaFilesUnderRoot: Uri[] = await workspace.findFiles(new RelativePattern(rootFolder, "*.java"), undefined, 1);
+		// Paths set by 'java.import.exclusions' will be ignored when searching trigger files.
+		const exclusionGlob = getExclusionBlob();
+
+		const javaFilesUnderRoot: Uri[] = await workspace.findFiles(new RelativePattern(rootFolder, "*.java"), exclusionGlob, 1);
 		for (const javaFile of javaFilesUnderRoot) {
 			if (isPrefix(rootPath, javaFile.fsPath)) {
 				openedJavaFiles.push(javaFile.toString());
@@ -926,7 +929,7 @@ async function getTriggerFiles(): Promise<string[]> {
 			}
 		}
 
-		const javaFilesInCommonPlaces: Uri[] = await workspace.findFiles(new RelativePattern(rootFolder, "{src, test}/**/*.java"), undefined, 1);
+		const javaFilesInCommonPlaces: Uri[] = await workspace.findFiles(new RelativePattern(rootFolder, "{src, test}/**/*.java"), exclusionGlob, 1);
 		for (const javaFile of javaFilesInCommonPlaces) {
 			if (isPrefix(rootPath, javaFile.fsPath)) {
 				openedJavaFiles.push(javaFile.toString());


### PR DESCRIPTION
This is a strange PR and I would have no qualms with it being rejected.

Similar to https://github.com/microsoft/vscode-java-debug/pull/1234, I'm hoping to ignore `node_modules` to prevent large CPU usage from this extension when my teammates open a Node.js project. There's details in the linked pull request, but happy to elaborate if there's questions. Thanks!

Specifically, we're seeing this process run for long periods of time. It's searching on `/{src, test}/**/*.java`.

```
❯ ps x | grep ripgrep
93718   ??  R      0:16.30 /Applications/Visual Studio Code.app/Contents/Resources/app/node_modules.asar.unpacked/@vscode/ripgrep/bin/rg --files --hidden --case-sensitive --no-require-git -g /{src, test}/**/*.java -g !**/.git -g !**/.svn -g !**/.hg -g !**/CVS -g !**/.DS_Store -g !**/Thumbs.db --no-ignore --no-config