### PR TITLE
Feat: Support for vscode settings expansions like ${workspaceFolder}

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { commands, ConfigurationTarget, env, ExtensionContext, Position, Range, Selection, SnippetString, TextDocument, Uri, window, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
 import { Commands } from './commands';
 import { cleanupLombokCache } from './lombokSupport';
-import { ensureExists, getJavaConfiguration } from './utils';
+import { ensureExists, getJavaConfiguration, resolvePathVariables } from './utils';
 import { apiManager } from './apiManager';
 import { isActive, setActive, smartSemicolonDetection } from './smartSemicolonDetection';
 import { BuildFileSelector, IMPORT_METHOD, PICKED_BUILD_FILES } from './buildFilesSelector';
@@ -242,7 +242,7 @@ export async function checkJavaPreferences(context: ExtensionContext): Promise<{
 	}
 
 	return {
-		javaHome,
+		javaHome: resolvePathVariables(javaHome),
 		preference
 	};
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -369,11 +369,6 @@ export function resolvePathVariables(pathStr: string): string {
 	if (!pathStr) {
 		return pathStr;
 	}
-	const requiresWorkspace = pathStr.includes('${workspaceFolder}') ||
-		pathStr.includes('${workspaceFolderBasename}');
-	if (requiresWorkspace && !workspace.workspaceFolders?.length) {
-		return pathStr;
-	}
 	return vscodeVariables(pathStr);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -284,6 +284,8 @@ export async function getJavaConfig(javaHome: string) {
 		javaConfig.implementationCodeLens = deprecatedImplementations ? "types" : "none";
 	}
 
+	javaConfig.import.gradle.java.home = resolvePathVariables(javaConfig.import.gradle.java.home);
+
 	return javaConfig;
 }
 
@@ -361,6 +363,18 @@ export function getVSCodeVariablesMap(): any {
 	const res = {};
 	keys.forEach(key => res[key] = vscodeVariables(`\${${key}}`));
 	return res;
+}
+
+export function resolvePathVariables(pathStr: string): string {
+	if (!pathStr) {
+		return pathStr;
+	}
+	const requiresWorkspace = pathStr.includes('${workspaceFolder}') ||
+		pathStr.includes('${workspaceFolderBasename}');
+	if (requiresWorkspace && !workspace.workspaceFolders?.length) {
+		return pathStr;
+	}
+	return vscodeVariables(pathStr);
 }
 
 /**


### PR DESCRIPTION
Allows setting vscode settings with variable substitutions such as:

```json
"java.import.gradle.java.home": "${workspaceFolder}/.vscode/mise-tools/java",
"java.jdt.ls.java.home": "${workspaceFolder}/.vscode/mise-tools/java",
```

Fixes #806
Fixes #1486

Solved by allowing using `${workspaceFolder}` followed by relative path to project dir:
Fixes #1070
Fixes #1357
Fixes #4318