### PR TITLE
Activate extension if a java file exists in src directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "workspaceContains:*/settings.gradle.kts",
     "workspaceContains:.classpath",
     "workspaceContains:*/.classpath",
+    "workspaceContains:src/**/*.java",
     "onCommand:_java.templateVariables",
     "onCommand:_java.metadataFilesGeneration"
   ],


### PR DESCRIPTION
Expands the `activationEvents` in `package.json` to include `workspaceContains:src/**/*.java`.

Please see issue #3940 for reasoning / explanation.

Refs #3940