### PR TITLE
Add setting to support method implementation code lens

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following settings are supported:
 * `java.configuration.maven.userSettings` : Path to Maven's user settings.xml.
 * `java.configuration.checkProjectSettingsExclusions`: **Deprecated, please use 'java.import.generatesMetadataFilesAtProjectRoot' to control whether to generate the project metadata files at the project root. And use 'files.exclude' to control whether to hide the project metadata files from the file explorer.** Controls whether to exclude extension-generated project settings files (`.project`, `.classpath`, `.factorypath`, `.settings/`) from the file explorer. Defaults to `false`.
 * `java.referencesCodeLens.enabled` : Enable/disable the references code lenses.
-* `java.implementationsCodeLens.enabled` : Enable/disable the implementations code lenses.
+* `java.implementationCodeLens` : Enable/disable the implementations code lens for the provided categories.
 * `java.signatureHelp.enabled` : Enable/disable signature help support (triggered on `(`).
 * `java.signatureHelp.description.enabled` : Enable/disable to show the description in signature help. Defaults to `false`.
 * `java.contentProvider.preferred` : Preferred content provider (see 3rd party decompilers available in [vscode-java-decompiler](https://github.com/dgileadi/vscode-java-decompiler)).

--- a/package.json
+++ b/package.json
@@ -1409,10 +1409,22 @@
             "scope": "window",
             "order": 10
           },
-          "java.implementationsCodeLens.enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable/disable the implementations code lens.",
+          "java.implementationCodeLens": {
+            "type": "string",
+            "enum": [
+              "none",
+              "types",
+              "methods",
+              "all"
+            ],
+            "enumDescriptions": [
+              "Disable the implementations code lens",
+              "Enable the implementations code lens only for types",
+              "Enable the implementations code lens only for methods",
+              "Enable the implementations code lens for types and methods"
+            ],
+            "default": "none",
+            "description": "Enable/disable the implementations code lens for the provided categories.",
             "scope": "window",
             "order": 20
           },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -272,6 +272,12 @@ export async function getJavaConfig(javaHome: string) {
 		const userConfiguredJREs: any[] = javaConfig.configuration.runtimes;
 		javaConfig.configuration.runtimes = await addAutoDetectedJdks(userConfiguredJREs);
 	}
+
+	if (!isPreferenceOverridden("java.implementationCodeLens") && typeof javaConfig.implementationsCodeLens?.enabled === 'boolean'){
+		const deprecatedImplementations = javaConfig.implementationsCodeLens.enabled;
+		javaConfig.implementationCodeLens = deprecatedImplementations ? "types" : "none";
+	}
+
 	return javaConfig;
 }
 


### PR DESCRIPTION
Fixes #3813

Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3333

Applies to abstract and interface methods, and protected by the `java.methodImplementationsCodeLens.enabled` setting (false by default).