### PR TITLE
Remove node_modules prefix from gulp commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1945,13 +1945,13 @@
     "watch": "webpack --mode development --watch",
     "pretest": "npm run compile",
     "test": "node ./out/test/runtest.js",
-    "build-server": "./node_modules/.bin/gulp build_server",
-    "build": "./node_modules/.bin/gulp build_or_download",
-    "fast-build-server": "./node_modules/.bin/gulp dev_server",
-    "watch-server": "./node_modules/.bin/gulp watch_server",
+    "build-server": "gulp build_server",
+    "build": "gulp build_or_download",
+    "fast-build-server": "gulp dev_server",
+    "watch-server": "gulp watch_server",
     "eslint": "eslint --ignore-path .eslintignore --ext .js,.ts,.tsx .",
-    "repo:check": "./node_modules/.bin/gulp repo_check",
-    "repo:fix": "./node_modules/.bin/gulp repo_fix"
+    "repo:check": "gulp repo_check",
+    "repo:fix": "gulp repo_fix"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",


### PR DESCRIPTION
Use `gulp <command>` instead of `gulp ./node_modules.bin/gulp`. This allows to build on Windows and likely is more robust, anyway.