### PR TITLE
fix: forward _all_ LSP telemetry events

### DIFF
--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -360,6 +360,7 @@ export class StandardLanguageClient {
 					return Telemetry.sendTelemetry(Telemetry.LS_ERROR, e.properties);
 				}
 			}
+			return Telemetry.sendTelemetry(e.name, e.properties);
 		});
 
 		context.subscriptions.push(commands.registerCommand(GRADLE_CHECKSUM, (wrapper: string, sha256: string) => {


### PR DESCRIPTION
Currently only "java.workspace.initialized" and "java.ls.error" events are sent. 

Either we keep whitelisting events, but then new stuff like potentially https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3544 need to add new events to the whitelist, or we trust all JDT.LS events to be forwarded to our telemetry backend.