### PR TITLE
feat: add inlay hints for lambda parameter types

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The following settings are supported:
 * `java.configuration.workspaceCacheLimit` : The number of days (if enabled) to keep unused workspace cache data. Beyond this limit, cached workspace data may be removed.
 * `java.import.generatesMetadataFilesAtProjectRoot` : Specify whether the project metadata files(.project, .classpath, .factorypath, .settings/) will be generated at the project root. Defaults to `false`.
 * `java.inlayHints.parameterNames.enabled`: Enable/disable inlay hints for parameter names. Supported values are: `none`(disable parameter name hints), `literals`(Enable parameter name hints only for literal arguments) and `all`(Enable parameter name hints for literal and non-literal arguments). Defaults to `literals`.
+* `java.inlayHints.parameterTypes.enabled`: Enable/disable inlay hints for (lambda) parameter types. Defaults to `false`.
 * `java.compile.nullAnalysis.nonnull`: Specify the Nonnull annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies. This setting will be ignored if `java.compile.nullAnalysis.mode` is set to `disabled`.
 * `java.compile.nullAnalysis.nullable`: Specify the Nullable annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies. This setting will be ignored if `java.compile.nullAnalysis.mode` is set to `disabled`.
 * `java.compile.nullAnalysis.nonnullbydefault`: Specify the NonNullByDefault annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in your project dependencies. This setting will be ignored if `java.compile.nullAnalysis.mode` is set to `disabled`.
@@ -259,8 +260,8 @@ The following settings are supported:
 * `java.references.includeDeclarations`: Include declarations when finding references. Defaults to `true`
 * `java.jdt.ls.appcds.enabled` : [Experimental] Enable Java AppCDS (Application Class Data Sharing) for improvements to extension activation. When set to `auto`, AppCDS will be enabled in Visual Studio Code - Insiders, and for pre-release versions.
 
-New in 1.46.0
-* `java.inlayHints.variableTypes.enabled`: Enable/disable inlay hints for implicit variable types.
+New in 1.47.0
+* `java.inlayHints.parameterTypes.enabled`: Enable/disable inlay hints for (lambda) parameter types. Defaults to `false`.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -1519,6 +1519,12 @@
             "markdownDescription": "Enable/disable inlay hints for implicit variable types:\n```java\n\nvar foo /* :Path */ = Path.of(\"foo\");\n \n```",
             "scope": "window"
           },
+          "java.inlayHints.parameterTypes.enabled": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enable/disable inlay hints for (lambda) parameter types:\n```java\n\nList.of(1, 2, 3, 4).filter(/*Integer */ n -> n % 2 == 0).toList();\n \n```",
+            "scope": "window"
+          },
           "java.search.scope": {
             "type": "string",
             "enum": [

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -62,8 +62,10 @@ export namespace Telemetry {
 			"java.cleanup.actionsOnSave", "java.completion.postfix.enabled",
 			"java.sharedIndexes.enabled", "java.inlayHints.parameterNames.enabled",
 			"java.inlayHints.variableTypes.enabled",
+			"java.inlayHints.parameterTypes.enabled",
 			"java.server.launchMode", "java.autobuild.enabled"
 		];
+
 		// settings where we only record their existence
 		const SETTINGS_CUSTOM = [
 			"java.settings.url", "java.format.settings.url"


### PR DESCRIPTION
As requested by @ayloncarrijo  in https://github.com/redhat-developer/vscode-java/issues/4031#issuecomment-3335195168

Shows inlay hints for implicit lambda parameter types. Controlled by the "java.inlayHints.parameterTypes.enabled" preference.

<img width="704" height="83" alt="Screenshot 2025-10-08 at 15 14 41" src="https://github.com/user-attachments/assets/c3a098e4-7c8b-4161-9373-9893e36c675b" />

requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3556