### PR TITLE
Remove title for package.json schema contribution

### DIFF
--- a/schemas/package.schema.json
+++ b/schemas/package.schema.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
-	"title": "Java Language server contributions to package.json",
 	"type": "object",
 	"properties": {
 		"contributes": {


### PR DESCRIPTION
This title will compete with the title of the base schema in cases like highlight, and the title is nonsensical for package.json for things other than VS Code extensions.

Fixes #4268