### PR TITLE
Inject json/xml/yaml syntax highlighting via language=* comment

### DIFF
--- a/language-support/json/inline-json.json
+++ b/language-support/json/inline-json.json
@@ -1,0 +1,44 @@
+{
+	"injectionSelector": "L:source.java -comment -string",
+	"patterns": [
+		{
+			"contentName": "meta.embedded.block.json",
+			"begin": "(?i)((/\\*\\s*(language=json)\\s*\\*/)|((//\\s*(language=json)\\s*)))",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.block"
+				}
+			},
+			"end": "(?<=\")",
+			"patterns": [
+				{
+					"begin": "\\s*(\"\"\")$",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"end": "\\s*(\"\"\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"patterns": [
+						{ "include": "source.json" }
+					]
+				},
+				{
+					"begin": "\\s*(\")",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"end": "\\s*(\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"patterns": [
+						{ "include": "source.json" }
+					]
+				}
+			]
+		}
+	],
+	"scopeName": "inline.json"
+}

--- a/language-support/xml/inline-xml.json
+++ b/language-support/xml/inline-xml.json
@@ -1,0 +1,44 @@
+{
+	"injectionSelector": "L:source.java -comment -string",
+	"patterns": [
+		{
+			"contentName": "meta.embedded.block.xml",
+			"begin": "(?i)((/\\*\\s*(language=xml)\\s*\\*/)|((//\\s*(language=xml)\\s*)))",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.block"
+				}
+			},
+			"end": "(?<=\")",
+			"patterns": [
+				{
+					"begin": "\\s*(\"\"\")$",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"end": "\\s*(\"\"\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"patterns": [
+						{ "include": "text.xml" }
+					]
+				},
+				{
+					"begin": "\\s*(\")",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"end": "\\s*(\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"patterns": [
+						{ "include": "text.xml" }
+					]
+				}
+			]
+		}
+	],
+	"scopeName": "inline.xml"
+}

--- a/language-support/yaml/inline-yaml.json
+++ b/language-support/yaml/inline-yaml.json
@@ -1,0 +1,44 @@
+{
+	"injectionSelector": "L:source.java -comment -string",
+	"patterns": [
+		{
+			"contentName": "meta.embedded.block.yaml",
+			"begin": "(?i)((/\\*\\s*(language=yaml)\\s*\\*/)|((//\\s*(language=yaml)\\s*)))",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.block"
+				}
+			},
+			"end": "(?<=\")",
+			"patterns": [
+				{
+					"begin": "\\s*(\"\"\")$",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"end": "\\s*(\"\"\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"patterns": [
+						{ "include": "source.yaml" }
+					]
+				},
+				{
+					"begin": "\\s*(\")",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"end": "\\s*(\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"patterns": [
+						{ "include": "source.yaml" }
+					]
+				}
+			]
+		}
+	],
+	"scopeName": "inline.yaml"
+}

--- a/package.json
+++ b/package.json
@@ -232,6 +232,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.json": "json"
         }
+      },
+      {
+        "injectTo": [
+          "source.java"
+        ],
+        "scopeName": "inline.xml",
+        "path": "./language-support/xml/inline-xml.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.xml": "xml"
+        }
       }
     ],
     "jsonValidation": [

--- a/package.json
+++ b/package.json
@@ -222,6 +222,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.sql": "sql"
         }
+      },
+      {
+        "injectTo": [
+          "source.java"
+        ],
+        "scopeName": "inline.json",
+        "path": "./language-support/json/inline-json.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.json": "json"
+        }
       }
     ],
     "jsonValidation": [

--- a/package.json
+++ b/package.json
@@ -242,6 +242,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.xml": "xml"
         }
+      },
+      {
+        "injectTo": [
+          "source.java"
+        ],
+        "scopeName": "inline.yaml",
+        "path": "./language-support/yaml/inline-yaml.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.yaml": "yaml"
+        }
       }
     ],
     "jsonValidation": [


### PR DESCRIPTION
Inspired by #3397, I basically search/replace'd sql with json. 

```java
String JSON = /* language=json */ 
      """
        {
          "xml.filePathSupport.mappings": [
            {
              "expressions": [
                {
                  "xpath": "*/@somepath",
                  "filter": [".txt"]
                },
                {
                  "xpath": "path/text()",
                  "separator":":"
                }
              ],
              "pattern": "**/*.xml"
            }
          ]
        }
      """;
 ``` 
 renders as:

<img width="508" alt="Screenshot 2024-01-10 at 10 21 36" src="https://github.com/redhat-developer/vscode-java/assets/148698/429e4ddf-6e73-4ab1-a232-5dd3fb3991f4">

Don't ask me to make any changes to the grammar, I'm textmate illiterate ;-)
  
