### PR TITLE
Use `source.gradle-kotlin-dsl` instead of `source.kotlin` to avoid clashes with other Kotlin grammars

### DIFF
--- a/language-support/kotlin/kotlin.tmLanguage.json
+++ b/language-support/kotlin/kotlin.tmLanguage.json
@@ -1,10 +1,11 @@
 {
     "information_for_contributors": [
-        "This file has been copied from https://github.com/eclipse/buildship/blob/b848d9a08283b68860671a73ceec3c99bdab27c2/org.eclipse.buildship.kotlindsl.provider/kotlin.tmLanguage.json"
+        "This file has been copied from https://github.com/eclipse/buildship/blob/b848d9a08283b68860671a73ceec3c99bdab27c2/org.eclipse.buildship.kotlindsl.provider/kotlin.tmLanguage.json",
+		"NOTE: This uses the scope 'source.gradle-kotlin-dsl' rather than 'source.kotlin' to avoid conflicts with other Kotlin grammars."
     ],
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-    "name": "Kotlin",
-    "scopeName": "source.kotlin",
+    "name": "Gradle Kotlin DSL",
+    "scopeName": "source.gradle-kotlin-dsl",
     "patterns": [
         {
             "include": "#import"

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
       },
       {
         "language": "gradle-kotlin-dsl",
-        "scopeName": "source.kotlin",
+        "scopeName": "source.gradle-kotlin-dsl",
         "path": "./language-support/kotlin/kotlin.tmLanguage.json"
       },
       {


### PR DESCRIPTION
The grammar is currently only used for Gradle Kotlin DSL (`.gradle.kts`) scripts, however uses the same scope as regular Kotlin grammars (`source.kotlin`). This causes it to silently override the Kotlin syntax highlighting, even in `.kt` files, when another grammar is installed. See https://github.com/redhat-developer/vscode-java/pull/3377#issuecomment-1891124971 for further rationale.

This fixes the issue by using a new scope for the Kotlin grammar, namely `source.gradle-kotlin-dsl`.