### PR TITLE
Fix inherited document symbols to collect interfaces as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.40.0 (February 27nd, 2025)
+## 1.40.0 (February 27th, 2025)
  * enhancement - Support for inherited document symbols. See [#2342](https://github.com/redhat-developer/vscode-java/issues/2342).
  * enhancement - Introduce approximately 15 new quick fixes. See [JLS#3368](https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3368), [JLS#3372](https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3372).
  * enhancement - Introduce quick assist & cleanup converting a pattern-instanceof-if-chain to a switch statement. See [#3951](https://github.com/redhat-developer/vscode-java/pull/3951).

--- a/src/outline/extendedOutlineQuickPick.ts
+++ b/src/outline/extendedOutlineQuickPick.ts
@@ -61,7 +61,7 @@ export class ExtendedOutlineQuickPick {
 				range: s.range
 			};
 			quickPickItems.push(item);
-			if (icon === 'symbol-class') {
+			if (icon === 'symbol-class' || icon === 'symbol-interface') {
 				const items: QuickPickItem[] = s.children.map(s => ({
 					label: `$(${getLThemeIcon(s.kind).id}) ${s.name}`,
 					// custom quick pick has automatic space between label & description


### PR DESCRIPTION
- Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3404