### PR TITLE
Make java.import.gradle.user.home machine-overridable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
           "type": "string",
           "default": null,
           "description": "Setting for GRADLE_USER_HOME.",
-          "scope": "window",
+          "scope": "machine-overridable",
           "order": 55
         },
         "java.import.gradle.offline.enabled": {


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/vscode-java/issues/3569
- Similar to what was done in https://github.com/redhat-developer/vscode-java/issues/3234 .