### PR TITLE
feat: suppress same-name numbered parameters inlay hints

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -19,12 +19,12 @@ vscode-java has opt-in telemetry collection, provided by [vscode-redhat-telemetr
  * Errors relating to running the language server, such as the message & stacktrace
  * Whether there is a mismatch between the project's requested source level, and the JDK used for the project (eg. true)
  * Information about the following settings. In the case of settings that store a well defined value (eg. path/url/string), we simply collect whether the setting has been set.
-   * `java.settings.url`, `java.format.settings.url`, `java.quickfix.showAt`, `java.symbols.includeSourceMethodDeclarations`, `java.completion.collapseCompletionItems`, `java.completion.guessMethodArguments`, `java.completion.postfix.enabled`, `java.cleanup.actionsOnSave`, `java.sharedIndexes.enabled`, `java.inlayHints.parameterNames.enabled`, `java.server.launchMode`, `java.autobuild.enabled`, `java.jdt.ls.javac.enabled`
+   * `java.settings.url`, `java.format.settings.url`, `java.quickfix.showAt`, `java.symbols.includeSourceMethodDeclarations`, `java.completion.collapseCompletionItems`, `java.completion.guessMethodArguments`, `java.completion.postfix.enabled`, `java.cleanup.actionsOnSave`, `java.sharedIndexes.enabled`, `java.inlayHints.parameterNames.enabled`, `java.inlayHints.parameterNames.suppressWhenSameNameNumbered`, `java.inlayHints.variableTypes.enabled`, `java.inlayHints.parameterTypes.enabled`, `java.server.launchMode`, `java.autobuild.enabled`, `java.jdt.ls.javac.enabled`
  * The extension name and the choice made when a recommendation to install a 3rd party extension is proposed
  * The name of Java commands being manually executed, and any resulting errors
  * The number of results (eg. 20), whether an error occurred (eg. false), engine type (eg. 'ecj', 'dom') and duration (in milliseconds) when code assist is activated
  * Whether the language server ran out of memory and the maximum allocated memory at which that occurred (eg. 200m)
- 
+
 ## What's included in the general telemetry data
 
 Please see the

--- a/package.json
+++ b/package.json
@@ -1503,6 +1503,13 @@
             "scope": "window",
             "order": 80
           },
+          "java.inlayHints.parameterNames.suppressWhenSameNameNumbered": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Suppress parameter name hints on arguments following the same-name numbered pattern.",
+            "scope": "window",
+            "order": 81
+          },
           "java.inlayHints.parameterNames.exclusions": {
             "type": "array",
             "items": {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -61,6 +61,7 @@ export namespace Telemetry {
 			"java.completion.collapseCompletionItems", "java.completion.guessMethodArguments",
 			"java.cleanup.actionsOnSave", "java.completion.postfix.enabled",
 			"java.sharedIndexes.enabled", "java.inlayHints.parameterNames.enabled",
+			"java.inlayHints.parameterNames.suppressWhenSameNameNumbered",
 			"java.inlayHints.variableTypes.enabled",
 			"java.inlayHints.parameterTypes.enabled",
 			"java.server.launchMode", "java.autobuild.enabled"


### PR DESCRIPTION
Adds new `java.inlayHints.parameterNames.suppressWhenSameNameNumbered` setting to show/hide inlay hints for method parameters that follow the same prefix followed by an incremented number (1st parameter must start at 1, increment by 1).

When set to `true`, the default, e1, e2, e3 parameter inlay hints are hidden:
<img width="202" height="30" alt="Screenshot 2025-10-10 at 13 04 51" src="https://github.com/user-attachments/assets/b43ca58a-e8fd-43e8-8475-2734e9762ba5" />

shown when set to `false`:
<img width="291" height="30" alt="Screenshot 2025-10-10 at 13 05 05" src="https://github.com/user-attachments/assets/b902cbb5-c850-4be4-aff5-a4aec4cd3516" />

requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3557