### PR TITLE
Expose source actions in light bulb

### DIFF
--- a/src/codeActionProvider.ts
+++ b/src/codeActionProvider.ts
@@ -19,7 +19,12 @@ export const javaRefactorKinds: Map<CodeActionKind, string> = new Map([
 
 export class RefactorDocumentProvider implements CodeActionProvider {
     provideCodeActions() {
-        return [];
+        return [{
+            // The aim of this is to expose the source actions in the light bulb.
+            title: "Source Actions...",
+            command: "editor.action.sourceAction",
+            kind: CodeActionKind.Empty,
+        }];
     }
 
     public static readonly metadata: CodeActionProviderMetadata = {


### PR DESCRIPTION
### Background

There is some feedback from customers saying that there is no `Generate getter and setter`, `Generate Constructor`, ... support in the extension. I guess they might not be aware that those actions can be found in the `Source actions...` menu, due to that the source actions will not be displayed in the list of the light bulb 💡. 

So I came up with the idea that put a link in the light bulb menu to allow user open the source actions - for more feature discoverability.


https://github.com/user-attachments/assets/4e6bd679-2174-4791-aa40-0ce7d739a64d

