### PR TITLE
Reduce delegate command calls when classpath changes

### DIFF
--- a/src/lombokSupport.ts
+++ b/src/lombokSupport.ts
@@ -4,7 +4,7 @@ import * as fse from "fs-extra";
 import * as path from "path";
 import * as semver from 'semver';
 import * as vscode from "vscode";
-import { ExtensionContext, window, commands } from "vscode";
+import { ExtensionContext, window, commands, Uri } from "vscode";
 import { Commands } from "./commands";
 import { apiManager } from "./apiManager";
 import { languageStatusBarProvider } from './runtimeStatusBarProvider';
@@ -117,7 +117,7 @@ export function addLombokParam(context: ExtensionContext, params: string[]) {
 	updateActiveLombokPath(lombokJarPath);
 }
 
-export async function checkLombokDependency(context: ExtensionContext) {
+export async function checkLombokDependency(context: ExtensionContext, projectUri?: Uri) {
 	if (!isLombokSupportEnabled()) {
 		return;
 	}
@@ -126,7 +126,7 @@ export async function checkLombokDependency(context: ExtensionContext) {
 	let currentLombokVersion: string = undefined;
 	let previousLombokVersion: string = undefined;
 	let currentLombokClasspath: string = undefined;
-	const projectUris: string[] = await getAllJavaProjects();
+	const projectUris: string[] = projectUri ? [projectUri.toString()] : await getAllJavaProjects();
 	for (const projectUri of projectUris) {
 		const classpathResult = await apiManager.getApiInstance().getClasspaths(projectUri, {scope: 'test'});
 		for (const classpath of classpathResult.classpaths) {

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -143,8 +143,8 @@ export class StandardLanguageClient {
 						showImportFinishNotification(context);
 					}
 					checkLombokDependency(context);
-					apiManager.getApiInstance().onDidClasspathUpdate((e: Uri) => {
-						checkLombokDependency(context);
+					apiManager.getApiInstance().onDidClasspathUpdate((projectUri: Uri) => {
+						checkLombokDependency(context, projectUri);
 					});
 					// Disable the client-side snippet provider since LS is ready.
 					snippetCompletionProvider.dispose();


### PR DESCRIPTION
This PR use the project uri from the classpath update event to reduce the delegate command invocation when checking the lombok dependency.

Previously, when a classpath update event comes, the extension will check the lombok dependency for all java projects. It was not using the project uri of the classpath update event. Assume a workspace contains 10 projects, it will generate 10*10=100 getClasspath command invocation.

I did a benchmark roughly for the project: https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/spring with following steps:

1. Disable auto build (too many modules causes too much time to build the workspace)
2. Set `java.trace.server` to message 
3. Open the folder.
4. Wait until no more traces appear in the output channel.

Without the change, it takes 7 mins and 30 secs, with 3295 requests sent to server.
With this change, it takes 5 mins and 40 secs, with 347 requests sent to server. 