### PR TITLE
add JSpecify annotations for null analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -859,7 +859,8 @@
             "default": [
               "javax.annotation.Nonnull",
               "org.eclipse.jdt.annotation.NonNull",
-              "org.springframework.lang.NonNull"
+              "org.springframework.lang.NonNull",
+              "org.jspecify.annotations.NonNull"
             ],
             "markdownDescription": "Specify the Nonnull annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in project dependencies. This setting will be ignored if `java.compile.nullAnalysis.mode` is set to `disabled`",
             "scope": "window"
@@ -869,7 +870,8 @@
             "default": [
               "javax.annotation.Nullable",
               "org.eclipse.jdt.annotation.Nullable",
-              "org.springframework.lang.Nullable"
+              "org.springframework.lang.Nullable",
+              "org.jspecify.annotations.Nullable"
             ],
             "markdownDescription": "Specify the Nullable annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in project dependencies. This setting will be ignored if `java.compile.nullAnalysis.mode` is set to `disabled`",
             "scope": "window"
@@ -879,7 +881,8 @@
             "default": [
               "javax.annotation.ParametersAreNonnullByDefault",
               "org.eclipse.jdt.annotation.NonNullByDefault",
-              "org.springframework.lang.NonNullApi"
+              "org.springframework.lang.NonNullApi",
+              "org.jspecify.annotations.NullMarked"
             ],
             "markdownDescription": "Specify the NonNullByDefault annotation types to be used for null analysis. If more than one annotation is specified, then the topmost annotation will be used first if it exists in project dependencies. This setting will be ignored if `java.compile.nullAnalysis.mode` is set to `disabled`",
             "scope": "window"


### PR DESCRIPTION
Due to JSpecify emerging as the new standard for null analysis annotations, here is the corresponding config for the default settings. The corresponding PR for the server-side changes to detect JSpecify will follow shortly.