### PR TITLE
Regex update and sealed removed.

### DIFF
--- a/.github/scripts/check_and_update_jdk.py
+++ b/.github/scripts/check_and_update_jdk.py
@@ -9,7 +9,7 @@ readme_ver_pattern = r'(?:(?<=Supports code from Java 1\.5 to Java )(\d+)|(?<=Ja
 
 # Query the Oracle website for the latest JDK version
 response = requests.get('http://javadl-esd-secure.oracle.com/update/baseline.version')
-latest_jdk = re.search(r'(?P<major>\d+)\.', response.text)
+latest_jdk = re.search(r'(?P<major>\d+)\.?', response.text)
 if latest_jdk is None:
     print('Failed to retrieve latest JDK version')
     exit(1)
@@ -33,10 +33,6 @@ if latest_jdk != current_jdk:
     uri_base = 'https://ci.eclipse.org/ls/job/jdt-ls-master/lastCompletedBuild/testReport/org.eclipse.jdt.ls.core.internal.{package}/{java_class}/{method}/api/python'
     # Define the test URLs to check using the template and list comprehension
     tests = [
-        uri_base.format(package='correction', java_class='ModifierCorrectionsQuickFixTest', method=m) for m in ['testAddSealedMissingClassModifierProposal', 'testAddSealedAsDirectSuperClass', 'testAddPermitsToDirectSuperClass']
-    ] + [
-        uri_base.format(package='correction', java_class='UnresolvedTypesQuickFixTest', method='testTypeInSealedTypeDeclaration')
-    ] + [
         uri_base.format(package='managers', java_class=c, method=m) for c, m in [('EclipseProjectImporterTest', 'testPreviewFeaturesDisabledByDefault'), ('InvisibleProjectImporterTest', 'testPreviewFeaturesEnabledByDefault'), ('MavenProjectImporterTest', f'testJava{latest_jdk}Project')]
     ]
 
@@ -61,11 +57,11 @@ if latest_jdk != current_jdk:
 
         # Replace the ~ with current_jdk
         readme_ver_pattern = re.sub('~', current_jdk, readme_ver_pattern)
-        
+
         # Write this to a file for the create-pull-request workflow
         with open('latest_jdk.txt', 'w') as f:
             f.write(latest_jdk)
-        
+
         # Replace the current supported JDK version with the latest JDK version
         readme = re.sub(readme_ver_pattern, latest_jdk, readme)
 


### PR DESCRIPTION
- Make `.` optional in the regex. Also, remove `sealed` class tests.

@mavaddat I've created your PR here. I removed the `testAddPermitsToDirectSuperClass` as well. I wrongly (only) said remove `sealed` but should have also specified `permits` also. It's the keyword that sealed classes use to restrict their usage.