### PR TITLE
Remove the compatibility check for createLanguageStatusItem() api

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { CodeActionContext, commands, ConfigurationTarget, Diagnostic, env, EventEmitter, ExtensionContext, extensions, IndentAction, InputBoxOptions, languages, RelativePattern, TextDocument, UIKind, Uri, ViewColumn, window, workspace, WorkspaceConfiguration, version } from 'vscode';
+import { CodeActionContext, commands, ConfigurationTarget, Diagnostic, env, EventEmitter, ExtensionContext, extensions, IndentAction, InputBoxOptions, languages, RelativePattern, TextDocument, UIKind, Uri, ViewColumn, window, workspace, WorkspaceConfiguration } from 'vscode';
 import { CancellationToken, CodeActionParams, CodeActionRequest, Command, CompletionRequest, DidChangeConfigurationNotification, ExecuteCommandParams, ExecuteCommandRequest, LanguageClientOptions, RevealOutputChannelOn } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { apiManager } from './apiManager';
@@ -22,7 +22,7 @@ import { collectJavaExtensions, getBundlesToReload, isContributedPartUpdated } f
 import { registerClientProviders } from './providerDispatcher';
 import { initialize as initializeRecommendation } from './recommendation';
 import * as requirements from './requirements';
-import { runtimeStatusBarProvider } from './runtimeStatusBarProvider';
+import { languageStatusBarProvider } from './runtimeStatusBarProvider';
 import { serverStatusBarProvider } from './serverStatusBarProvider';
 import { ACTIVE_BUILD_TOOL_STATE, cleanWorkspaceFileName, getJavaServerMode, handleTextDocumentChanges, getImportMode, onConfigurationChange, ServerMode, ImportMode } from './settings';
 import { snippetCompletionProvider } from './snippetCompletionProvider';
@@ -399,7 +399,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 
 			context.subscriptions.push(snippetCompletionProvider.initialize());
 			context.subscriptions.push(serverStatusBarProvider);
-			context.subscriptions.push(runtimeStatusBarProvider);
+			context.subscriptions.push(languageStatusBarProvider);
 
 			const classEditorProviderRegistration = window.registerCustomEditorProvider(JavaClassEditorProvider.viewType, new JavaClassEditorProvider(context));
 			context.subscriptions.push(classEditorProviderRegistration);
@@ -410,7 +410,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 				if (event === ServerMode.standard) {
 					syntaxClient.stop();
 					fileEventHandler.setServerStatus(true);
-					runtimeStatusBarProvider.initialize(context);
+					languageStatusBarProvider.initialize(context);
 				}
 				commands.executeCommand('setContext', 'java:serverMode', event);
 			});

--- a/src/languageStatusItemFactory.ts
+++ b/src/languageStatusItemFactory.ts
@@ -13,22 +13,12 @@ const languageServerDocumentSelector = [
 	{ pattern: '**/{build,settings}.gradle.kts'}
 ];
 
