### PR TITLE
Add 'removeUnusedLambdaParameters' to the cleanup settings.

### DIFF
--- a/document/_java.learnMoreAboutCleanUps.md
+++ b/document/_java.learnMoreAboutCleanUps.md
@@ -406,3 +406,29 @@ public class A {
     }
 }
 ```
+
+### `removeUnusedLambdaParameters`
+
+Rename unused lambda parameters, or unused pattern variables to `_`.
+
+For example:
+
+```java
+J j = (a, b) -> System.out.println(a);
+
+switch (r) {
+    case R(_, long l) -> {}
+    case R r2 -> {}
+}
+```
+
+becomes:
+
+```java
+J j = (a, _) -> System.out.println(a);
+
+switch (r) {
+    case R(_, _) -> {}
+    case R _ -> {}
+}
+```

--- a/package.json
+++ b/package.json
@@ -1313,7 +1313,8 @@
                 "switchExpression",
                 "tryWithResource",
                 "renameFileToType",
-                "organizeImports"
+                "organizeImports",
+                "removeUnusedLambdaParameters"
               ]
             },
             "default": [


### PR DESCRIPTION
- Based on https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3319

Calling it lambda parameters seems a little odd, given it also supports unused pattern variables but I think we can live with this for now. Calling it "unusedLocalVariable" based on the naming in JDT seems a bit too confusing given that it doesn't rename all types of unused local variables.