### PR TITLE
Added Content-Security-Policy meta tags to webviews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,11 +54,11 @@
         "gulp-download": "0.0.1",
         "lodash.findindex": "^4.6.0",
         "lodash.template": ">=4.5.0",
+        "mini-css-extract-plugin": "^2.9.4",
         "minimist": ">=1.2.6",
         "mocha": "^11.1.0",
         "request": "^2.88.2",
         "sinon": "^14.0.0",
-        "style-loader": "^3.3.1",
         "ts-loader": "^9.4.2",
         "typescript": "^4.6.4",
         "webpack": "^5.94.0",
@@ -3301,6 +3301,23 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
       "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -5201,6 +5218,84 @@
         "node": ">=6"
       }
     },
+    "node_modules/mini-css-extract-plugin": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "schema-utils": "^4.0.0",
+        "tapable": "^2.2.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6893,22 +6988,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/style-loader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -2024,7 +2024,7 @@
     "mocha": "^11.1.0",
     "request": "^2.88.2",
     "sinon": "^14.0.0",
-    "style-loader": "^3.3.1",
+    "mini-css-extract-plugin": "^2.9.4",
     "ts-loader": "^9.4.2",
     "typescript": "^4.6.4",
     "webpack": "^5.94.0",

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -110,27 +110,23 @@ class DashboardPanel {
 	}
 
 	private getWebviewContent(): string {
-		const scriptUri = getUri(this.webView, this.context.extensionUri, [
-			"dist",
-			"dashboard.js",
-		]);
-
-		const nonce = getNonce();
-		const codiconsUri = this.webView.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css'));
+		const scriptUri = getUri(this.webView, this.context.extensionUri, "dist", "dashboard.js");
+		const styleUri = getUri(this.webView, this.context.extensionUri, "dist", "dashboard.css");
 
 		return /* html*/ `
 	  <!DOCTYPE html>
 	  <html lang="en">
 		<head>
 		  <meta charset="utf-8">
+		  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${this.webView.cspSource}; font-src ${this.webView.cspSource} data:; style-src ${this.webView.cspSource};">
 		  <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 		  <meta name="theme-color" content="#000000">
-		  <link href="${codiconsUri}" rel="stylesheet" />
 		  <title>Dashboard</title>
+		  <link href="${styleUri}" rel="stylesheet">
 		</head>
 		<body>
 		  <div id="root"></div>
-		  <script nonce="${nonce}" src="${scriptUri}"></script>
+		  <script src="${scriptUri}"></script>
 		</body>
 	  </html>
 	`;

--- a/src/refactoring/changeSignaturePanel.ts
+++ b/src/refactoring/changeSignaturePanel.ts
@@ -108,26 +108,24 @@ export class ChangeSignaturePanel {
 	}
 
 	private getWebviewContent(webview: Webview, extensionUri: Uri) {
-
-		const scriptUri = getUri(webview, extensionUri, [
-			"dist",
-			"changeSignature.js",
-		]);
-
-		const nonce = getNonce();
+		const scriptUri = getUri(webview, extensionUri, "dist", "changeSignature.js");
+		const styleUri = getUri(webview, extensionUri, "dist", "changeSignature.css");
 
 		return /* html*/ `
       <!DOCTYPE html>
       <html lang="en">
         <head>
           <meta charset="utf-8">
+		  <!-- We need the 'unsafe-inline' because of webview UI toolkit setting style attributes -->
+		  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webview.cspSource}; font-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'unsafe-inline';">
           <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
           <meta name="theme-color" content="#000000">
           <title>Change Signature</title>
+		  <link rel = "stylesheet" href="${styleUri}">
         </head>
         <body>
           <div id="root"></div>
-          <script nonce="${nonce}" src="${scriptUri}"></script>
+          <script src="${scriptUri}"></script>
         </body>
       </html>
     `;

--- a/src/webview/dashboard/dashboard.css
+++ b/src/webview/dashboard/dashboard.css
@@ -1,3 +1,5 @@
+@import "../../../node_modules/@vscode/codicons/dist/codicon.css";
+
 .toolbar {
     margin: 8px;
 	width: 100%;

--- a/src/webviewUtils.ts
+++ b/src/webviewUtils.ts
@@ -1,6 +1,6 @@
 import { Uri, Webview } from "vscode";
 
-export function getUri(webview: Webview, extensionUri: Uri, pathList: string[]) {
+export function getUri(webview: Webview, extensionUri: Uri, ...pathList: string[]) {
     return webview.asWebviewUri(Uri.joinPath(extensionUri, ...pathList));
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,8 @@ const config = {
 	},
 }
 
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
 const configChangeSignature = {
 	name: 'changeSignature',
 	mode: 'none',
@@ -70,7 +72,7 @@ const configChangeSignature = {
 		}, {
 			test: /\.(css)$/,
 			use: [{
-				loader: 'style-loader'
+				loader: MiniCssExtractPlugin.loader,
 			}, {
 				loader: 'css-loader'
 			}]
@@ -86,6 +88,9 @@ const configChangeSignature = {
 		devtoolModuleFilenameTemplate: "../[resource-path]"
 	},
 	plugins: [
+		new MiniCssExtractPlugin({
+			filename: 'changeSignature.css'
+		}),
 		new webpack.ProvidePlugin({
 			process: 'process/browser',
 		}),
@@ -113,7 +118,7 @@ const configDashboard = {
 		}, {
 			test: /\.(css)$/,
 			use: [{
-				loader: 'style-loader'
+				loader: MiniCssExtractPlugin.loader,
 			}, {
 				loader: 'css-loader'
 			}]
@@ -129,6 +134,9 @@ const configDashboard = {
 		devtoolModuleFilenameTemplate: "../[resource-path]"
 	},
 	plugins: [
+		new MiniCssExtractPlugin({
+			filename: 'dashboard.css'
+		}),
 		new webpack.ProvidePlugin({
 			process: 'process/browser',
 		}),


### PR DESCRIPTION
Title says it all: had to relax the restrictions a bit for "change method signature" because the vscode webview ui toolkit adds style tags programmatically. 

How to test: make sure the "Java Dashboard" and the "Change Method Signature" refactoring UI's work properly and styling and codicons show up correctly. In order to properly test, one should build a vsix version (`vsce package`) and install that. 