### PR TITLE
Fix command 'java.dashboard.refresh' not found

### DIFF
--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -35,7 +35,7 @@ class DashboardPanel {
 		}));
 		this.setWebviewMessageListener();
 		this.webView.html = this.getWebviewContent();
-		
+
 
 		this.disposables.push(vscode.commands.registerCommand('java.dashboard.revealFileInOS', async (arg: { path: string }) => {
 			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(arg.path));
@@ -146,7 +146,7 @@ class DashboardPanel {
 export namespace Dashboard {
     export function initialize(context: vscode.ExtensionContext): void {
         console.log('registering dashboard webview provider');
-        
+
         let dashboardPanel: DashboardPanel | undefined = undefined;
         let webviewPanel: vscode.WebviewPanel | undefined = undefined;
 
@@ -173,12 +173,12 @@ export namespace Dashboard {
                     retainContextWhenHidden: true,
                     localResourceRoots: [context.extensionUri],
                 });
-                
+
                 webviewPanel.iconPath = Uri.file(path.join(context.extensionPath, 'icons', 'icon128.png'));
                 dashboardPanel = new DashboardPanel(webviewPanel.webview, context);
 
                 webviewPanel.onDidDispose(() => {
-                    dashboardPanel?.dispose(); 
+                    dashboardPanel?.dispose();
                     dashboardPanel = undefined;
                     webviewPanel = undefined;
                     vscode.commands.executeCommand('setContext', 'java:dashboard', false);

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -35,20 +35,10 @@ class DashboardPanel {
 		}));
 		this.setWebviewMessageListener();
 		this.webView.html = this.getWebviewContent();
-		this.disposables.push(vscode.commands.registerCommand('java.dashboard.refresh', async () => {
-			this.refreshLSInfo();
-		}));
+		
 
 		this.disposables.push(vscode.commands.registerCommand('java.dashboard.revealFileInOS', async (arg: { path: string }) => {
 			await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(arg.path));
-		}));
-
-		this.disposables.push(vscode.commands.registerCommand('java.dashboard.dumpState', async () => {
-			const doc = await vscode.workspace.openTextDocument({
-				language: 'json',
-				content: JSON.stringify(currentState, null, 2)
-			});
-			vscode.window.showTextDocument(doc);
 		}));
 	}
 
@@ -134,7 +124,7 @@ class DashboardPanel {
 	`;
 	}
 
-	private async refreshLSInfo(): Promise<void> {
+	public async refreshLSInfo(): Promise<void> {
 		if (!this.webView) {
 			return;
 		}
@@ -154,32 +144,49 @@ class DashboardPanel {
 }
 
 export namespace Dashboard {
-	export function initialize(context: vscode.ExtensionContext): void {
-		console.log('registering dashboard webview provider');
-		let dashboardPanel: DashboardPanel;
-		let webviewPanel: vscode.WebviewPanel;
+    export function initialize(context: vscode.ExtensionContext): void {
+        console.log('registering dashboard webview provider');
+        
+        let dashboardPanel: DashboardPanel | undefined = undefined;
+        let webviewPanel: vscode.WebviewPanel | undefined = undefined;
 
-		context.subscriptions.push(vscode.commands.registerCommand(Commands.OPEN_JAVA_DASHBOARD, async () => {
-			if (!dashboardPanel) {
-				webviewPanel = vscode.window.createWebviewPanel('java.dashboard', 'Java Dashboard', vscode.ViewColumn.Active, {
-					enableScripts: true,
-					enableCommandUris: true,
-					retainContextWhenHidden: true,
-					localResourceRoots: [context.extensionUri],
-				});
-				webviewPanel.iconPath = Uri.file(path.join(context.extensionPath, 'icons', 'icon128.png'));
-				dashboardPanel = new DashboardPanel(webviewPanel.webview, context);
+        context.subscriptions.push(vscode.commands.registerCommand('java.dashboard.refresh', async () => {
+            await vscode.commands.executeCommand(Commands.OPEN_JAVA_DASHBOARD);
+            if (dashboardPanel) {
+                await dashboardPanel.refreshLSInfo();
+            }
+        }));
 
-				webviewPanel.onDidDispose(() => {
-					dashboardPanel.dispose();
-					dashboardPanel = undefined;
-					webviewPanel = undefined;
-					vscode.commands.executeCommand('setContext', 'java:dashboard', false);
-				}, undefined, context.subscriptions);
-			} else {
-				webviewPanel.reveal();
-			}
-		}));
-		console.log('registered dashboard webview provider');
-	}
+        context.subscriptions.push(vscode.commands.registerCommand('java.dashboard.dumpState', async () => {
+            const doc = await vscode.workspace.openTextDocument({
+                language: 'json',
+                content: JSON.stringify(currentState, null, 2)
+            });
+            vscode.window.showTextDocument(doc);
+        }));
+
+        context.subscriptions.push(vscode.commands.registerCommand(Commands.OPEN_JAVA_DASHBOARD, async () => {
+            if (!dashboardPanel || !webviewPanel) {
+                webviewPanel = vscode.window.createWebviewPanel('java.dashboard', 'Java Dashboard', vscode.ViewColumn.Active, {
+                    enableScripts: true,
+                    enableCommandUris: true,
+                    retainContextWhenHidden: true,
+                    localResourceRoots: [context.extensionUri],
+                });
+                
+                webviewPanel.iconPath = Uri.file(path.join(context.extensionPath, 'icons', 'icon128.png'));
+                dashboardPanel = new DashboardPanel(webviewPanel.webview, context);
+
+                webviewPanel.onDidDispose(() => {
+                    dashboardPanel?.dispose(); 
+                    dashboardPanel = undefined;
+                    webviewPanel = undefined;
+                    vscode.commands.executeCommand('setContext', 'java:dashboard', false);
+                }, undefined, context.subscriptions);
+            } else {
+                webviewPanel.reveal();
+            }
+        }));
+        console.log('registered dashboard webview provider');
+    }
 }

--- a/test/lightweight-mode-suite/extension.test.ts
+++ b/test/lightweight-mode-suite/extension.test.ts
@@ -8,7 +8,7 @@ suite('Java Language Extension - LightWeight', () => {
 
 	suiteSetup(async function() {
 		getJavaConfiguration().update('server.launchMode', 'LightWeight');
-		await extensions.getExtension('redhat.java').activate();
+		await extensions.getExtension('redhat.java')!.activate();
 	});
 
 	test('should register syntax-only java commands', () => {
@@ -30,6 +30,8 @@ suite('Java Language Extension - LightWeight', () => {
 				Commands.FILESEXPLORER_ONPASTE,
 				Commands.CHANGE_JAVA_SEARCH_SCOPE,
 				Commands.OPEN_JAVA_DASHBOARD,
+				'java.dashboard.dumpState',
+                'java.dashboard.refresh',
 				Commands.ADD_JAVA_RUNTIME
 			].sort();
 			const foundJavaCommands = commands.filter((value) => {


### PR DESCRIPTION
## Summary

Fixes the issue where running **Java: Refresh** from the command palette fails with:

`command 'java.dashboard.refresh' not found`

## Root cause

The dashboard refresh command was registered only after the Java Dashboard panel was opened.

## Fix

* moved dashboard refresh command registration to initialization
* ensured the dashboard is opened before refresh logic runs
* preserved refresh behavior when the panel is already open

## Validation

* launched extension development host
* ran `Java: Refresh` directly from command palette
* verified dashboard opens successfully
* reran refresh to confirm no duplicate tab and no command errors

Fixes #4381
