### PR TITLE
Guard against a null completion item resolved on cancellation.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,7 +248,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 					},
 					resolveCompletionItem: async (item, token, next): Promise<CompletionItem> => {
 						const completionItem = await next(item, token);
-						if (completionItem.documentation instanceof MarkdownString) {
+						if (completionItem?.documentation instanceof MarkdownString) {
 							completionItem.documentation = fixJdtLinksInDocumentation(completionItem.documentation);
 						}
 						return completionItem;


### PR DESCRIPTION
If you activate completion, and use the arrow keys to quickly scroll through all the options, you eventually get :

```
2025-03-11 16:29:37.201 [error] [redhat.java] provider FAILED
2025-03-11 16:29:37.201 [error] TypeError: Cannot read properties of null (reading 'documentation')
	at /home/rgrunber/git/vscode-java/dist/extension.js:91685:48
	at Generator.next (<anonymous>)
	at fulfilled (/home/rgrunber/git/vscode-java/dist/extension.js:91445:58)
	at processTicksAndRejections (node:internal/process/task_queues:95:5)
	at runNextTicks (node:internal/process/task_queues:64:3)
	at process.processImmediate (node:internal/timers:454:9)
	at process.callbackTrampoline (node:internal/async_hooks:130:17)
```

It seems mostly harmless but does pollute the extension host logs so would be good to handle this.

- A cancelled completion item resolve request returns as null