### PR TITLE
Fix the focus issue of the java shortcuts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -361,7 +361,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 				if (status === ServerStatusKind.error || status === ServerStatusKind.warning) {
 					commands.executeCommand("workbench.panel.markers.view.focus");
 				} else {
-					commands.executeCommand(Commands.SHOW_SERVER_TASK_STATUS);
+					commands.executeCommand(Commands.SHOW_SERVER_TASK_STATUS, true);
 				}
 
 				items.push({
@@ -376,10 +376,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 					command: Commands.CLEAN_WORKSPACE
 				});
 
-				const choice = await window.showQuickPick(items, {
-					ignoreFocusOut: true,
-					placeHolder: "Press 'ESC' to close."
-				});
+				const choice = await window.showQuickPick(items);
 				if (!choice) {
 					return;
 				}

--- a/src/serverTaskPresenter.ts
+++ b/src/serverTaskPresenter.ts
@@ -8,12 +8,12 @@ import { getJavaConfiguration } from "./utils";
 const JAVA_SERVER_TASK_PRESENTER_TASK_NAME = "Java Build Status";
 
 export namespace serverTaskPresenter {
-	export async function presentServerTaskView() {
+	export async function presentServerTaskView(preserveFocus?: boolean) {
 		const execution = await getPresenterTaskExecution();
 		const terminals = window.terminals;
 		const presenterTerminals = terminals.filter(terminal => terminal.name.indexOf(execution.task.name) >= 0);
 		if (presenterTerminals.length > 0) {
-			presenterTerminals[0].show();
+			presenterTerminals[0].show(preserveFocus);
 		}
 		activationProgressNotification.hide();
 	}

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -698,7 +698,7 @@ export class StandardLanguageClient {
 		}));
 
 		context.subscriptions.push(commands.registerCommand(Commands.OPEN_OUTPUT, () => this.languageClient.outputChannel.show(ViewColumn.Three)));
-		context.subscriptions.push(commands.registerCommand(Commands.SHOW_SERVER_TASK_STATUS, () => serverTaskPresenter.presentServerTaskView()));
+		context.subscriptions.push(commands.registerCommand(Commands.SHOW_SERVER_TASK_STATUS, (preserveFocus?: boolean) => serverTaskPresenter.presentServerTaskView(preserveFocus)));
 	}
 
 	public start(): Promise<void> {


### PR DESCRIPTION
fix https://github.com/redhat-developer/vscode-java/pull/3537#issuecomment-2022748711

For some reason, I guess I missed something that I thought `preserveFocus` did not work by mistake.

This time, when I try it, it's working. So we can also get rid of the keybinding issue.

@rgrunber Sorry for the confusion I made.