### PR TITLE
feat: allow turning off automatic creation of class body when creating a new java file

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The following settings are supported:
 * `java.hover.javadoc.enabled` : Enable/disable displaying Javadoc on hover. Defaults to `true`.
 
 New in 1.53.0
+* `java.templates.newFile.enabled` : Enable/disable automatic generation of class body and package declaration when creating a new Java file. Set to `false` to create empty Java files. Defaults to `true`.
 * `java.updateImportsOnPaste.enabled` : Enable/disable auto organize imports when pasting code. Defaults to `true`.
 
 Semantic Highlighting

--- a/package.json
+++ b/package.json
@@ -1191,6 +1191,13 @@
         "title": "Code Generation",
         "order": 100,
         "properties": {
+          "java.templates.newFile.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable/disable automatic generation of class body and package declaration when creating a new Java file. Set to `false` to create empty Java files. Defaults to `true`.",
+            "scope": "window",
+            "order": 5
+          },
           "java.templates.fileHeader": {
             "type": "array",
             "markdownDescription": "Specifies the file header comment for new Java file. Supports configuring multi-line comments with an array of strings, and using ${variable} to reference the [predefined variables](command:_java.templateVariables).",

--- a/src/fileEventHandler.ts
+++ b/src/fileEventHandler.ts
@@ -47,6 +47,9 @@ export function registerFileEventHandlers(client: LanguageClient, context: Exten
 }
 
 async function handleNewJavaFiles(e: FileCreateEvent) {
+    if (!getJavaConfiguration().get<boolean>('templates.newFile.enabled', true)) {
+        return;
+    }
     const emptyFiles: Uri[] = [];
     const textDocuments: TextDocument[] = [];
     for (const uri of e.files) {


### PR DESCRIPTION
Adds a new `java.templates.newFile.enabled` setting to enable/disable automatic generation of class body and package declaration when creating a new Java file. Set to `false` to create empty Java files. Defaults to `true`.

Fixes https://github.com/redhat-developer/vscode-java/issues/2652
