### PR TITLE
chore: Update Eclipse formatter settings to version 25

### DIFF
--- a/formatters/eclipse-formatter.xml
+++ b/formatters/eclipse-formatter.xml
@@ -2,11 +2,11 @@
 <profiles version="13">
 <profile kind="CodeFormatterProfile" name="Eclipse" version="13">
 <setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="10"/>
-<setting id="org.eclipse.jdt.core.compiler.compliance" value="10"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="25"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="25"/>
 <setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
 <setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
-<setting id="org.eclipse.jdt.core.compiler.source" value="10"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="25"/>
 <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
 <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>


### PR DESCRIPTION
Bump the default version to avoid formatting issues on features newer than java 10. 
(example: switch statement formatted on a single line)

Since a higher version is a superset, formatting on lower java version will still work.
<img width="461" height="121" alt="image" src="https://github.com/user-attachments/assets/e07d7001-d7e6-4f4b-963d-8d4fe842306d" />
