### PR TITLE
Add setting java.codeGeneration.addFinalForNewDeclaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ The following settings are supported:
 * `java.configuration.detectJdksAtStart`: Automatically detect JDKs installed on local machine at startup. If you have specified the same JDK version in `java.configuration.runtimes`, the extension will use that version first. Defaults to `true`.
 * `java.completion.collapseCompletionItems`: Enable/disable the collapse of overloaded methods in completion items. Overrides `java.completion.guessMethodArguments`. Defaults to `false`.
 
+New in 1.30.0
+* `java.codeGeneration.addFinalForNewDeclaration`: Whether to generate the 'final' modifer for code actions that create new declarations. Defaults to `none`.
+  - `none`: Do not generate final modifier
+  - `fields`: Generate 'final' modifier only for new field declarations
+  - `variables`: Generate 'final' modifier only for new variable declarations
+  - `all`: Generate 'final' modifier for all new declarations
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/package.json
+++ b/package.json
@@ -1157,6 +1157,24 @@
           "scope": "window",
           "order": 30
         },
+        "java.codeGeneration.addFinalForNewDeclaration": {
+          "type": "string",
+          "enum": [
+            "none",
+            "fields",
+            "variables",
+            "all"
+          ],
+          "enumDescriptions": [
+            "Do not generate final modifier.",
+            "Generate 'final' modifier only for new field declarations.",
+            "Generate 'final' modifier only for new variable declarations.",
+            "Generate 'final' modifier for all new declarations."
+          ],
+          "description": "Whether to generate the 'final' modifer for code actions that create new declarations.",
+          "default": "none",
+          "scope": "window"
+        },
         "java.codeGeneration.hashCodeEquals.useJava7Objects": {
           "type": "boolean",
           "description": "Use Objects.hash and Objects.equals when generating the hashCode and equals methods. This setting only applies to Java 7 and higher.",


### PR DESCRIPTION
- Generates the 'final' modifier for certain new variable/field declarations
- Defaults to 'none' (disabled)
- Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2371