### PR TITLE
feat: add setting to disable adding imports on paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,10 @@ The following settings are supported:
 * `java.completion.engine`: [Experimental] Select code completion engine. Defaults to `ecj`.
 * `java.references.includeDeclarations`: Include declarations when finding references. Defaults to `true`
 * `java.jdt.ls.appcds.enabled` : [Experimental] Enable Java AppCDS (Application Class Data Sharing) for improvements to extension activation. When set to `auto`, AppCDS will be enabled in Visual Studio Code - Insiders, and for pre-release versions.
-
-New in 1.50.0
 * `java.hover.javadoc.enabled` : Enable/disable displaying Javadoc on hover. Defaults to `true`.
+
+New in 1.53.0
+* `java.updateImportsOnPaste.enabled` : Enable/disable auto organize imports when pasting code. Defaults to `true`.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -1387,6 +1387,13 @@
             "scope": "window",
             "order": 20
           },
+          "java.updateImportsOnPaste.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable/disable auto organize imports when pasting code",
+            "scope": "window",
+            "order": 25
+          },
           "java.sources.organizeImports.starThreshold": {
             "type": "integer",
             "description": "Specifies the number of imports added before a star-import declaration is used.",

--- a/src/pasteAction.ts
+++ b/src/pasteAction.ts
@@ -14,6 +14,7 @@ export function registerCommands(languageClient: LanguageClient, context: Extens
 }
 
 export async function registerOrganizeImportsOnPasteCommand(): Promise<void> {
+
 	const clipboardText: string = await env.clipboard.readText();
 	const editor: TextEditor = window.activeTextEditor;
 	const documentText: string = editor.document.getText();
@@ -40,6 +41,10 @@ export async function registerOrganizeImportsOnPasteCommand(): Promise<void> {
 
 	action.then((wasApplied) => {
 		if (wasApplied && editor.document.languageId === "java") {
+			const updateImportsOnPasteEnabled = workspace.getConfiguration().get<boolean>("java.updateImportsOnPaste.enabled", true);
+			if (!updateImportsOnPasteEnabled) {
+				return;
+			}
 			const fileURI = editor.document.uri.toString();
 			const hasText: boolean = documentText !== null && /\S/.test(documentText);
 			if (hasText) {


### PR DESCRIPTION
New "java.updateImportsOnPaste.enabled" boolean setting, to enable/disable updating imports when pasting Java code in a file.

Fixes https://github.com/redhat-developer/vscode-java/issues/4325
Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3700