-export function supportsLanguageStatus(): boolean {
-	return !!vscode.languages.createLanguageStatusItem;
-}
-
 export namespace StatusCommands {
 	export const switchToStandardCommand = {
 		title: "Load Projects",
 		command: Commands.SWITCH_SERVER_MODE,
 		arguments: ['Standard', true],
 		tooltip: "LightWeight mode only provides limited features, please load projects to get full feature set"
-	};
-
-	export const showServerStatusCommand = {
-		title: "Show Build Status",
-		command: Commands.SHOW_SERVER_TASK_STATUS,
-		tooltip: "Show Build Status"
 	};
 
 	export const configureJavaRuntimeCommand = {
@@ -47,19 +37,16 @@ export namespace StatusCommands {
 }
 
 export namespace RuntimeStatusItemFactory {
-	export function create(text: string, vmInstallPath: string): any {
-		if (supportsLanguageStatus()) {
-			const item = vscode.languages.createLanguageStatusItem("javaRuntimeStatusItem", languageServerDocumentSelector);
-			item.severity = vscode.LanguageStatusSeverity?.Information;
-			item.name = "Java Runtime";
-			item.text = text;
-			item.command = StatusCommands.configureJavaRuntimeCommand;
-			if (vmInstallPath) {
-				item.command.tooltip = `Language Level: ${text} <${vmInstallPath}>`;
-			}
-			return item;
+	export function create(text: string, vmInstallPath: string): vscode.LanguageStatusItem {
+		const item = vscode.languages.createLanguageStatusItem("javaRuntimeStatusItem", languageServerDocumentSelector);
+		item.severity = vscode.LanguageStatusSeverity?.Information;
+		item.name = "Java Runtime";
+		item.text = text;
+		item.command = StatusCommands.configureJavaRuntimeCommand;
+		if (vmInstallPath) {
+			item.command.tooltip = `Language Level: ${text} <${vmInstallPath}>`;
 		}
-		return undefined;
+		return item;
 	}
 
 	export function update(item: any, text: string, vmInstallPath: string): void {
@@ -69,17 +56,14 @@ export namespace RuntimeStatusItemFactory {
 }
 
 export namespace BuildFileStatusItemFactory {
-	export function create(buildFilePath: string): any {
-		if (supportsLanguageStatus()) {
-			const fileName = path.basename(buildFilePath);
-			const item = vscode.languages.createLanguageStatusItem("javaBuildFileStatusItem", languageServerDocumentSelector);
-			item.severity = vscode.LanguageStatusSeverity?.Information;
-			item.name = "Java Build File";
-			item.text = fileName;
-			item.command = getOpenBuildFileCommand(buildFilePath);
-			return item;
-		}
-		return undefined;
+	export function create(buildFilePath: string): vscode.LanguageStatusItem {
+		const fileName = path.basename(buildFilePath);
+		const item = vscode.languages.createLanguageStatusItem("javaBuildFileStatusItem", languageServerDocumentSelector);
+		item.severity = vscode.LanguageStatusSeverity?.Information;
+		item.name = "Java Build File";
+		item.text = fileName;
+		item.command = getOpenBuildFileCommand(buildFilePath);
+		return item;
 	}
 
 	export function update(item: any, buildFilePath: string): void {

--- a/src/lombokSupport.ts
+++ b/src/lombokSupport.ts
@@ -7,8 +7,7 @@ import * as vscode from "vscode";
 import { ExtensionContext, window, commands } from "vscode";
 import { Commands } from "./commands";
 import { apiManager } from "./apiManager";
-import { supportsLanguageStatus } from "./languageStatusItemFactory";
-import { runtimeStatusBarProvider } from './runtimeStatusBarProvider';
+import { languageStatusBarProvider } from './runtimeStatusBarProvider';
 import { logger } from './log';
 import { getAllJavaProjects } from "./utils";
 
@@ -157,11 +156,11 @@ export async function checkLombokDependency(context: ExtensionContext) {
 			registerLombokConfigureCommand(context);
 			isLombokCommandInitialized = true;
 		}
-		runtimeStatusBarProvider.initializeLombokStatusBar();
+		languageStatusBarProvider.initializeLombokStatusBar();
 		isLombokStatusBarInitialized = true;
 	}
 	if (isLombokStatusBarInitialized && !projectLombokPath) {
-		runtimeStatusBarProvider.destroyLombokStatusBar();
+		languageStatusBarProvider.destroyLombokStatusBar();
 		isLombokStatusBarInitialized = false;
 		cleanupLombokCache(context);
 	}
@@ -245,16 +244,13 @@ export function registerLombokConfigureCommand(context: ExtensionContext) {
 }
 
 export namespace LombokVersionItemFactory {
-	export function create(text: string): any {
-		if (supportsLanguageStatus()) {
-			const item = vscode.languages.createLanguageStatusItem("javaLombokVersionItem", languageServerDocumentSelector);
-			item.severity = vscode.LanguageStatusSeverity?.Information;
-			item.name = "Lombok Version";
-			item.text = text;
-			item.command = getLombokChangeCommand();
-			return item;
-		}
-		return undefined;
+	export function create(text: string): vscode.LanguageStatusItem {
+		const item = vscode.languages.createLanguageStatusItem("javaLombokVersionItem", languageServerDocumentSelector);
+		item.severity = vscode.LanguageStatusSeverity?.Information;
+		item.name = "Lombok Version";
+		item.text = text;
+		item.command = getLombokChangeCommand();
+		return item;
 	}
 
 	export function update(item: any, text: string): void {


### PR DESCRIPTION
Remove the createLanguageStatusItem() api check since theia fully supports this api now: https://eclipse-theia.github.io/vscode-theia-comparator/status.html

fix #3081 