### PR TITLE
Do not exclude duplicate flags specified by java.jdt.ls.vmargs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For information on getting started, refer to the [CONTRIBUTING instructions](CON
 Continuous Integration builds can be installed from [http://download.jboss.org/jbosstools/jdt.ls/staging/](http://download.jboss.org/jbosstools/jdt.ls/staging/?C=M;O=D). Download the most recent `java-<version>.vsix` file and install it by following the instructions [here](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix).
 Stable releases are archived under http://download.jboss.org/jbosstools/static/jdt.ls/stable/.
 
-Also, you can contribute your own VSCode extension to enhance the existing features by following the instructions [here](https://github.com/redhat-developer/vscode-java/wiki/Contribute-a-Java-Extension).
+Also, you can contribute your own VS Code extension to enhance the existing features by following the instructions [here](https://github.com/redhat-developer/vscode-java/wiki/Contribute-a-Java-Extension).
 
 Feedback
 ===============

--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -312,9 +312,7 @@ export function parseVMargs(params: any[], vmargsLine: string) {
 		arg = arg.replace(/(\\)?"/g, ($0, $1) => { return ($1 ? $0 : ''); });
 		// unescape all escaped double quotes
 		arg = arg.replace(/(\\)"/g, '"');
-		if (params.indexOf(arg) < 0) {
-			params.push(arg);
-		}
+		params.push(arg);
 	});
 }
 

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -134,11 +134,11 @@ suite('Java Language Extension - Standard', () => {
 
 		java.parseVMargs(vmArgs, userArgs);
 
-		assert.equal(4, vmArgs.length);
+		assert.equal(5, vmArgs.length);
 		assert.equal('-noverify', vmArgs[0]);
 		assert.equal('foo', vmArgs[1]);
 		assert.equal('-Xmx512m', vmArgs[2]);
-		assert.equal('-Dfoo=something with blank', vmArgs[3]);
+		assert.equal('-Dfoo=something with blank', vmArgs[4]);
 	});
 
 	test('should parse VM arguments with spaces', () => {


### PR DESCRIPTION
- Flags like --add-exports, which can be specified multiple times can break if excluded
- Fixes #3577 