### PR TITLE
Dynamically remove the Equinox launcher fragment for macOS x86_64.

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -1,5 +1,6 @@
 
 import * as fs from 'fs';
+import * as fse from 'fs-extra';
 import * as glob from 'glob';
 import * as net from 'net';
 import * as os from 'os';
@@ -9,7 +10,7 @@ import { Executable, ExecutableOptions, StreamInfo, TransportKind } from 'vscode
 import { logger } from './log';
 import { addLombokParam, isLombokSupportEnabled } from './lombokSupport';
 import { RequirementsData } from './requirements';
-import { getJavaagentFlag, getJavaEncoding, getKey, isInWorkspaceFolder, IS_WORKSPACE_VMARGS_ALLOWED } from './settings';
+import { IS_WORKSPACE_VMARGS_ALLOWED, getJavaEncoding, getJavaagentFlag, getKey, isInWorkspaceFolder } from './settings';
 import { deleteDirectory, ensureExists, getJavaConfiguration, getTimestamp } from './utils';
 
 // eslint-disable-next-line no-var
@@ -315,4 +316,14 @@ export function parseVMargs(params: any[], vmargsLine: string) {
 			params.push(arg);
 		}
 	});
+}
+
+export function removeEquinoxFragmentOnDarwinX64(context: ExtensionContext) {
+	// https://github.com/redhat-developer/vscode-java/issues/3484
+	const extensionPath = context.extensionPath;
+	const matches = new glob.GlobSync(`${extensionPath}/server/plugins/org.eclipse.equinox.launcher.cocoa.macosx.x86_64*.jar`).found;
+	for (const fragment of matches) {
+		fse.removeSync(fragment);
+		logger.info(`Removing Equinox launcher fragment : ${fragment}`);
+	}
 }


### PR DESCRIPTION
- Fixes #3484 
- `os.release()` seems like the right thing to use according to https://en.wikipedia.org/wiki/Uname#Examples (and not `version()` .
- `process.platform`, `process.arch` are said to be equivalent to `os.platform()`, `os.arch()`.