### PR TITLE
Changelog for 1.43.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.43.1 (July 1st, 2025)
+* bug fix - Fix compilation issue when annotation exists on a record class. [#4096](https://github.com/redhat-developer/vscode-java/issues/4096)
+
 ## 1.43.0 (June 26th, 2025)
  * performance - "Rebuild Projects" command should be done incrementally. See [#4041](https://github.com/redhat-developer/vscode-java/pull/4041).
  * enhancement - Adopt quick fixes for various modifier corrections. See [JLS#1053](https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/1053).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "java",
-  "version": "1.44.0",
+  "version": "1.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "java",
-      "version": "1.44.0",
+      "version": "1.43.1",
       "license": "EPL-2.0",
       "dependencies": {
         "@redhat-developer/vscode-extension-proposals": "0.0.23",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Red Hat",
   "icon": "icons/icon128.png",
   "license": "EPL-2.0",
-  "version": "1.44.0",
+  "version": "1.43.1",
   "publisher": "redhat",
   "bugs": "https://github.com/redhat-developer/vscode-java/issues",
   "preview": false,


### PR DESCRIPTION
It's worth doing a bug fix release to fix https://github.com/redhat-developer/vscode-java/issues/4096 . A simple rebuild that takes in the newer JDT Core (containing https://github.com/eclipse-jdt/eclipse.jdt.core/commit/5b4b32467ed054d4152101e9d74d1148811eca92 ) is all we need.

CC'ing @testforstephen for awareness.