### PR TITLE
Add setting to collapse completion items for overloaded methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ The following settings are supported:
 * `java.edit.smartSemicolonDetection.enabled`: Defines the `smart semicolon` detection. Defaults to `false`.
 * `java.configuration.detectJdksAtStart`: Automatically detect JDKs installed on local machine at startup. If you have specified the same JDK version in `java.configuration.runtimes`, the extension will use that version first. Defaults to `true`.
 
+New in 1.29.0
+* `java.completion.collapseCompletionItems`: Enable/disable the collapse of overloaded methods in completion items. Overrides `java.completion.guessMethodArguments`.
 
 Semantic Highlighting
 ===============

--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -18,7 +18,7 @@ vscode-java has opt-in telemetry collection, provided by [vscode-redhat-telemetr
  * The number of unresolved imports within the project(s)
  * Whether there is a mismatch between the project's requested source level, and the JDK used for the project (eg. true)
  * Information about the following settings. In the case of settings that store a well defined value (eg. path/url/string), we simply collect whether the setting has been set.
-   * `java.settings.url`, `java.format.settings.url`, `java.quickfix.showAt`, `java.symbols.includeSourceMethodDeclarations`, `java.completion.guessMethodArguments`, `java.completion.postfix.enabled`, `java.cleanup.actionsOnSave`, `java.sharedIndexes.enabled`, `java.inlayHints.parameterNames.enabled`, `java.server.launchMode`, `java.autobuild.enabled`
+   * `java.settings.url`, `java.format.settings.url`, `java.quickfix.showAt`, `java.symbols.includeSourceMethodDeclarations`, `java.completion.collapseCompletionItems`, `java.completion.guessMethodArguments`, `java.completion.postfix.enabled`, `java.cleanup.actionsOnSave`, `java.sharedIndexes.enabled`, `java.inlayHints.parameterNames.enabled`, `java.server.launchMode`, `java.autobuild.enabled`
  * The extension name and the choice made when a recommendation to install a 3rd party extension is proposed
  * The name of Java commands being manually executed, and any resulting errors
  * The number of results (eg. 20), whether an error occured (eg. false), and duration (in milliseconds) when code assist is activated

--- a/package.json
+++ b/package.json
@@ -1096,6 +1096,12 @@
           "default": false,
           "description": "Enable/disable to show the description in signature help.",
           "scope": "window"
+        },
+        "java.completion.collapseCompletionItems": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/disable the collapse of overloaded methods in completion items. Overrides `#java.completion.guessMethodArguments#`.",
+          "scope": "window"
         }
       }
     },

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -66,10 +66,10 @@ export namespace Telemetry {
 		// settings whose values we can record
 		const SETTINGS_BASIC = [
 			"java.quickfix.showAt", "java.symbols.includeSourceMethodDeclarations",
-			"java.completion.guessMethodArguments", "java.cleanup.actionsOnSave",
-			"java.completion.postfix.enabled", "java.sharedIndexes.enabled",
-			"java.inlayHints.parameterNames.enabled", "java.server.launchMode",
-			"java.autobuild.enabled"
+			"java.completion.collapseCompletionItems", "java.completion.guessMethodArguments",
+			"java.cleanup.actionsOnSave", "java.completion.postfix.enabled",
+			"java.sharedIndexes.enabled", "java.inlayHints.parameterNames.enabled",
+			"java.server.launchMode", "java.autobuild.enabled"
 		];
 		// settings where we only record their existence
 		const SETTINGS_CUSTOM = [


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2282

Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3053