### PR TITLE
Inject html syntax highlighting via language=html comment

### DIFF
--- a/language-support/html/inline-html.json
+++ b/language-support/html/inline-html.json
@@ -1,0 +1,44 @@
+{
+	"injectionSelector": "L:source.java -comment -string",
+	"patterns": [
+		{
+			"contentName": "meta.embedded.block.html",
+			"begin": "(?i)((/\\*\\s*(language=html)\\s*\\*/)|((//\\s*(language=html)\\s*)))",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.block"
+				}
+			},
+			"end": "(?<=\")",
+			"patterns": [
+				{
+					"begin": "\\s*(\"\"\")$",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"end": "\\s*(\"\"\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.triple.java" }
+					},
+					"patterns": [
+						{ "include": "text.html.derivative" }
+					]
+				},
+				{
+					"begin": "\\s*(\")",
+					"beginCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"end": "\\s*(\")",
+					"endCaptures": {
+						"0": { "name": "string.quoted.double.java" }
+					},
+					"patterns": [
+						{ "include": "text.html.derivative" }
+					]
+				}
+			]
+		}
+	],
+	"scopeName": "inline.html"
+}

--- a/package.json
+++ b/package.json
@@ -252,6 +252,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.yaml": "yaml"
         }
+      },
+      {
+        "injectTo": [
+          "source.java"
+        ],
+        "scopeName": "inline.html",
+        "path": "./language-support/html/inline-html.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.html": "html"
+        }
       }
     ],
     "jsonValidation": [


### PR DESCRIPTION
Following up on #3455 to add support for HTML syntax highlighting with a `language=html` comment.

```java
String HTML = /* language=html */ 
"""
  <!DOCTYPE html>
  <html>
    <body>
      <p style="color:white">
      This paragraph
      contains a lot of lines
      in the source code,
      but the browser 
      
      ignores it.
      </p>
      </body>
  </html>
""";
```

renders as :

<img width="456" alt="Screenshot 2024-01-16 at 16 11 03" src="https://github.com/redhat-developer/vscode-java/assets/148698/570334df-acf7-40c9-9af8-31af455680f6">

One caveat: invalid closing `<script>` causes a red semicolon at the end of the declaration: 


<img width="452" alt="Screenshot 2024-01-16 at 16 11 26" src="https://github.com/redhat-developer/vscode-java/assets/148698/a0e6f7cd-05b1-4634-8276-d505d096e83a">

It uses the HTML Derivative grammar, as it's [supposed to better handle malformed HTML](https://github.com/textmate/html.tmbundle/commit/390c8870273a2ae80244dae6db6ba064a802f407) specifically for templating purposes, which is exactly what we're doing here.
