### PR TITLE
Add Maven flag for updating artifacts from snapshot repositories.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build JDT-LS
         if: "${{ inputs.JDT_LS_VERSION == '' }}"
         run: |
-          ./mvnw clean verify -B -DskipTests -Pserver-distro
+          ./mvnw clean verify -B -U -DskipTests -Pserver-distro
           mkdir ../staging
           cp org.eclipse.jdt.ls.product/distro/jdt-language-server-*.tar.gz ../staging
       - name: Check Out VS Code Java


### PR DESCRIPTION
- With JDT-LS depending on static (eg. latest) repositories, the Tycho build system may end up using stale artifacts cached locally, even when newer ones exist.