### PR TITLE
Check for updated snapshot repositories when running build.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -278,7 +278,7 @@ function download_server_fn(){
 
 function build_server_fn(){
 	fse.removeSync('./server');
-	cp.execSync(mvnw() + ' -Pserver-distro clean package -Declipse.jdt.ls.skipGradleChecksums', { cwd: server_dir, stdio: [0, 1, 2] });
+	cp.execSync(mvnw() + ' -Pserver-distro clean package -U -Declipse.jdt.ls.skipGradleChecksums', { cwd: server_dir, stdio: [0, 1, 2] });
 	gulp.src(server_dir + '/org.eclipse.jdt.ls.product/distro/*.tar.gz', { encoding: false })
 		.pipe(decompress())
 		.pipe(gulp.dest('./server'));


### PR DESCRIPTION
- Tycho p2 repositories whose underlying content is updated are considered snapshot repositories, and locally cached data can become stale and lead to cryptic compilation errors

https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/64cc830f5444c7245c01c041d031b431eca72c0e/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target#L31
https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/64cc830f5444c7245c01c041d031b431eca72c0e/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target#L38

The content there can get cached in a developer's local area and continue to pull that stale content. I'm not sure if version bumps "reset" things and cause the latest to be pulled but I definitely ran into an issue recently where I could see a jdt.core bundle from November 5th, while everything else was from early December, resulting in things like :


```
!ENTRY org.eclipse.jdt.core.manipulation 4 0 2024-12-09 10:58:18.928
!MESSAGE Error in JDT Core during AST creation
!STACK 0
java.lang.NoSuchMethodError: 'boolean org.eclipse.jdt.internal.compiler.ast.ImportReference.isImplicit()'
	at org.eclipse.jdt.core.dom.ASTConverter.convert(ASTConverter.java:1545)
	at org.eclipse.jdt.core.dom.CompilationUnitResolver.convert(CompilationUnitResolver.java:380)
	at org.eclipse.jdt.core.dom.CompilationUnitResolver.toCompilationUnit(CompilationUnitResolver.java:1483)
	at org.eclipse.jdt.core.dom.CompilationUnitResolver$ECJCompilationUnitResolver.toCompilationUnit(CompilationUnitResolver.java:106)
	at org.eclipse.jdt.core.dom.ASTParser.internalCreateASTCached(ASTParser.java:1299)
	at org.eclipse.jdt.core.dom.ASTParser.lambda$1(ASTParser.java:1178)
	at org.eclipse.jdt.internal.core.JavaModelManager.cacheZipFiles(JavaModelManager.java:5692)
	at org.eclipse.jdt.core.dom.ASTParser.internalCreateAST(ASTParser.java:1178)
	at org.eclipse.jdt.core.dom.ASTParser.createAST(ASTParser.java:918)
	at org.eclipse.jdt.core.manipulation.CoreASTProvider$1.run(CoreASTProvider.java:294)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.jdt.core.manipulation.CoreASTProvider.createAST(CoreASTProvider.java:286)
	at org.eclipse.jdt.core.manipulation.CoreASTProvider.getAST(CoreASTProvider.java:199)
	at org.eclipse.jdt.ls.core.internal.handlers.DocumentHighlightHandler.documentHighlight(DocumentHighlightHandler.java:56)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$12(JDTLanguageServer.java:731)
	at org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer.lambda$0(BaseJDTLanguageServer.java:87)
```