### PR TITLE
feat: add preference to disable returning Javadoc on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ The following settings are supported:
 * `java.references.includeDeclarations`: Include declarations when finding references. Defaults to `true`
 * `java.jdt.ls.appcds.enabled` : [Experimental] Enable Java AppCDS (Application Class Data Sharing) for improvements to extension activation. When set to `auto`, AppCDS will be enabled in Visual Studio Code - Insiders, and for pre-release versions.
 
+New in 1.50.0
+* `java.hover.javadoc.enabled` : Enable/disable displaying Javadoc on hover. Defaults to `true`.
+
 Semantic Highlighting
 ===============
 [Semantic Highlighting](https://github.com/redhat-developer/vscode-java/wiki/Semantic-Highlighting) fixes numerous syntax highlighting issues with the default Java Textmate grammar. However, you might experience a few minor issues, particularly a delay when it kicks in, as it needs to be computed by the Java Language server, when opening a new file or when typing. Semantic highlighting can be disabled for all languages using the `editor.semanticHighlighting.enabled` setting, or for Java only using [language-specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings).

--- a/package.json
+++ b/package.json
@@ -1424,6 +1424,13 @@
         "title": "Code Navigation",
         "order": 120,
         "properties": {
+          "java.hover.javadoc.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable/disable displaying Javadoc on hover.",
+            "scope": "window",
+            "order": 5
+          },
           "java.referencesCodeLens.enabled": {
             "type": "boolean",
             "default": false,


### PR DESCRIPTION
New `java.hover.javadoc.enabled` preference to disable displaying javadoc on hover. Defaults to `true`.

<img width="689" height="235" alt="Screenshot 2025-11-21 at 09 09 08" src="https://github.com/user-attachments/assets/7367376a-fcaf-42af-9597-07395b1d01e3" />


Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3610
Fixes https://github.com/redhat-developer/vscode-java/issues/1420

Signed-off-by: Fred Bricon <fbricon@gmail.com>
