### PR TITLE
Report language server exiting with unsaved changes as 'java.ls.error'.

### DIFF
--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -343,15 +343,21 @@ export class StandardLanguageClient {
 			} else if (e.name === Telemetry.LS_ERROR) {
 				const tags = [];
 				const exception: string = e?.properties.exception;
+				const message: string = e?.properties.message;
 				if (exception !== undefined) {
 					if (exception.includes("dtree.ObjectNotFoundException")) {
 						tags.push("dtree.ObjectNotFoundException");
 					}
-
-					if (tags.length > 0) {
-						e.properties['tags'] = tags;
-						return Telemetry.sendTelemetry(Telemetry.LS_ERROR, e.properties);
+				}
+				if (message !== undefined) {
+					if (message.includes("workspace exited with unsaved changes")) {
+						tags.push("workspace-exited-unsaved-changes");
 					}
+				}
+
+				if (tags.length > 0) {
+					e.properties['tags'] = tags;
+					return Telemetry.sendTelemetry(Telemetry.LS_ERROR, e.properties);
 				}
 			}
 		});


### PR DESCRIPTION
- Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3439

Attempting to recover from a workspace exiting with unsaved changes can really slow down import, so if this is a problem, we need to have an idea of whether people really running into this.