### PR TITLE
feat: add setting to show generated code in document symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ New in 1.53.0
 * `java.updateImportsOnPaste.enabled` : Enable/disable auto organize imports when pasting code. Defaults to `true`.
 * `java.jdt.ls.kotlinSupport.enabled`: [Experimental] Specify whether to enable `org.jetbrains.kotlin.jvm` plugin in Gradle projects. Defaults to `true`.
 * `java.jdt.ls.groovySupport.enabled`: [Experimental] Specify whether to enable `groovy` plugin in Gradle projects. Defaults to `true`.
+* `java.symbols.includeGeneratedCode` : Include generated code (e.g. Lombok getters, setters, constructors) in document outline/symbols. Defaults to `false`.
 
 Semantic Highlighting
 ===============

--- a/package.json
+++ b/package.json
@@ -1521,6 +1521,13 @@
             "scope": "window",
             "order": 60
           },
+          "java.symbols.includeGeneratedCode": {
+            "type": "boolean",
+            "markdownDescription": "Include generated code (e.g. Lombok getters, setters, constructors) in document outline/symbols.",
+            "default": false,
+            "scope": "window",
+            "order": 65
+          },
           "java.typeHierarchy.lazyLoad": {
             "type": "boolean",
             "default": false,


### PR DESCRIPTION
New `java.symbols.includeGeneratedCode` boolean setting to enable returning generated code in document symbols. 

Requires https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3706 
Fixes https://github.com/redhat-developer/vscode-java/issues/4084

<img width="1820" height="1082" alt="Screenshot 2026-02-12 at 13 01 45" src="https://github.com/user-attachments/assets/20962217-fad3-4be7-be5e-7fba20809eec" />


Because there's no way to programmatically trigger an outline view refresh (see https://github.com/microsoft/vscode/issues/108722), after changing the setting you need to close/reopen the java files, or make a dummy change to see the updates in the outline view.