### PR TITLE
build: avoid calling webpack for each platform build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,13 +134,16 @@ jobs:
           echo "publishPreReleaseFlag=--pre-release" >> $GITHUB_ENV
       - name: Package vscode-java
         run: |
+          # Compile JavaScript once for the universal VSIX (webpack is platform-independent)
+          vsce package ${{ env.publishPreReleaseFlag }} -o vscode-java-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}.vsix
+
+          # Package for each platform (only downloads JDK and creates VSIX, no recompilation)
           platforms=("win32-x64" "win32-arm64" "linux-x64" "linux-arm64" "darwin-x64" "darwin-arm64")
           for platform in ${platforms[@]}; do
             npm run download-jre -- --target ${platform} --javaVersion 21
-            vsce package ${{ env.publishPreReleaseFlag }} --target ${platform} -o java-${platform}-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}.vsix
+            SKIP_WEBPACK=true vsce package ${{ env.publishPreReleaseFlag }} --target ${platform} -o java-${platform}-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}.vsix
           done
-          rm -rf jre/
-          vsce package ${{ env.publishPreReleaseFlag }} -o vscode-java-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}.vsix
+
           ls -lash *.vsix
       - name: Upload VSIX Artifacts
         uses: actions/upload-artifact@v5

--- a/package.json
+++ b/package.json
@@ -2020,7 +2020,7 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "webpack --mode production",
+    "vscode:prepublish": "node scripts/prepublish.mjs",
     "compile": "tsc -p ./&webpack --mode development",
     "watch": "webpack --mode development --watch",
     "pretest": "npm run compile",

--- a/scripts/prepublish.mjs
+++ b/scripts/prepublish.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// Skip webpack if SKIP_WEBPACK environment variable is set to 'true'
+if (process.env.SKIP_WEBPACK === 'true') {
+    console.log('Skipping webpack compilation (SKIP_WEBPACK=true)');
+    process.exit(0);
+}
+
+// Otherwise, run webpack using the local webpack-cli installation
+const { spawn } = await import('child_process');
+const { fileURLToPath } = await import('url');
+const { dirname, resolve, join } = await import('path');
+
+const scriptFilename = fileURLToPath(import.meta.url);
+const scriptDirname = dirname(scriptFilename);
+const projectRoot = resolve(scriptDirname, '..');
+
+// Use webpack-cli from local node_modules (cross-platform)
+const webpackCliPath = join(projectRoot, 'node_modules', '.bin', 'webpack');
+const isWindows = process.platform === 'win32';
+const webpackCommand = isWindows ? `${webpackCliPath}.cmd` : webpackCliPath;
+
+const webpack = spawn(webpackCommand, ['--mode', 'production'], {
+    stdio: 'inherit',
+    cwd: projectRoot
+});
+
+webpack.on('close', (code) => {
+    process.exit(code || 0);
+});
+
+webpack.on('error', (error) => {
+    console.error('Error running webpack:', error);
+    process.exit(1);
+});


### PR DESCRIPTION
That should speed up the release process, as webpack will be called once instead of 7 times (6 platforms + 1 universal)