### PR TITLE
Revamp server status bar item.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -350,4 +350,18 @@ export namespace Commands {
      */
     export const RESOLVE_PASTED_TEXT = "java.project.resolveText";
 
+    /**
+     * The command when clicking the server status bar item.
+     */
+    export const OPEN_STATUS_SHORTCUT = "_java.openShortcuts";
+
+}
+
+/**
+ * Command titles used to render in the UI
+ */
+export namespace CommandTitle {
+    export const OPEN_JAVA_SETTINGS = "$(settings-gear) Open Java Settings";
+    export const OPEN_LOGS = "$(output) Open Logs...";
+    export const CLEAN_WORKSPACE_CACHE = "$(trash) Clean Workspace Cache";
 }

--- a/src/serverStatus.ts
+++ b/src/serverStatus.ts
@@ -2,7 +2,7 @@
 
 import { EventEmitter } from "vscode";
 import { serverTasks } from "./serverTasks";
-import { ProgressKind } from "./protocol";
+import { serverStatusBarProvider } from "./serverStatusBarProvider";
 
 export enum ServerStatusKind {
 	ready = "Ready",
@@ -32,7 +32,11 @@ export namespace serverStatus {
 
 	export function initialize() {
 		serverTasks.onDidUpdateServerTask(tasks => {
-			isBusy = tasks.some(task => !(task.complete));
+			const busyTask = tasks.find(task => !task.complete);
+			isBusy = !!busyTask;
+			if (isBusy) {
+				serverStatusBarProvider.setBusy(busyTask.value.message);
+			}
 			fireEvent();
 		});
 	}

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -17,7 +17,6 @@ class ServerStatusBarProvider implements Disposable {
 	public showLightWeightStatus(): void {
 		this.statusBarItem.name = "Java Server Mode";
 		this.statusBarItem.text = `${StatusIcon.lightWeight} Java: Lightweight Mode`;
-		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
 		this.statusBarItem.command = StatusCommands.switchToStandardCommand;
 		this.statusBarItem.tooltip = "Java language server is running in LightWeight mode, click to switch to Standard mode";
 	}
@@ -25,7 +24,6 @@ class ServerStatusBarProvider implements Disposable {
 	public showNotImportedStatus(): void {
 		this.statusBarItem.name = "No projects are imported";
 		this.statusBarItem.text = `${StatusIcon.notImported} Java: No Projects Imported`;
-		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
 		this.statusBarItem.command = StatusCommands.startStandardServerCommand;
 		this.statusBarItem.tooltip = "No projects are imported, click to load projects";
 	}
@@ -33,7 +31,6 @@ class ServerStatusBarProvider implements Disposable {
 	public setBusy(process: string): void {
 		this.statusBarItem.text = `${StatusIcon.busy} Java: ${process}`;
 		this.statusBarItem.tooltip = process;
-		this.statusBarItem.backgroundColor = undefined;
 		this.statusBarItem.command = {
 			title: "Show Java status menu",
 			command: Commands.OPEN_STATUS_SHORTCUT,
@@ -44,7 +41,6 @@ class ServerStatusBarProvider implements Disposable {
 
 	public setError(): void {
 		this.statusBarItem.text = `${StatusIcon.java} Java: Error`;
-		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.errorBackground");
 		this.statusBarItem.tooltip = "Show Java status menu";
 		this.statusBarItem.command = {
 			title: "Show Java status menu",
@@ -56,7 +52,6 @@ class ServerStatusBarProvider implements Disposable {
 
 	public setWarning(): void {
 		this.statusBarItem.text = `${StatusIcon.java} Java: Warning`;
-		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
 		this.statusBarItem.tooltip = "Show Java status menu";
 		this.statusBarItem.command = {
 			title: "Show Java status menu",

--- a/src/serverStatusBarProvider.ts
+++ b/src/serverStatusBarProvider.ts
@@ -1,64 +1,80 @@
 'use strict';
 
-import { StatusBarItem, window, StatusBarAlignment } from "vscode";
-import { Commands } from "./commands";
+import { StatusBarItem, window, StatusBarAlignment, ThemeColor, commands, QuickPickItem, QuickPickItemKind } from "vscode";
 import { Disposable } from "vscode-languageclient";
 import { StatusCommands } from "./languageStatusItemFactory";
+import { Commands } from "./commands";
+import { ServerStatusKind } from "./serverStatus";
 
 class ServerStatusBarProvider implements Disposable {
 	private statusBarItem: StatusBarItem;
 
 	constructor() {
-		this.statusBarItem = window.createStatusBarItem("java.serverStatus", StatusBarAlignment.Right, Number.MIN_VALUE);
+		this.statusBarItem = window.createStatusBarItem("java.serverStatus", StatusBarAlignment.Left);
+		this.statusBarItem.show();
 	}
 
 	public showLightWeightStatus(): void {
 		this.statusBarItem.name = "Java Server Mode";
-		this.statusBarItem.text = StatusIcon.lightWeight;
+		this.statusBarItem.text = `${StatusIcon.lightWeight} Java: Lightweight Mode`;
+		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
 		this.statusBarItem.command = StatusCommands.switchToStandardCommand;
 		this.statusBarItem.tooltip = "Java language server is running in LightWeight mode, click to switch to Standard mode";
-		this.statusBarItem.show();
 	}
 
 	public showNotImportedStatus(): void {
 		this.statusBarItem.name = "No projects are imported";
-		this.statusBarItem.text = StatusIcon.notImported;
+		this.statusBarItem.text = `${StatusIcon.notImported} Java: No Projects Imported`;
+		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
 		this.statusBarItem.command = StatusCommands.startStandardServerCommand;
 		this.statusBarItem.tooltip = "No projects are imported, click to load projects";
-		this.statusBarItem.show();
 	}
 
-	public showStandardStatus(): void {
-		this.statusBarItem.name = "Java Server Status";
-		this.statusBarItem.text = StatusIcon.busy;
-		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-		this.statusBarItem.tooltip = "";
-		this.statusBarItem.show();
-	}
-
-	public setBusy(): void {
-		this.statusBarItem.text = StatusIcon.busy;
+	public setBusy(process: string): void {
+		this.statusBarItem.text = `${StatusIcon.busy} Java: ${process}`;
+		this.statusBarItem.tooltip = process;
+		this.statusBarItem.backgroundColor = undefined;
+		this.statusBarItem.command = {
+			title: "Show Java status menu",
+			command: Commands.OPEN_STATUS_SHORTCUT,
+			tooltip: "Show Java status menu",
+			arguments: [ServerStatusKind.busy],
+		};
 	}
 
 	public setError(): void {
-		this.statusBarItem.text = StatusIcon.error;
-		this.statusBarItem.command = Commands.OPEN_LOGS;
+		this.statusBarItem.text = `${StatusIcon.java} Java: Error`;
+		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.errorBackground");
+		this.statusBarItem.tooltip = "Show Java status menu";
+		this.statusBarItem.command = {
+			title: "Show Java status menu",
+			command: Commands.OPEN_STATUS_SHORTCUT,
+			tooltip: "Show Java status menu",
+			arguments: [ServerStatusKind.error],
+		};
 	}
 
 	public setWarning(): void {
-		this.statusBarItem.text = StatusIcon.warning;
-		this.statusBarItem.command = "workbench.panel.markers.view.focus";
-		this.statusBarItem.tooltip = "Errors occurred in project configurations, click to show the PROBLEMS panel";
+		this.statusBarItem.text = `${StatusIcon.java} Java: Warning`;
+		this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
+		this.statusBarItem.tooltip = "Show Java status menu";
+		this.statusBarItem.command = {
+			title: "Show Java status menu",
+			command: Commands.OPEN_STATUS_SHORTCUT,
+			tooltip: "Show Java status menu",
+			arguments: [ServerStatusKind.warning],
+		};
 	}
 
 	public setReady(): void {
-		this.statusBarItem.text = StatusIcon.ready;
-		this.statusBarItem.command = Commands.SHOW_SERVER_TASK_STATUS;
-		this.statusBarItem.tooltip = "ServiceReady";
-	}
-
-	public updateTooltip(tooltip: string): void {
-		this.statusBarItem.tooltip = tooltip;
+		this.statusBarItem.text = `${StatusIcon.java} Java: Ready`;
+		this.statusBarItem.tooltip = "Show Java status menu";
+		this.statusBarItem.command = {
+			title: "Show Java status menu",
+			command: Commands.OPEN_STATUS_SHORTCUT,
+			tooltip: "Show Java status menu",
+			arguments: ["Ready"],
+		};
 	}
 
 	public dispose(): void {
@@ -68,11 +84,14 @@ class ServerStatusBarProvider implements Disposable {
 
 export enum StatusIcon {
 	lightWeight = "$(rocket)",
+	notImported = "$(info)",
 	busy = "$(sync~spin)",
-	ready = "$(thumbsup)",
-	warning = "$(thumbsdown)",
-	error = "$(thumbsdown)",
-	notImported = "$(info)"
+	java = "$(coffee)",
+}
+
+export interface ShortcutQuickPickItem extends QuickPickItem {
+	command: string;
+	args?: any[];
 }
 
 export const serverStatusBarProvider: ServerStatusBarProvider = new ServerStatusBarProvider();

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -75,13 +75,11 @@ export class StandardLanguageClient {
 
 		serverStatus.initialize();
 		serverStatus.onServerStatusChanged(status => {
-			if (status === ServerStatusKind.busy) {
-				serverStatusBarProvider.setBusy();
-			} else if (status === ServerStatusKind.error) {
+			if (status === ServerStatusKind.error) {
 				serverStatusBarProvider.setError();
 			} else if (status === ServerStatusKind.warning) {
 				serverStatusBarProvider.setWarning();
-			} else {
+			} else if (status === ServerStatusKind.ready) {
 				serverStatusBarProvider.setReady();
 			}
 		});
@@ -180,9 +178,6 @@ export class StandardLanguageClient {
 				case 'Message':
 					// message goes to progress report instead
 					break;
-			}
-			if (!serverStatus.hasErrors()) {
-				serverStatusBarProvider.updateTooltip(report.message);
 			}
 		});
 


### PR DESCRIPTION
This PR made following changes to the server status bar item.

1. Move to the left. This aligns VS Code's status bar [UX guideline](https://code.visualstudio.com/api/ux-guidelines/status-bar): Place primary (global) items on the left.

2. Display the progress more explicitly
![screenshot-1706253148794](https://github.com/redhat-developer/vscode-java/assets/6193897/9859d784-530e-4d64-94be-faf770f47699)

3. Use background color to highlight the status item when action is required
![screenshot-1706253180936](https://github.com/redhat-developer/vscode-java/assets/6193897/a7acbeb1-385e-4f5c-b2f1-4a8fcc409408)
![screenshot-1706253204678](https://github.com/redhat-developer/vscode-java/assets/6193897/26b395f4-7125-4fb2-a4a8-dd40a3f1a769)

4. Make the status bar item as an entrance to access other useful commands.
![screenshot-1706254021696](https://github.com/redhat-developer/vscode-java/assets/6193897/8dbfb930-6f9c-494b-9329-9258ac911277)
