### PR TITLE
Add restart IntelliSense command for active file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1814,6 +1814,11 @@
         "category": "Java"
       },
       {
+        "command": "java.runtime.restartIntellisense",
+        "title": "Restart IntelliSense for Active File",
+        "category": "Java"
+      },
+      {
         "command": "java.action.filesExplorerPasteAction",
         "title": "%java.action.filesExplorerPasteAction%",
         "category": "Java"
@@ -1941,6 +1946,11 @@
           "command": "java.action.showTypeHierarchy",
           "when": "javaLSReady && editorTextFocus && editorLangId == java",
           "group": "0_navigation@3"
+        },
+        {
+          "command": "java.runtime.restartIntellisense",
+          "when": "editorTextFocus && editorLangId == java",
+          "group": "navigation@91"
         }
       ],
       "commandPalette": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -284,6 +284,7 @@ export namespace Commands {
      * Command to restart the language server.
      */
 	export const RESTART_LANGUAGE_SERVER = 'java.server.restart';
+    export const RESTART_INTELLISENSE_FOR_ACTIVE_FILE = 'java.runtime.restartIntellisense';
 
     export const LEARN_MORE_ABOUT_REFACTORING = '_java.learnMoreAboutRefactorings';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1270,6 +1270,13 @@ function registerRestartJavaLanguageServerCommand(context: ExtensionContext) {
 				break;
 		}
 	}));
+    context.subscriptions.push(commands.registerCommand(Commands.RESTART_INTELLISENSE_FOR_ACTIVE_FILE, async () => {
+        const editor = window.activeTextEditor;
+        if (!editor || editor.document.languageId !== "java") {
+            return;
+        }
+        await commands.executeCommand(Commands.RESTART_LANGUAGE_SERVER);
+    }));
 }
 
 function escapeSnippetLiterals(value: string): string {

--- a/test/lightweight-mode-suite/extension.test.ts
+++ b/test/lightweight-mode-suite/extension.test.ts
@@ -26,6 +26,7 @@ suite('Java Language Extension - LightWeight', () => {
 				Commands.SWITCH_SERVER_MODE,
 				Commands.OPEN_FILE,
 				Commands.CLEAN_SHARED_INDEXES,
+				Commands.RESTART_INTELLISENSE_FOR_ACTIVE_FILE,
 				Commands.RESTART_LANGUAGE_SERVER,
 				Commands.FILESEXPLORER_ONPASTE,
 				Commands.CHANGE_JAVA_SEARCH_SCOPE,


### PR DESCRIPTION
Fixes #4293
## Summary

This PR adds a new editor context menu action **“Restart IntelliSense for Active File”** for Java files.

The command appears when right-clicking inside a Java editor and reuses the existing Java language server restart flow to refresh IntelliSense.

## Changes

* Added a new command: `java.runtime.restartIntellisense`
* Added command palette contribution in `package.json`
* Added editor context menu contribution for Java files
* Registered the command in `src/extension.ts`
* Reused the existing `java.server.restart` command instead of duplicating restart logic
* Scoped the action to the active Java editor only

## Testing

* Ran `npm run compile` successfully
* Verified command registration in:

  * `src/commands.ts`
  * `src/extension.ts`
  * `package.json`
* Launched Extension Development Host
* Opened a `.java` file
* Verified the context menu shows **Restart IntelliSense for Active File**
* Verified the command reuses the existing restart language server flow

## Notes

Since the Java language server operates at the workspace level, this command is exposed only for the active Java editor while internally reusing the existing workspace-level restart behavior.
