### PR TITLE
Support for pasting a java file in the file explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1487,6 +1487,11 @@
         "command": "java.server.restart",
         "title": "%java.server.restart%",
         "category": "Java"
+      },
+      {
+        "command": "java.action.filesExplorerPasteAction",
+        "title": "%java.action.filesExplorerPasteAction%",
+        "category": "Java"
       }
     ],
     "keybindings": [
@@ -1504,6 +1509,12 @@
         "key": "ctrl+shift+v",
         "mac": "cmd+shift+v",
         "when": "javaLSReady && editorLangId == java"
+      },
+      {
+        "command": "java.action.filesExplorerPasteAction",
+        "key": "ctrl+shift+v",
+        "mac": "cmd+shift+v",
+        "when": "explorerViewletFocus && config.editor.pasteAs.enabled"
       }
     ],
     "menus": {
@@ -1622,6 +1633,10 @@
         {
           "command": "java.server.restart",
           "when": "javaLSReady"
+        },
+        {
+          "command": "java.action.filesExplorerPasteAction",
+          "when": "false"
         }
       ],
       "view/title": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -25,5 +25,6 @@
 	"java.project.createModuleInfo.command": "Create module-info.java",
 	"java.clean.sharedIndexes": "Clean Shared Indexes",
 	"java.server.restart": "Restart Java Language Server",
-	"java.edit.smartSemicolonDetection": "Java Smart Semicolon Detection"
+	"java.edit.smartSemicolonDetection": "Java Smart Semicolon Detection",
+	"java.action.filesExplorerPasteAction": "Paste clipboard text into a file"
 }

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -22,5 +22,6 @@
 	"java.action.showSupertypeHierarchy": "Supertype 계층 구조 표시",
 	"java.action.showSubtypeHierarchy": "Subtype 계층 구조 표시",
 	"java.action.changeBaseType": "이 유형을 기준으로",
-	"java.project.createModuleInfo.command": "module-info.java 생성"
+	"java.project.createModuleInfo.command": "module-info.java 생성",
+	"java.action.filesExplorerPasteAction": "클립보드 텍스트를 파일에 붙여넣기"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -23,5 +23,6 @@
 	"java.action.showSubtypeHierarchy": "显示子类层次结构",
 	"java.action.changeBaseType": "基于此类型",
 	"java.project.createModuleInfo.command": "创建 module-info.java",
-	"java.clean.sharedIndexes": "清理共享的索引文件"
+	"java.clean.sharedIndexes": "清理共享的索引文件",
+	"java.action.filesExplorerPasteAction": "将剪贴板文本粘贴到文件中"
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -22,5 +22,6 @@
 	"java.action.showSupertypeHierarchy": "顯示父類別階層結構",
 	"java.action.showSubtypeHierarchy": "顯示子類別階層結構",
 	"java.action.changeBaseType": "以此型別為基礎",
-	"java.project.createModuleInfo.command": "創建 module-info.java"
+	"java.project.createModuleInfo.command": "創建 module-info.java",
+	"java.action.filesExplorerPasteAction": "將剪貼簿文字貼到文件中"
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -192,6 +192,10 @@ export namespace Commands {
      */
     export const CLIPBOARD_ONPASTE = 'java.action.clipboardPasteAction';
     /**
+     * Custom paste action in files explorer
+     */
+     export const FILESEXPLORER_ONPASTE = 'java.action.filesExplorerPasteAction';
+    /**
      * Choose type to import.
      */
     export const CHOOSE_IMPORTS = "java.action.organizeImports.chooseImports";
@@ -340,5 +344,10 @@ export namespace Commands {
     * Smart semicolon detection.
     */
     export const SMARTSEMICOLON_DETECTION = "java.edit.smartSemicolonDetection";
+
+    /**
+     * Determine if pasted text is a java file and resolve packages
+     */
+    export const RESOLVE_PASTED_TEXT = "java.project.resolveText";
 
 }

--- a/test/lightweight-mode-suite/extension.test.ts
+++ b/test/lightweight-mode-suite/extension.test.ts
@@ -25,6 +25,7 @@ suite('Java Language Extension - LightWeight', () => {
 				Commands.OPEN_FILE,
 				Commands.CLEAN_SHARED_INDEXES,
 				Commands.RESTART_LANGUAGE_SERVER,
+				Commands.FILESEXPLORER_ONPASTE
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -118,6 +118,8 @@ suite('Java Language Extension - Standard', () => {
 				Commands.UPDATE_SOURCE_ATTACHMENT_CMD,
 				Commands.SMARTSEMICOLON_DETECTION,
 				Commands.RESOLVE_SOURCE_ATTACHMENT,
+				Commands.FILESEXPLORER_ONPASTE,
+				Commands.RESOLVE_PASTED_TEXT,
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {
 				return JAVA_COMMANDS.indexOf(value)>=0 || value.startsWith('java.');


### PR DESCRIPTION
Addresses #3323

Introduces new keybinding and command for pasting a java file into the file explorer. Relies on delegate command introduced in https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2981.