### PR TITLE
Support add/remove imported projects

### DIFF
--- a/src/apiManager.ts
+++ b/src/apiManager.ts
@@ -18,6 +18,7 @@ class ApiManager {
     private onDidClasspathUpdateEmitter: Emitter<Uri> = new Emitter<Uri>();
     private onDidServerModeChangeEmitter: Emitter<ServerMode> = new Emitter<ServerMode>();
     private onDidProjectsImportEmitter: Emitter<Uri[]> = new Emitter<Uri[]>();
+    private onDidProjectsDeleteEmitter: Emitter<Uri[]> = new Emitter<Uri[]>();
     private traceEventEmitter: Emitter<any> = new Emitter<any>();
     private sourceInvalidatedEventEmitter: Emitter<SourceInvalidatedEvent> = new Emitter<SourceInvalidatedEvent>();
     private serverReadyPromiseResolve: (result: boolean) => void;
@@ -46,6 +47,7 @@ class ApiManager {
         const onDidClasspathUpdate = this.onDidClasspathUpdateEmitter.event;
         const onDidServerModeChange = this.onDidServerModeChangeEmitter.event;
         const onDidProjectsImport = this.onDidProjectsImportEmitter.event;
+        const onDidProjectsDelete = this.onDidProjectsDeleteEmitter.event;
         const traceEvent = this.traceEventEmitter.event;
 
         const serverReadyPromise: Promise<boolean> = new Promise<boolean>((resolve) => {
@@ -69,6 +71,7 @@ class ApiManager {
             serverMode,
             onDidServerModeChange,
             onDidProjectsImport,
+            onDidProjectsDelete,
             serverReady,
             onWillRequestStart,
             onDidRequestEnd,
@@ -95,6 +98,10 @@ class ApiManager {
 
     public fireDidProjectsImport(event: Uri[]): void {
         this.onDidProjectsImportEmitter.fire(event);
+    }
+
+    public fireDidProjectsDelete(event: Uri[]): void {
+        this.onDidProjectsDeleteEmitter.fire(event);
     }
 
     public fireTraceEvent(event: any): void {

--- a/src/buildFilesSelector.ts
+++ b/src/buildFilesSelector.ts
@@ -1,41 +1,69 @@
-import { ExtensionContext, MessageItem, QuickPickItem, QuickPickItemKind, Uri, WorkspaceFolder, extensions, window, workspace } from "vscode";
-import { convertToGlob, getExclusionGlob as getExclusionGlobPattern, getInclusionPatternsFromNegatedExclusion } from "./utils";
+import { ExtensionContext, MessageItem, QuickPickItem, QuickPickItemKind, Uri, WorkspaceFolder, window, workspace } from "vscode";
+import { convertToGlob, getExclusionGlob, getInclusionPatternsFromNegatedExclusion } from "./utils";
 import * as path from "path";
+import { IBuildTool, getContributedBuildTools } from "./plugin";
 
 export const PICKED_BUILD_FILES = "java.pickedBuildFiles";
+export const BUILD_TOOL_FOR_CONFLICTS = "java.buildToolForConflicts";
 export class BuildFileSelector {
-	private buildTypes: IBuildTool[] = [];
+	/**
+	 * The build tools that are contributed/supported by extensions.
+	 */
+	private buildTools: IBuildTool[] = [];
+	/**
+	 * The extension context.
+	 */
 	private context: ExtensionContext;
+	/**
+	 * Glob pattern that needs to be excluded from the search.
+	 */
 	private exclusionGlobPattern: string;
-	// cached glob pattern for build files.
+	/**
+	 * Glob pattern to search build files.
+	 */
 	private searchPattern: string;
-	// cached glob pattern for build files that are explicitly
-	// included from the setting: "java.import.exclusions" (negated exclusion).
+	/**
+	 * Glob pattern for build files that are explicitly
+	 * included from the setting: "java.import.exclusions" (negated exclusion).
+	 */
 	private negatedExclusionSearchPattern: string | undefined;
 
-	constructor(context: ExtensionContext) {
+	/**
+	 * string array for the imported folder paths.
+	 */
+	private importedFolderPaths: string[];
+
+	/**
+	 * Mark if the selector is used during initialization.
+	 */
+	private isInitialization: boolean;
+
+	/**
+	 * The build files that are found in the workspace.
+	 */
+	private foundBuildFiles: Uri[] = [];
+
+	/**
+	 * @param context The extension context.
+	 * @param isInitialization Mark if the selector is used during initialization.
+	 */
+	constructor(context: ExtensionContext, importedFolderUris: string[], isInitialization: boolean = true) {
 		this.context = context;
-		// TODO: should we introduce the exclusion globs into the contribution point?
-		this.exclusionGlobPattern = getExclusionGlobPattern(["**/target/**", "**/bin/**", "**/build/**"]);
-		for (const extension of extensions.all) {
-			const javaBuildTools: IBuildTool[] = extension.packageJSON.contributes?.javaBuildTools;
-			if (!Array.isArray(javaBuildTools)) {
-				continue;
-			}
-
-			for (const buildType of javaBuildTools) {
-				if (!this.isValidBuildTypeConfiguration(buildType)) {
-					continue;
-				}
-
-				this.buildTypes.push(buildType);
-			}
+		this.importedFolderPaths = importedFolderUris.map(uri => Uri.parse(uri).fsPath);
+		this.isInitialization = isInitialization;
+		const buildTool = this.context.workspaceState.get<IBuildTool>(BUILD_TOOL_FOR_CONFLICTS);
+		if (!buildTool) {
+			this.buildTools = getContributedBuildTools();
+		} else {
+			this.buildTools.push(buildTool);
 		}
-		this.searchPattern = `**/{${this.buildTypes.map(buildType => buildType.buildFileNames.join(","))}}`;
+		// TODO: should we introduce the exclusion globs into the contribution point?
+		this.exclusionGlobPattern = getExclusionGlob(["**/target/**", "**/bin/**", "**/build/**"]);
+		this.searchPattern = `**/{${this.buildTools.map(buildTool => buildTool.buildFileNames.join(","))}}`;
 		const inclusionFolderPatterns: string[] = getInclusionPatternsFromNegatedExclusion();
 		if (inclusionFolderPatterns.length > 0) {
 			const buildFileNames: string[] = [];
-			this.buildTypes.forEach(buildType => buildFileNames.push(...buildType.buildFileNames));
+			this.buildTools.forEach(buildTool => buildFileNames.push(...buildTool.buildFileNames));
 			this.negatedExclusionSearchPattern = convertToGlob(buildFileNames, inclusionFolderPatterns);
 		}
 	}
@@ -44,7 +72,7 @@ export class BuildFileSelector {
 	 * @returns `true` if there are build files in the workspace, `false` otherwise.
 	 */
 	public async hasBuildFiles(): Promise<boolean> {
-		if (this.buildTypes.length === 0) {
+		if (this.buildTools.length === 0) {
 			return false;
 		}
 
@@ -65,24 +93,23 @@ export class BuildFileSelector {
 	/**
 	 * Get the uri strings for the build files that the user selected.
 	 * @returns An array of uri string for the build files that the user selected.
-	 * An empty array means user canceled the selection.
+	 * An empty array means user canceled the selection. Or `undefined` on cancellation.
 	 */
-	public async getBuildFiles(): Promise<string[] | undefined> {
+	public async selectBuildFiles(): Promise<string[] | undefined> {
 		const cache = this.context.workspaceState.get<string[]>(PICKED_BUILD_FILES);
-		if (cache !== undefined) {
+		if (this.isInitialization && cache !== undefined) {
 			return cache;
 		}
 
-		const choice = await this.chooseBuildFilePickers();
-		const pickedUris = await this.eliminateBuildToolConflict(choice);
+		const choices = await this.chooseBuildFilePickers();
+		if (choices === undefined) {
+			return undefined;
+		}
+		const pickedUris = await this.eliminateBuildToolConflict(choices);
 		if (pickedUris.length > 0) {
 			this.context.workspaceState.update(PICKED_BUILD_FILES, pickedUris);
 		}
 		return pickedUris;
-	}
-
-	private isValidBuildTypeConfiguration(buildType: IBuildTool): boolean {
-		return !!buildType.displayName && !!buildType.buildFileNames;
 	}
 
 	private async chooseBuildFilePickers(): Promise<IBuildFilePicker[]> {
@@ -100,52 +127,58 @@ export class BuildFileSelector {
 	 * Get pickers for all build files in the workspace.
 	 */
 	private async getBuildFilePickers(): Promise<IBuildFilePicker[]> {
+		const addedFolders: Map<string, IBuildFilePicker> = new Map<string, IBuildFilePicker>();
 		const uris: Uri[] = await workspace.findFiles(this.searchPattern, this.exclusionGlobPattern);
 		if (this.negatedExclusionSearchPattern) {
 			uris.push(...await workspace.findFiles(this.negatedExclusionSearchPattern, null /* force not use default exclusion */));
 		}
+		this.foundBuildFiles.push(...uris);
 
-		// group build files by build tool and then sort them by build tool name.
-		const groupByBuildTool = new Map<IBuildTool, Uri[]>();
 		for (const uri of uris) {
-			const buildType = this.buildTypes.find(buildType => buildType.buildFileNames.includes(path.basename(uri.fsPath)));
-			if (!buildType) {
+			const containingFolder = path.dirname(uri.fsPath);
+			const buildTool = this.buildTools.find(buildTool => buildTool.buildFileNames.includes(path.basename(uri.fsPath)));
+			if (!buildTool) {
 				continue;
 			}
-			if (!groupByBuildTool.has(buildType)) {
-				groupByBuildTool.set(buildType, []);
-			}
-			groupByBuildTool.get(buildType)?.push(uri);
-		}
-
-		const buildTypeArray = Array.from(groupByBuildTool.keys());
-		buildTypeArray.sort((a, b) => a.displayName.localeCompare(b.displayName));
-		const addedFolders: Map<string, IBuildFilePicker> = new Map<string, IBuildFilePicker>();
-		for (const buildType of buildTypeArray) {
-			const uris = groupByBuildTool.get(buildType);
-			for (const uri of uris) {
-				const containingFolder = path.dirname(uri.fsPath);
-				if (addedFolders.has(containingFolder)) {
-					const picker = addedFolders.get(containingFolder);
-					if (!picker.buildTypeAndUri.has(buildType)) {
-						picker.detail += `, ./${workspace.asRelativePath(uri)}`;
-						picker.description += `, ${buildType.displayName}`;
-						picker.buildTypeAndUri.set(buildType, uri);
-					}
-				} else {
-					addedFolders.set(containingFolder, {
-						label: path.basename(containingFolder),
-						detail: `./${workspace.asRelativePath(uri)}`,
-						description: buildType.displayName,
-						buildTypeAndUri: new Map<IBuildTool, Uri>([[buildType, uri]]),
-						picked: true,
-					});
+			if (addedFolders.has(containingFolder)) {
+				const picker = addedFolders.get(containingFolder);
+				if (!picker.buildToolAndUri.has(buildTool)) {
+					picker.buildToolAndUri.set(buildTool, uri);
 				}
+			} else {
+				addedFolders.set(containingFolder, {
+					label: path.basename(containingFolder),
+					detail: "", // update later
+					description: "", // update later
+					buildToolAndUri: new Map<IBuildTool, Uri>([[buildTool, uri]]),
+				});
 			}
 		}
-
 		const pickers: IBuildFilePicker[] = Array.from(addedFolders.values());
+		await this.setPickerUiComponents(pickers);
 		return this.addSeparator(pickers);
+	}
+
+	private isImported(uri: Uri): boolean {
+		return this.importedFolderPaths.some(importedFolderPath =>
+				path.relative(importedFolderPath, path.dirname(uri.fsPath)) === "");
+	}
+
+	/**
+	 * Update the picker's UI components, including detail, description and picked flag.
+	 */
+	private async setPickerUiComponents(pickers: IBuildFilePicker[]) {
+		for (const picker of pickers) {
+			const buildTools = Array.from(picker.buildToolAndUri.keys())
+				.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+			const details = buildTools.map(buildTool => workspace.asRelativePath(picker.buildToolAndUri.get(buildTool)));
+			const descriptions = buildTools.map(buildTool => buildTool.displayName);
+
+			picker.detail = details.join(', ');
+			picker.description = descriptions.join(', ');
+			picker.picked = this.isInitialization || this.isImported(picker.buildToolAndUri.values().next().value);
+		}
 	}
 
 	/**
@@ -155,14 +188,10 @@ export class BuildFileSelector {
 		// group pickers by their containing workspace folder
 		const workspaceFolders = new Map<WorkspaceFolder, IBuildFilePicker[]>();
 		for (const picker of pickers) {
-			const folder = workspace.getWorkspaceFolder(picker.buildTypeAndUri.values().next().value);
-			if (!folder) {
-				continue;
+			const folder = workspace.getWorkspaceFolder(picker.buildToolAndUri.values().next().value);
+			if (folder) {
+			  workspaceFolders.set(folder, [...(workspaceFolders.get(folder) || []), picker]);
 			}
-			if (!workspaceFolders.has(folder)) {
-				workspaceFolders.set(folder, []);
-			}
-			workspaceFolders.get(folder)?.push(picker);
 		}
 
 		const newPickers: IBuildFilePicker[] = [];
@@ -173,7 +202,7 @@ export class BuildFileSelector {
 			newPickers.push({
 				label: folder.name,
 				kind: QuickPickItemKind.Separator,
-				buildTypeAndUri: null
+				buildToolAndUri: null
 			});
 			newPickers.push(...this.sortPickers(pickersInFolder));
 		}
@@ -182,8 +211,8 @@ export class BuildFileSelector {
 
 	private sortPickers(pickers: IBuildFilePicker[]): IBuildFilePicker[] {
 		return pickers.sort((a, b) => {
-			const pathA = path.dirname(a.buildTypeAndUri.values().next().value.fsPath);
-			const pathB = path.dirname(b.buildTypeAndUri.values().next().value.fsPath);
+			const pathA = path.dirname(a.buildToolAndUri.values().next().value.fsPath);
+			const pathB = path.dirname(b.buildToolAndUri.values().next().value.fsPath);
 			return pathA.localeCompare(pathB);
 		});
 	}
@@ -191,68 +220,86 @@ export class BuildFileSelector {
 	/**
 	 * Ask user to choose a build tool when there are multiple build tools in the same folder.
 	 */
-	private async eliminateBuildToolConflict(choice?: IBuildFilePicker[]): Promise<string[]> {
-		if (!choice) {
-			return [];
-		}
-		const conflictBuildTypeAndUris = new Map<IBuildTool, Uri[]>();
+	private async eliminateBuildToolConflict(choices?: IBuildFilePicker[]): Promise<string[]> {
+		// group uris by build tool
+		const conflictBuildToolAndUris = new Map<IBuildTool, Uri[]>();
 		const result: string[] = [];
-		for (const picker of choice) {
-			if (picker.buildTypeAndUri.size > 1) {
-				for (const [buildType, uri] of picker.buildTypeAndUri) {
-					if (!conflictBuildTypeAndUris.has(buildType)) {
-						conflictBuildTypeAndUris.set(buildType, []);
-					}
-					conflictBuildTypeAndUris.get(buildType)?.push(uri);
-				}
+		for (const picker of choices) {
+			if (picker.buildToolAndUri.size > 1) {
+			  picker.buildToolAndUri.forEach((uri, buildTool) => {
+				conflictBuildToolAndUris.set(buildTool, [...(conflictBuildToolAndUris.get(buildTool) || []), uri]);
+			  });
 			} else {
-				result.push(picker.buildTypeAndUri.values().next().value.toString());
+			  result.push(picker.buildToolAndUri.values().next().value.toString());
 			}
 		}
 
-		if (conflictBuildTypeAndUris.size > 0) {
-			const conflictItems: IConflictItem[] = [];
-			for (const buildType of conflictBuildTypeAndUris.keys()) {
-				conflictItems.push({
-					title: buildType.displayName,
-					uris: conflictBuildTypeAndUris.get(buildType),
-				});
-			}
-			conflictItems.sort((a, b) => a.title.localeCompare(b.title));
-			conflictItems.push({
-				title: "Skip",
-				isCloseAffordance: true,
-			});
-
-			const choice = await window.showInformationMessage<IConflictItem>(
-				"Which build tool would you like to use for the workspace?",
-				{
-					modal: true,
-				},
-				...conflictItems
-			);
-
-			if (choice?.title !== "Skip" && choice?.uris) {
-				result.push(...choice.uris.map(uri => uri.toString()));
+		if (conflictBuildToolAndUris.size > 0) {
+			const buildTool = this.context.workspaceState.get<IBuildTool>(BUILD_TOOL_FOR_CONFLICTS);
+			if (buildTool) {
+				result.push(...this.filterByCachedBuildTool(conflictBuildToolAndUris, buildTool));
+			} else {
+				result.push(...await this.askToResolveConflicts(conflictBuildToolAndUris));
 			}
 		}
 		return result;
 	}
-}
 
-interface IBuildTool {
-	displayName: string;
-	buildFileNames: string[];
+	private filterByCachedBuildTool(conflictBuildToolAndUris: Map<IBuildTool, Uri[]>, buildTool: IBuildTool): string[] {
+		const result: string[] = [];
+		if (conflictBuildToolAndUris.has(buildTool)) {
+			result.push(...conflictBuildToolAndUris.get(buildTool)!.map(uri => uri.toString()));
+		}
+		return result;
+	}
+
+	private async askToResolveConflicts(conflictBuildToolAndUris: Map<IBuildTool, Uri[]>): Promise<string[]> {
+		const result: string[] = [];
+		const conflictItems: IConflictItem[] = [];
+		for (const buildTool of conflictBuildToolAndUris.keys()) {
+			conflictItems.push({
+				title: buildTool.displayName,
+				buildTool: buildTool,
+				uris: conflictBuildToolAndUris.get(buildTool),
+			});
+		}
+		conflictItems.sort((a, b) => a.title.localeCompare(b.title));
+		conflictItems.push({
+			title: "Skip",
+			uris: [],
+			isCloseAffordance: true,
+		});
+
+		const choice = await window.showInformationMessage<IConflictItem>(
+			"Which build tool would you like to use for the workspace?",
+			{
+				modal: true,
+			},
+			...conflictItems
+		);
+
+		if (choice?.title !== "Skip") {
+			result.push(...choice.uris.map(uri => uri.toString()));
+			this.context.workspaceState.update(BUILD_TOOL_FOR_CONFLICTS, choice.buildTool);
+		}
+		return result;
+	}
+
+	public getAllFoundBuildFiles(): Uri[] {
+		return this.foundBuildFiles;
+	}
 }
 
 interface IConflictItem extends MessageItem {
-	uris?: Uri[];
+	uris: Uri[];
+	buildTool?: IBuildTool;
 }
 
 interface IBuildFilePicker extends QuickPickItem {
-	buildTypeAndUri: Map<IBuildTool, Uri>;
+	buildToolAndUri: Map<IBuildTool, Uri>;
 }
 
 export function cleanupProjectPickerCache(context: ExtensionContext) {
 	context.workspaceState.update(PICKED_BUILD_FILES, undefined);
+	context.workspaceState.update(BUILD_TOOL_FOR_CONFLICTS, undefined);
 }

--- a/src/buildFilesSelector.ts
+++ b/src/buildFilesSelector.ts
@@ -96,19 +96,12 @@ export class BuildFileSelector {
 	 * An empty array means user canceled the selection. Or `undefined` on cancellation.
 	 */
 	public async selectBuildFiles(): Promise<string[] | undefined> {
-		const cache = this.context.workspaceState.get<string[]>(PICKED_BUILD_FILES);
-		if (this.isInitialization && cache !== undefined) {
-			return cache;
-		}
-
 		const choices = await this.chooseBuildFilePickers();
 		if (choices === undefined) {
 			return undefined;
 		}
 		const pickedUris = await this.eliminateBuildToolConflict(choices);
-		if (pickedUris.length > 0) {
-			this.context.workspaceState.update(PICKED_BUILD_FILES, pickedUris);
-		}
+		this.context.workspaceState.update(PICKED_BUILD_FILES, pickedUris);
 		return pickedUris;
 	}
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -162,6 +162,7 @@ export namespace Commands {
      */
     export const IMPORT_PROJECTS_CMD = 'java.project.import.command';
     export const IMPORT_PROJECTS = 'java.project.import';
+    export const CHANGE_IMPORTED_PROJECTS = 'java.project.changeImportedProjects';
     /**
      * Override or implements the methods from the supertypes.
      */

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -111,7 +111,7 @@ export interface SourceInvalidatedEvent {
 	affectedEditorDocuments?: Uri[];
 }
 
-export const extensionApiVersion = '0.12';
+export const extensionApiVersion = '0.13';
 
 export interface ExtensionAPI {
 	readonly apiVersion: string;
@@ -136,6 +136,16 @@ export interface ExtensionAPI {
 	 * The Uris in the array point to the project root path.
 	 */
 	readonly onDidProjectsImport: Event<Uri[]>;
+
+	/**
+	 * An event fires on projects deleted. This API is not supported in light weight server mode so far.
+	 * The Uris in the array point to the project root path.
+	 *
+	 * @since API version 0.13
+	 * @since extension version 1.25.0
+	 */
+	readonly onDidProjectsDelete: Event<Uri[]>;
+
 	readonly goToDefinition: GoToDefinitionCommand;
 	/**
 	 * Indicates the current active mode for Java Language Server. Possible modes are:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -469,7 +469,7 @@ async function startStandardServer(context: ExtensionContext, requirements: requ
 		return;
 	}
 
-	const selector: BuildFileSelector = new BuildFileSelector(context);
+	const selector: BuildFileSelector = new BuildFileSelector(context, []);
 	const importMode: ImportMode = await getImportMode(context, selector);
 	if (importMode === ImportMode.automatic) {
 		if (!await ensureNoBuildToolConflicts(context, clientOptions)) {
@@ -478,7 +478,7 @@ async function startStandardServer(context: ExtensionContext, requirements: requ
 	} else {
 		const buildFiles: string[] = [];
 		if (importMode === ImportMode.manual) {
-			buildFiles.push(...await selector.getBuildFiles());
+			buildFiles.push(...(await selector.selectBuildFiles() || []));
 		}
 		if (buildFiles.length === 0) {
 			// cancelled by user

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -97,3 +97,30 @@ export function isContributedPartUpdated(oldContributedPart: Array<string>, newC
 	}
 	return hasChanged;
 }
+
+export function getContributedBuildTools(): IBuildTool[] {
+	const buildTypes: IBuildTool[] = [];
+	for (const extension of extensions.all) {
+		const javaBuildTools: IBuildTool[] = extension.packageJSON.contributes?.javaBuildTools;
+		if (!Array.isArray(javaBuildTools)) {
+			continue;
+		}
+
+		for (const buildType of javaBuildTools) {
+			if (!isValidBuildTypeConfiguration(buildType)) {
+				continue;
+			}
+			buildTypes.push(buildType);
+		}
+	}
+	return buildTypes;
+}
+
+export interface IBuildTool {
+	displayName: string;
+	buildFileNames: string[];
+}
+
+function isValidBuildTypeConfiguration(buildType: IBuildTool): boolean {
+	return !!buildType.displayName && !!buildType.buildFileNames;
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -58,6 +58,7 @@ export enum FeatureStatus {
 export enum EventType {
     classpathUpdated = 100,
     projectsImported = 200,
+    projectsDeleted = 210,
     incompatibleGradleJdkIssue = 300,
     upgradeGradleWrapper = 400,
     sourceInvalidated = 500,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,9 +145,24 @@ function parseToStringGlob(patterns: string[]): string {
  * @returns string array for the project uris.
  */
 export async function getAllJavaProjects(excludeDefaultProject: boolean = true): Promise<string[]> {
-	let projectUris: string[] = await commands.executeCommand<string[]>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_ALL_JAVA_PROJECTS);
+	const projectUris: string[] = await commands.executeCommand<string[]>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_ALL_JAVA_PROJECTS);
+	return filterDefaultProject(projectUris, excludeDefaultProject);
+}
+
+/**
+ * Get all projects from Java Language Server.
+ * @param excludeDefaultProject whether the default project should be excluded from the list, defaults to true.
+ * @returns string array for the project uris.
+ */
+export async function getAllProjects(excludeDefaultProject: boolean = true): Promise<string[]> {
+	const projectUris: string[] = await commands.executeCommand<string[]>(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.GET_ALL_JAVA_PROJECTS,
+		JSON.stringify({ includeNonJava: true }));
+	return filterDefaultProject(projectUris, excludeDefaultProject);
+}
+
+function filterDefaultProject(projectUris: string[], excludeDefaultProject: boolean): string[] {
 	if (excludeDefaultProject) {
-		projectUris = projectUris.filter((uriString) => {
+		return projectUris.filter((uriString) => {
 			const projectPath = Uri.parse(uriString).fsPath;
 			return path.basename(projectPath) !== "jdt.ls-java-project";
 		});


### PR DESCRIPTION
- Reuse the 'BuildFilesSelector' and enable change the imported projects after the activation finishes.

requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2972