### PR TITLE
Avoid notifying of failures for workspace builds.

### DIFF
--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -493,22 +493,22 @@ export class StandardLanguageClient {
 
 			return window.withProgress({ location: ProgressLocation.Window }, async p => {
 				p.report({ message: 'Rebuilding projects...' });
-				return new Promise(async (resolve, reject) => {
-					const start = new Date().getTime();
+				const start = new Date().getTime();
 
-					let res: CompileWorkspaceStatus;
-					try {
-						res = token ? await this.languageClient.sendRequest(BuildProjectRequest.type, params, token) :
-							await this.languageClient.sendRequest(BuildProjectRequest.type, params);
-					} catch (error) {
-						if (error && error.code === -32800) { // Check if the request is cancelled.
-							res = CompileWorkspaceStatus.cancelled;
-						}
-						reject(error);
+				let res: CompileWorkspaceStatus;
+				try {
+					res = token ? await this.languageClient.sendRequest(BuildProjectRequest.type, params, token) :
+					await this.languageClient.sendRequest(BuildProjectRequest.type, params);
+				} catch (error) {
+					if (error && error.code === -32800) { // Check if the request is cancelled.
+						res = CompileWorkspaceStatus.cancelled;
 					}
+					throw error;
+				}
 
-					const elapsed = new Date().getTime() - start;
-					const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
+				const elapsed = new Date().getTime() - start;
+				const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
+				return new Promise(async (resolve, reject) => {
 					setTimeout(() => { // set a timeout so user would still see the message when build time is short
 						resolve(res);
 					}, humanVisibleDelay);
@@ -540,11 +540,7 @@ export class StandardLanguageClient {
 				const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
 				return new Promise((resolve, reject) => {
 					setTimeout(() => { // set a timeout so user would still see the message when build time is short
-						if (res === CompileWorkspaceStatus.succeed) {
-							resolve(res);
-						} else {
-							reject(res);
-						}
+						resolve(res);
 					}, humanVisibleDelay);
 				});
 			});


### PR DESCRIPTION
I'd like to make it easier for users to manually compile their projects (incrementally) quicker and the notification popup can make that a bit annoying. This one :

![image](https://github.com/user-attachments/assets/62f46153-88a7-4eda-9c23-39d9280cd216)

As an example, `Java: Rebuild Projects` doesn't show a notifications if there is a failure to build so I really don't think `Java: Force Java Compilation` should either. Also some of the UI elements at https://github.com/microsoft/vscode-java-dependency/issues/878 , which call the `java.workspace.compile` command don't notify of any compilation errors. I think it should be enough to show the various error markers.

- Notifications of failure aren't shown for project builds
- Also standardizes based on approach of other extensions that use similar functionality in their UI elements

@testforstephen , @jdneo let me know your thoughts on this.