### PR TITLE
Update to vscode-extension-proposals 0.0.23.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.35.0",
       "license": "EPL-2.0",
       "dependencies": {
-        "@redhat-developer/vscode-extension-proposals": "0.0.22",
+        "@redhat-developer/vscode-extension-proposals": "0.0.23",
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
         "@vscode/codicons": "^0.0.32",
         "@vscode/webview-ui-toolkit": "1.2.2",
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@redhat-developer/vscode-extension-proposals": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-extension-proposals/-/vscode-extension-proposals-0.0.22.tgz",
-      "integrity": "sha512-hH/0YRkCmYsGTPScE6xFd5bUkbDWU1iu7/LJqcrU4drqYLsFWe/6gLEaaOxm6koFwI3ItjGt8t0o0q8VMC4MiA=="
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-extension-proposals/-/vscode-extension-proposals-0.0.23.tgz",
+      "integrity": "sha512-ecJcUShveU2qFPvp/h/YaICRATQQAZarCQ+MApZmqWD1OC9ultnDHsSgqX2ircBX3d2Ni5mqRbKf+LlHQEFhKA=="
     },
     "node_modules/@redhat-developer/vscode-redhat-telemetry": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -1889,7 +1889,7 @@
     "webpack-cli": "^4.6.0"
   },
   "dependencies": {
-    "@redhat-developer/vscode-extension-proposals": "0.0.22",
+    "@redhat-developer/vscode-extension-proposals": "0.0.23",
     "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
     "@vscode/codicons": "^0.0.32",
     "@vscode/webview-ui-toolkit": "1.2.2",


### PR DESCRIPTION
- With https://github.com/redhat-developer/vscode-extension-proposals/issues/16 (in 0.0.23), we should now be honouring `unwantedRecommendations`.