### PR TITLE
Clear the active selected build tool where a project supports multiple.

### DIFF
--- a/src/buildFilesSelector.ts
+++ b/src/buildFilesSelector.ts
@@ -2,6 +2,7 @@ import { ExtensionContext, MessageItem, QuickPickItem, QuickPickItemKind, Uri, W
 import { convertToGlob, getExclusionGlob, getInclusionPatternsFromNegatedExclusion } from "./utils";
 import * as path from "path";
 import { IBuildTool, getContributedBuildTools } from "./plugin";
+import { ACTIVE_BUILD_TOOL_STATE } from "./settings";
 
 export const PICKED_BUILD_FILES = "java.pickedBuildFiles";
 export const BUILD_TOOL_FOR_CONFLICTS = "java.buildToolForConflicts";
@@ -293,8 +294,9 @@ interface IBuildFilePicker extends QuickPickItem {
 	buildToolAndUri: Map<IBuildTool, Uri>;
 }
 
-export function cleanupProjectPickerCache(context: ExtensionContext) {
+export function cleanupWorkspaceState(context: ExtensionContext) {
 	context.workspaceState.update(PICKED_BUILD_FILES, undefined);
 	context.workspaceState.update(BUILD_TOOL_FOR_CONFLICTS, undefined);
 	context.workspaceState.update(IMPORT_METHOD, undefined);
+	context.workspaceState.update(ACTIVE_BUILD_TOOL_STATE, undefined);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ import { getMessage } from './errorUtils';
 import { TelemetryService } from '@redhat-developer/vscode-redhat-telemetry/lib';
 import { activationProgressNotification } from "./serverTaskPresenter";
 import { loadSupportedJreNames } from './jdkUtils';
-import { BuildFileSelector, PICKED_BUILD_FILES, cleanupProjectPickerCache } from './buildFilesSelector';
+import { BuildFileSelector, PICKED_BUILD_FILES, cleanupWorkspaceState } from './buildFilesSelector';
 import { pasteFile } from './pasteAction';
 import { ServerStatusKind } from './serverStatus';
 
@@ -345,7 +345,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 				const data = {};
 				try {
 					cleanupLombokCache(context);
-					cleanupProjectPickerCache(context);
+					cleanupWorkspaceState(context);
 					deleteDirectory(workspacePath);
 					deleteDirectory(syntaxServerWorkspacePath);
 				} catch (error) {


### PR DESCRIPTION
- Fixes #3567

~~I haven't tested this yet but~~ it seems like the right approach to clear the build tool selection.