### PR TITLE
Fix decompiled.javaClass editor in WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
         "selector": [
           {
             "filenamePattern": "file:/**/*.class"
+          },
+          {
+            "filenamePattern": "vscode-remote:/**/*.class"
           }
         ]
       }


### PR DESCRIPTION
This PR fixes https://github.com/redhat-developer/vscode-java/issues/4114

## Problem

When using the extension in Windows Subsystem for Linux (WSL), the `decompiled.javaClass` editor does not work properly. Opening a `.class` file results in an error text, "The file is not displayed in the text editor because it is either binary or uses an unsupported text encoding."

<details>
<summary>Screenshot</summary>

<img width="1094" height="535" alt="Opening .class file without fix" src="https://github.com/user-attachments/assets/35fa8edc-c890-4a93-94b0-49b53657e226" />

</details>

Clicking "Open Anyway" opens the raw bytecode rather than the decompiled sources:

<details>
<summary>Screenshot</summary>

<img width="1095" height="531" alt="'Open Anyway' before fix" src="https://github.com/user-attachments/assets/3965a381-d23a-4b05-8ccc-8ada7c977b47" />

</details>

When right-clicking a `.class` file and selecting "Open With...", the `decompiled.javaClass` editor is not listed:

<details>
<summary>Screenshot</summary>

<img width="1097" height="535" alt="'Open With...' dialog without fix" src="https://github.com/user-attachments/assets/f3a3f480-0475-4635-aefe-73fc26e88923" />

</details>

## Solution

By adding a new filename pattern to the `package.json` file, the issue is gone. Opening a `.class` file directly shows the decompiled code, and the "Open With..." dialog also lists the `decompiled.javaClass` editor.

<details>
<summary>Screenshots</summary>

<img width="1097" height="534" alt="Opening .class file with fix" src="https://github.com/user-attachments/assets/d2a31a47-cdac-494b-a249-e382c1ad2d20" />

<img width="1090" height="525" alt="'Open With...' dialog with fix" src="https://github.com/user-attachments/assets/d4b56d00-392d-4bef-b6db-d7ba30322cfa" />

</details>
