### PR TITLE
"Rebuild Projects" command should be done incrementally.

### DIFF
--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -494,7 +494,7 @@ export class StandardLanguageClient {
 				})),
 				// we can consider expose 'isFullBuild' according to users' feedback,
 				// currently set it to true by default.
-				isFullBuild: isFullBuild === undefined ? true : isFullBuild,
+				isFullBuild: isFullBuild === undefined ? false : isFullBuild,
 			};
 
 			return window.withProgress({ location: ProgressLocation.Window }, async p => {


### PR DESCRIPTION
Similar to the proposal at https://github.com/microsoft/vscode-java-dependency/issues/878 .

>- Eclipse IDE's Build All is incremental by default : https://github.com/eclipse-platform/eclipse.platform.ui/blob/70a35a94b2c6aa67018f919d627b4426c17cb8a4/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/handlers/BuildAllProjectsHandler.java#L37
>- JDT's Build Project is incremental by default : https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/3d780e85b18b6bd8f7548efdc37367959b1218e8/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/BuildActionGroup.java#L129

CC'ing @testforstephen @jdneo for awareness. I'd probably aim to do this **after** the upcoming release (mid-May).