### PR TITLE
Report errors of type dtree.ObjectNotFoundException as 'java.ls.error'.

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -16,6 +16,7 @@ vscode-java has opt-in telemetry collection, provided by [vscode-redhat-telemetr
  * The total size (in bytes) of libraries that were indexed after project initialization
  * The number of error markers on the project(s)
  * The number of unresolved imports within the project(s)
+ * Errors relating to running the language server, such as the message & stacktrace
  * Whether there is a mismatch between the project's requested source level, and the JDK used for the project (eg. true)
  * Information about the following settings. In the case of settings that store a well defined value (eg. path/url/string), we simply collect whether the setting has been set.
    * `java.settings.url`, `java.format.settings.url`, `java.quickfix.showAt`, `java.symbols.includeSourceMethodDeclarations`, `java.completion.collapseCompletionItems`, `java.completion.guessMethodArguments`, `java.completion.postfix.enabled`, `java.cleanup.actionsOnSave`, `java.sharedIndexes.enabled`, `java.inlayHints.parameterNames.enabled`, `java.server.launchMode`, `java.autobuild.enabled`

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -338,6 +338,11 @@ export class StandardLanguageClient {
 			apiManager.fireTraceEvent(e);
 			if (e.name === Telemetry.SERVER_INITIALIZED_EVT) {
 				return Telemetry.sendTelemetry(Telemetry.STARTUP_EVT, e.properties);
+			} else if (e.name === Telemetry.LS_ERROR) {
+				const exception: string = e?.properties.exception;
+				if (exception !== undefined && exception.includes("dtree.ObjectNotFoundException")) {
+					return Telemetry.sendTelemetry(Telemetry.LS_ERROR, e.properties);
+				}
 			}
 		});
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -9,6 +9,7 @@ export namespace Telemetry {
 	export const STARTUP_EVT = "startup";
 	export const COMPLETION_EVENT = "textCompletion";
 	export const SERVER_INITIALIZED_EVT = "java.workspace.initialized";
+	export const LS_ERROR = "java.ls.error";
 	let telemetryManager: TelemetryService = null;
 	let serverInitializedReceived = false;
 


### PR DESCRIPTION
- Report language server errors relating to 'org.eclipse.core.internal.dtree.ObjectNotFoundException', coming from 'telemetry/event' as 'java.ls.error'.
- Related to #2405 