### PR TITLE
Adopt the Lombok 1.18.36 release.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,7 +127,7 @@ gulp.task('download_lombok', async function (done) {
 	}
 
 	await new Promise(function (resolve, reject) {
-		const lombokVersion = '1.18.34';
+		const lombokVersion = '1.18.36';
 		// The latest lombok version can be found on the website https://projectlombok.org/downloads
 		const lombokUrl = `https://projectlombok.org/downloads/lombok-${lombokVersion}.jar`;
 		download(lombokUrl)


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/vscode-java/issues/3733 .