### PR TITLE
Adopt the Lombok 1.18.32 release.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,18 +127,14 @@ gulp.task('download_lombok', async function (done) {
 	}
 
 	await new Promise(function (resolve, reject) {
-		const lombokVersion = '1.18.31';
+		const lombokVersion = '1.18.32';
 		// The latest lombok version can be found on the website https://projectlombok.org/downloads
-		const lombokUrl = `https://projectlombok.org/lombok-edge.jar`;
+		const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`;
 		download(lombokUrl)
 			.pipe(gulp.dest("./lombok/"))
 			.on("error", reject)
-			.on("end", () => {
-				fse.renameSync("./lombok/lombok-edge.jar", `./lombok/lombok-${lombokVersion}.jar`);
-				resolve();
-			});
+			.on("end", resolve);
 	});
-	// TODO: Switch to stable version once lombok 1.18.31 is released.
 	done();
 });
 


### PR DESCRIPTION
There was a release of Lombok 1.18.32 a few days ago.

@snjeza , if you could just confirm this still works for you. There should be no errors, or stacktraces like :

```
[Error - 10:43:33] Mar. 22, 2024, 10:43:33 a.m. Lombok annotation handler class lombok.eclipse.handlers.HandleData failed
'java.lang.StringBuffer org.eclipse.jdt.internal.compiler.ast.Expression.print(int, java.lang.StringBuffer)'
java.lang.NoSuchMethodError: 'java.lang.StringBuffer org.eclipse.jdt.internal.compiler.ast.Expression.print(int, java.lang.StringBuffer)'
...
...
```

when using something like :

```
@Data(staticConstructor = "of")
public class Test {
      private final int a;
      private final int b;
      private final int c;
      private final String random;
}
```

I noticed some reports in the [original issue](https://github.com/projectlombok/lombok/issues/3564) claiming some problems with the edge / 1.18.32 release, but as far as I can tell it works.

