### PR TITLE
Use Java Application class data sharing (AppCDS).

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ The following settings are supported:
 * `java.completion.engine`: [Experimental] Select code completion engine. Defaults to `ecj`.
 * `java.references.includeDeclarations`: Include declarations when finding references. Defaults to `true`
 
+New in 1.44.0
+* `java.jdt.ls.appcds.enabled` : [Experimental] Enable Java AppCDS (Application Class Data Sharing) for improvements to extension activation. When set to `auto`, AppCDS will be enabled in Visual Studio Code - Insiders, and for pre-release versions.
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/package.json
+++ b/package.json
@@ -420,6 +420,18 @@
             "scope": "window",
             "order": 95
           },
+          "java.jdt.ls.appcds.enabled": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "on",
+              "off"
+            ],
+            "default": "auto",
+            "markdownDescription": "[Experimental] Enable Java AppCDS (Application Class Data Sharing) for improvements to extension activation. When set to `auto`, AppCDS will be enabled in Visual Studio Code - Insiders, and for pre-release versions.",
+            "scope": "machine-overridable",
+            "order": 100
+          },
           "java.trace.server": {
             "type": "string",
             "enum": [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -139,7 +139,8 @@ function hasJavaConfigChanged(oldConfig: WorkspaceConfiguration, newConfig: Work
 		|| hasConfigKeyChanged('transport', oldConfig, newConfig)
 		|| hasConfigKeyChanged('diagnostic.filter', oldConfig, newConfig)
 		|| hasConfigKeyChanged('jdt.ls.javac.enabled', oldConfig, newConfig)
-		|| hasConfigKeyChanged('completion.engine', oldConfig, newConfig);
+		|| hasConfigKeyChanged('completion.engine', oldConfig, newConfig)
+		|| hasConfigKeyChanged('jdt.ls.appcds.enabled', oldConfig, newConfig);
 }
 
 function hasConfigKeyChanged(key, oldConfig, newConfig) {


### PR DESCRIPTION
- Boost startup performance using AppCDS

See https://developers.redhat.com/articles/2024/01/23/speed-java-application-startup-time-appcds & https://dev.java/learn/jvm/cds-appcds/

Taking a sample of 10 runs, sorted by duration.

**JDT-LS startup time (currently)**
1565 1643 1656 1670 1676 1684 1694 1706 1733 1904
median ~= 1680ms

**JDT-LS startup time (PR)**
1400 1405 1408 1415 1450 1470 1480 1498 1522 1541
median ~= 1460ms

Note that the first startup time with the PR was 1819ms as that's when the shared archive is generated. This phase is expected to be slow.

I also tried testing this entirely within vscode-java by measuring the duration until the Java language server reports it has started and observed the following times :

**JavaLanguageServerPlugin startup time (currently)**
2.345 2.247 2.268 2.229

**JavaLanguageServerPlugin startup time (PR)**
1.849 1.906 1.793 1.843

So basically, I would expect ~10-20% improvement on just the JDT-LS runtime initial startup (often 1-2 seconds).