### PR TITLE
Delete client log files when deleting workspace

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,19 @@ export function deleteDirectory(dir) {
 	}
 }
 
+export function deleteClientLog(dir) {
+	if (fs.existsSync(dir)) {
+		fs.readdirSync(dir).forEach((child) => {
+			if (child.startsWith('client.log') || child.endsWith('audit.json')) {
+				const entry = path.join(dir, child);
+				if (!fs.lstatSync(entry).isDirectory()) {
+					fs.unlinkSync(entry);
+				}
+			}
+		});
+	}
+}
+
 export function getTimestamp(file) {
 	if (!fs.existsSync(file)) {
 		return -1;


### PR DESCRIPTION
Fixes #3349 

I can only reproduce the problem when I stop the o.e.jdt.ls.core plugin while debugging Java LS.
The PR deletes the client.log.* files when run `Java: Clean the Java Language Server Workspace`. 