### PR TITLE
Update release.yml, java-version: 23 -> 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Set Up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '23'
-          distribution: 'adopt'
+          java-version: '24'
+          distribution: 'temurin'
       - name: Build JDT-LS
         if: "${{ inputs.JDT_LS_VERSION == '' }}"
         run: |


### PR DESCRIPTION
# Update the Java and Node versions in the environment

- java-version: '24' 
- distribution:  'adopt' -> 'temurin'

because: 
 `adopt` for the distribution input referred to AdoptOpenJDK.   AdoptOpenJDK is now Eclipse Temurin,  so use `temurin` instead.