### PR TITLE
Add setting to exclude files from diagnostic publishing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ The following settings are supported:
 * `java.configuration.detectJdksAtStart`: Automatically detect JDKs installed on local machine at startup. If you have specified the same JDK version in `java.configuration.runtimes`, the extension will use that version first. Defaults to `true`.
 * `java.completion.collapseCompletionItems`: Enable/disable the collapse of overloaded methods in completion items. Overrides `java.completion.guessMethodArguments`. Defaults to `false`.
 
+New in 1.33.0
+* `java.diagnostic.filter`: Specifies a list of file patterns for which matching documents should not have their diagnostics reported (eg. '**/Foo.java').
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/package.json
+++ b/package.json
@@ -1474,6 +1474,15 @@
             "markdownDescription": "Specifies whether to recheck all open Java files for diagnostics when editing a Java file.",
             "scope": "window"
           },
+          "java.diagnostic.filter": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Specifies a list of file patterns for which matching documents should not have their diagnostics reported (eg. '**/Foo.java').",
+            "scope": "window"
+          },
           "java.editor.reloadChangedSources": {
             "type": "string",
             "enum": [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -136,11 +136,16 @@ function hasJavaConfigChanged(oldConfig: WorkspaceConfiguration, newConfig: Work
 		|| hasConfigKeyChanged('jdt.ls.vmargs', oldConfig, newConfig)
 		|| hasConfigKeyChanged('server.launchMode', oldConfig, newConfig)
 		|| hasConfigKeyChanged('sharedIndexes.location', oldConfig, newConfig)
-		|| hasConfigKeyChanged('transport', oldConfig, newConfig);
+		|| hasConfigKeyChanged('transport', oldConfig, newConfig)
+		|| hasConfigKeyChanged('diagnostic.filter', oldConfig, newConfig);
 }
 
 function hasConfigKeyChanged(key, oldConfig, newConfig) {
-	return oldConfig.get(key) !== newConfig.get(key);
+	const oldValue = oldConfig.get(key);
+	const newValue = newConfig.get(key);
+	return Array.isArray(oldValue) && Array.isArray(newValue)
+		? JSON.stringify(oldValue) !== JSON.stringify(newValue)
+		: oldValue !== newValue;
 }
 
 export function getJavaEncoding(): string {


### PR DESCRIPTION
- Fixes #2150 
- Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3218

- Suggest project reload when the setting changes.

The language server side supports clearing diagnostics from documents when they are excluded due to setting update. This is easily done by getting the list of documents that have any diagnostics, and comparing against the updated filter. Any new matches can have their diagnostics cleared. However, it does not support restoring diagnostics on documents that are no longer filtered. The main reason is because finding all documents and comparing them to the filters might be a lot more expensive for large projects. The diagnostics would be restored as soon as the document is modified. As a result we let this setting trigger the notification that recommends reloading the project.