### PR TITLE
Make the server status as a normal status bar item

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,8 +129,6 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 
 	cleanJavaWorkspaceStorage();
 
-	serverStatusBarProvider.initialize();
-
 	return requirements.resolveRequirements(context).catch(error => {
 		// show error
 		window.showErrorMessage(error.message, error.label).then((selection) => {

--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -3,7 +3,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { Commands } from "./commands";
-import { StatusIcon } from "./serverStatusBarProvider";
 
 const languageServerDocumentSelector = [
 	{ scheme: 'file', language: 'java' },
@@ -45,77 +44,6 @@ export namespace StatusCommands {
 		arguments: ['Standard', true],
 		tooltip: "Select Projects..."
 	};
-}
-
-export namespace ServerStatusItemFactory {
-	export function create(): any {
-		if (supportsLanguageStatus()) {
-			const item = vscode.languages.createLanguageStatusItem("JavaServerStatusItem", languageServerDocumentSelector);
-			item.name = "Java Language Server Status";
-			return item;
-		}
-		return undefined;
-	}
-
-	export function showLightWeightStatus(item: any): void {
-		item.severity = vscode.LanguageStatusSeverity?.Warning;
-		item.text = StatusIcon.lightWeight;
-		item.detail = "Lightweight Mode";
-		item.command = StatusCommands.switchToStandardCommand;
-	}
-
-	export function showNotImportedStatus(item: any): void {
-		item.severity = vscode.LanguageStatusSeverity?.Warning;
-		item.text = "No projects are imported";
-		item.command = StatusCommands.startStandardServerCommand;
-	}
-
-	export function showStandardStatus(item: any): void {
-		item.severity = vscode.LanguageStatusSeverity?.Information;
-		item.command = StatusCommands.showServerStatusCommand;
-	}
-
-	export function setBusy(item: any): void {
-		if (item.busy === true) {
-			return;
-		}
-		item.text = "Building";
-		item.busy = true;
-	}
-
-	export function setError(item: any): void {
-		item.busy = false;
-		item.severity = vscode.LanguageStatusSeverity?.Error;
-		item.command = {
-			title: "Open logs",
-			command: Commands.OPEN_LOGS
-		};
-		item.text = StatusIcon.error;
-		item.detail = "Errors occurred in initializing language server";
-	}
-
-	export function setWarning(item: any): void {
-		item.busy = false;
-		item.severity = vscode.LanguageStatusSeverity?.Error;
-		item.command = {
-			title: "Show PROBLEMS Panel",
-			command: "workbench.panel.markers.view.focus",
-			tooltip: "Errors occurred in project configurations, click to show the PROBLEMS panel"
-		};
-		item.text = StatusIcon.warning;
-		item.detail = "Project Configuration Error";
-	}
-
-	export function setReady(item: any): void {
-		if (item.text === StatusIcon.ready) {
-			return;
-		}
-		item.busy = false;
-		item.severity = vscode.LanguageStatusSeverity?.Information;
-		item.command = StatusCommands.showServerStatusCommand;
-		item.text = StatusIcon.ready;
-		item.detail = "";
-	}
 }
 
 export namespace RuntimeStatusItemFactory {

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -1,123 +1,68 @@
 'use strict';
 
-import { StatusBarItem, window, StatusBarAlignment, version } from "vscode";
+import { StatusBarItem, window, StatusBarAlignment } from "vscode";
 import { Commands } from "./commands";
 import { Disposable } from "vscode-languageclient";
-import * as semver from "semver";
-import { ServerStatusItemFactory, StatusCommands, supportsLanguageStatus } from "./languageStatusItemFactory";
+import { StatusCommands } from "./languageStatusItemFactory";
 
 class ServerStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
-	private languageStatusItem: any;
-	// Adopt new API for status bar item, meanwhile keep the compatibility with Theia.
-	// See: https://github.com/redhat-developer/vscode-java/issues/1982
-	private isAdvancedStatusBarItem: boolean;
 
 	constructor() {
-		this.isAdvancedStatusBarItem = semver.gte(version, "1.57.0");
-	}
-
-	public initialize(): void {
-		if (supportsLanguageStatus()) {
-			this.languageStatusItem = ServerStatusItemFactory.create();
-		} else {
-			if (this.isAdvancedStatusBarItem) {
-				this.statusBarItem = (window.createStatusBarItem as any)("java.serverStatus", StatusBarAlignment.Right, Number.MIN_VALUE);
-			} else {
-				this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, Number.MIN_VALUE);
-			}
-		}
+		this.statusBarItem = window.createStatusBarItem("java.serverStatus", StatusBarAlignment.Right, Number.MIN_VALUE);
 	}
 
 	public showLightWeightStatus(): void {
-		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.showLightWeightStatus(this.languageStatusItem);
-		} else {
-			if (this.isAdvancedStatusBarItem) {
-				(this.statusBarItem as any).name = "Java Server Mode";
-			}
-			this.statusBarItem.text = StatusIcon.lightWeight;
-			this.statusBarItem.command = StatusCommands.switchToStandardCommand;
-			this.statusBarItem.tooltip = "Java language server is running in LightWeight mode, click to switch to Standard mode";
-			this.statusBarItem.show();
-		}
+		this.statusBarItem.name = "Java Server Mode";
+		this.statusBarItem.text = StatusIcon.lightWeight;
+		this.statusBarItem.command = StatusCommands.switchToStandardCommand;
+		this.statusBarItem.tooltip = "Java language server is running in LightWeight mode, click to switch to Standard mode";
+		this.statusBarItem.show();
 	}
 
 	public showNotImportedStatus(): void {
-		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.showNotImportedStatus(this.languageStatusItem);
-		} else {
-			if (this.isAdvancedStatusBarItem) {
-				(this.statusBarItem as any).name = "No projects are imported";
-			}
-			this.statusBarItem.text = StatusIcon.notImported;
-			this.statusBarItem.command = StatusCommands.startStandardServerCommand;
-			this.statusBarItem.tooltip = "No projects are imported, click to load projects";
-			this.statusBarItem.show();
-		}
+		this.statusBarItem.name = "No projects are imported";
+		this.statusBarItem.text = StatusIcon.notImported;
+		this.statusBarItem.command = StatusCommands.startStandardServerCommand;
+		this.statusBarItem.tooltip = "No projects are imported, click to load projects";
+		this.statusBarItem.show();
 	}
 
 	public showStandardStatus(): void {
-		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.showStandardStatus(this.languageStatusItem);
-			ServerStatusItemFactory.setBusy(this.languageStatusItem);
-		} else {
-			if (this.isAdvancedStatusBarItem) {
-				(this.statusBarItem as any).name = "Java Server Status";
-			}
-			this.statusBarItem.text = StatusIcon.busy;
-			this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-			this.statusBarItem.tooltip = "";
-			this.statusBarItem.show();
-		}
+		this.statusBarItem.name = "Java Server Status";
+		this.statusBarItem.text = StatusIcon.busy;
+		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
+		this.statusBarItem.tooltip = "";
+		this.statusBarItem.show();
 	}
 
 	public setBusy(): void {
-		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.setBusy(this.languageStatusItem);
-		} else {
-			this.statusBarItem.text = StatusIcon.busy;
-		}
+		this.statusBarItem.text = StatusIcon.busy;
 	}
 
 	public setError(): void {
-		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.setError(this.languageStatusItem);
-		} else {
-			this.statusBarItem.text = StatusIcon.error;
-			this.statusBarItem.command = Commands.OPEN_LOGS;
-		}
+		this.statusBarItem.text = StatusIcon.error;
+		this.statusBarItem.command = Commands.OPEN_LOGS;
 	}
 
 	public setWarning(): void {
-		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.setWarning(this.languageStatusItem);
-		} else {
-			this.statusBarItem.text = StatusIcon.warning;
-			this.statusBarItem.command = "workbench.panel.markers.view.focus";
-			this.statusBarItem.tooltip = "Errors occurred in project configurations, click to show the PROBLEMS panel";
-		}
+		this.statusBarItem.text = StatusIcon.warning;
+		this.statusBarItem.command = "workbench.panel.markers.view.focus";
+		this.statusBarItem.tooltip = "Errors occurred in project configurations, click to show the PROBLEMS panel";
 	}
 
 	public setReady(): void {
-		if (supportsLanguageStatus()) {
-			ServerStatusItemFactory.setReady(this.languageStatusItem);
-		} else {
-			this.statusBarItem.text = StatusIcon.ready;
-			this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-			this.statusBarItem.tooltip = "ServiceReady";
-		}
+		this.statusBarItem.text = StatusIcon.ready;
+		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
+		this.statusBarItem.tooltip = "ServiceReady";
 	}
 
 	public updateTooltip(tooltip: string): void {
-		if (!supportsLanguageStatus()) {
-			this.statusBarItem.tooltip = tooltip;
-		}
+		this.statusBarItem.tooltip = tooltip;
 	}
 
 	public dispose(): void {
 		this.statusBarItem?.dispose();
-		this.languageStatusItem?.dispose();
 	}
 }
 


### PR DESCRIPTION
This actually makes the implementation much clear.

I also removed the check for the advanced status bar item because according to the theia & VS Code api comparation page, theia already **fully** supports the createStatusBarItem API: https://[eclipse-theia.github.io/vscode-theia-comparator/status.html](https://eclipse-theia.github.io/vscode-theia-comparator/status.html)

Let me know if you have any input @rgrunber @fbricon 

fix #3416 