### PR TITLE
Fix escape characters within textblock

### DIFF
--- a/language-support/java/java.tmLanguage.json
+++ b/language-support/java/java.tmLanguage.json
@@ -1596,11 +1596,7 @@
 					"name": "string.quoted.triple.java",
 					"patterns": [
 						{
-							"match": "\\\\\"\"\"",
-							"name": "constant.character.escape.java"
-						},
-						{
-							"match": "\\\\.",
+							"match": "(\\\\\"\"\")(?!\")|(\\\\.)",
 							"name": "constant.character.escape.java"
 						}
 					]


### PR DESCRIPTION
Fixes #3384 

Before:
![Screenshot from 2023-12-04 15-41-28](https://github.com/redhat-developer/vscode-java/assets/115827695/15927c56-48a8-4d51-a4ff-0a908bba3352)

After:
![Screenshot from 2023-12-04 15-39-43](https://github.com/redhat-developer/vscode-java/assets/115827695/62835326-cd2d-41a3-8ed1-c319d9a17040)
