### PR TITLE
Rename 'removeUnusedLambdaParameters' to 'renameUnusedLocalVariables'.

### DIFF
--- a/document/_java.learnMoreAboutCleanUps.md
+++ b/document/_java.learnMoreAboutCleanUps.md
@@ -407,9 +407,9 @@ public class A {
 }
 ```
 
-### `removeUnusedLambdaParameters`
+### `renameUnusedLocalVariables`
 
-Rename unused lambda parameters, or unused pattern variables to `_`.
+Rename unused loop variables, try-with-resource variables, catch parameters, lambda parameters, pattern variables to `_`.
 
 For example:
 

--- a/package.json
+++ b/package.json
@@ -1314,7 +1314,7 @@
                 "tryWithResource",
                 "renameFileToType",
                 "organizeImports",
-                "removeUnusedLambdaParameters"
+                "renameUnusedLocalVariables"
               ]
             },
             "default": [


### PR DESCRIPTION
- The clean up now supports additional cases from upstream.
- See https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3329