### PR TITLE
Add telemetry for language server OutOfMemory events.

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -23,6 +23,7 @@ vscode-java has opt-in telemetry collection, provided by [vscode-redhat-telemetr
  * The extension name and the choice made when a recommendation to install a 3rd party extension is proposed
  * The name of Java commands being manually executed, and any resulting errors
  * The number of results (eg. 20), whether an error occured (eg. false), and duration (in milliseconds) when code assist is activated
+ * Whether the language server ran out of memory and the maximum allocated memory at which that occured (eg. 200m)
  
 ## What's included in the general telemetry data
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1160,6 +1160,9 @@ function registerOutOfMemoryDetection(storagePath: string) {
 				maxMem: getMaxMemFromConfiguration(true),
 			}
 		});
+		Telemetry.sendTelemetry("java.process.outofmemory", {
+			maxMem: getMaxMemFromConfiguration(true),
+		});
 		showOOMMessage();
 		serverStatusBarProvider.setError();
 		activationProgressNotification.hide();


### PR DESCRIPTION
Keeping track of this would be a good way to ensure performance is improving / catching regressions for each release.