### PR TITLE
Bump jdk-utils to 0.6.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
         "htmlparser2": "6.0.1",
-        "jdk-utils": "^0.5.1",
+        "jdk-utils": "^0.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "semver": "^7.5.2",
@@ -4587,9 +4587,10 @@
       }
     },
     "node_modules/jdk-utils": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.5.1.tgz",
-      "integrity": "sha512-BEQZ4JOmnWvZtuda+CRaCj8WbcgUs4RPZ07ZaM5bei+iFtx8fWrF0NpXDe3zM1k4SQajjYQ9zFc1/PhYT1Z6Og==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.6.0.tgz",
+      "integrity": "sha512-/CHgo6Q5xyfW/+vWXLz7cAb+iwIye3mNo7SV8UTHsbLhRykk+N7LzKXRlCvdeoblyuTrA8pb00iZX8De3txvWQ==",
+      "license": "MIT",
       "bin": {
         "jdk-utils": "bin/cli.js"
       }

--- a/package.json
+++ b/package.json
@@ -1987,7 +1987,7 @@
     "fs-extra": "^8.1.0",
     "glob": "^7.1.3",
     "htmlparser2": "6.0.1",
-    "jdk-utils": "^0.5.1",
+    "jdk-utils": "^0.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "semver": "^7.5.2",


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/vscode-java/issues/3799
- See https://github.com/Eskibear/node-jdk-utils/pull/18