### PR TITLE
fix: safeguard workspace hash computation in telemetry service

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -25,14 +25,21 @@ export namespace Telemetry {
 		if (!!telemetryManager) {
 			throw new Error("The telemetry service for vscode-java has already been started");
 		}
-		workspaceHash = cyrb53(workspace.workspaceFolders.map(f => f.uri.toString()).join('|'));
+		workspaceHash = computeWorkspaceHash();
 		workspace.onDidChangeWorkspaceFolders(() => {
-			workspaceHash = cyrb53(workspace.workspaceFolders.map(f => f.uri.toString()).join('|'));
+			workspaceHash = computeWorkspaceHash();
 		});
 		const redhatService = await getRedHatService(context);
 		const telemService = await redhatService.getTelemetryService();
 		telemetryManager = telemService;
 		return telemService;
+	}
+
+	function computeWorkspaceHash(): number {
+		if (!workspace.workspaceFolders?.length) {
+			return 0;
+		}
+		return cyrb53(workspace.workspaceFolders.map(f => f.uri.toString()).join('|'));
 	}
 
 	/**


### PR DESCRIPTION
Telemetry fails to initialize when starting without a workspace folder, e.g. after triggering the "Java: Add Java Runtime" command:

```
rejected promise not handled within 1 second: TypeError: Cannot read properties of undefined (reading 'map')
extensionHostProcess.js:204
stack trace: TypeError: Cannot read properties of undefined (reading 'map')
	at Object.<anonymous> (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96860:85)
	at Generator.next (<anonymous>)
	at /Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96830:71
	at new Promise (<anonymous>)
	at __webpack_modules__../src/telemetry.ts.__awaiter (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96826:12)
	at Object.startTelemetry (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96856:16)
	at /Users/fbricon/Dev/projects/vscode-java/dist/extension.js:88878:31
	at Generator.next (<anonymous>)
	at fulfilled (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:88712:58)
extensionHostProcess.js:204
rejected promise not handled within 1 second: Error: The telemetry service for vscode-java has not been started yet
extensionHostProcess.js:204
stack trace: Error: The telemetry service for vscode-java has not been started yet
	at Object.<anonymous> (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96881:23)
	at Generator.next (<anonymous>)
	at /Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96830:71
	at new Promise (<anonymous>)
	at __webpack_modules__../src/telemetry.ts.__awaiter (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96826:12)
	at Object.sendTelemetry (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:96879:16)
	at StandardLanguageClient.<anonymous> (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:95999:45)
	at Generator.next (<anonymous>)
	at /Users/fbricon/Dev/projects/vscode-java/dist/extension.js:95629:71
	at new Promise (<anonymous>)
	at __webpack_modules__../src/standardLanguageClient.ts.__awaiter (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:95625:12)
	at /Users/fbricon/Dev/projects/vscode-java/dist/extension.js:95994:48
	at CallbackList.invoke (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:99523:39)
	at Emitter.fire (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:99585:36)
	at /Users/fbricon/Dev/projects/vscode-java/dist/extension.js:102415:40
	at handleNotification (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:98858:25)
	at handleMessage (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:98560:13)
	at processMessageQueue (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:98580:17)
	at Immediate.<anonymous> (/Users/fbricon/Dev/projects/vscode-java/dist/extension.js:98552:13)
	at process.processImmediate (node:internal/timers:485:21)
	at process.callbackTrampoline (node:internal/async_hooks:130:17)
extensionHostProcess.js:204
```