### PR TITLE
Add support for externally provided 'lifecycle-mapping-metadata.xml' file

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ The following settings are supported:
 * `java.edit.smartSemicolonDetection.enabled`: Defines the `smart semicolon` detection. Defaults to `false`.
 * `java.configuration.detectJdksAtStart`: Automatically detect JDKs installed on local machine at startup. If you have specified the same JDK version in `java.configuration.runtimes`, the extension will use that version first. Defaults to `true`.
 
+New in 1.27.0
+* `java.configuration.maven.lifecycleMappings` : Path to Maven's lifecycle mappings xml.
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/package.json
+++ b/package.json
@@ -659,6 +659,13 @@
           "description": "Specifies default mojo execution action when no associated metadata can be detected.",
           "scope": "window",
           "order": 90
+        },
+        "java.configuration.maven.lifecycleMappings": {
+          "type": "string",
+          "default": null,
+          "description": "Path to Maven's lifecycle mappings xml",
+          "scope": "window",
+          "order": 100
         }
       }
     },


### PR DESCRIPTION
Fixes #3393 
Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3005