### PR TITLE
Update bundled JRE to Java 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           # Package for each platform (only downloads JDK and creates VSIX, no recompilation)
           platforms=("win32-x64" "win32-arm64" "linux-x64" "linux-arm64" "darwin-x64" "darwin-arm64")
           for platform in ${platforms[@]}; do
-            npm run download-jre -- --target ${platform} --javaVersion 21
+            npm run download-jre -- --target ${platform} --javaVersion 25
             SKIP_WEBPACK=true vsce package ${{ env.publishPreReleaseFlag }} --target ${platform} -o java-${platform}-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}.vsix
           done
 

--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -113,7 +113,7 @@ Commands:
     repo-fix                            Fix package-lock.json registry references
 
 Examples:
-  node scripts/index.js download-jre --target darwin-x64 --javaVersion 21
+  node scripts/index.js download-jre --target darwin-x64 --javaVersion 25
   node scripts/index.js build-or-download
   node scripts/index.js watch-server
             `);

--- a/scripts/jre.mjs
+++ b/scripts/jre.mjs
@@ -8,7 +8,7 @@ import { downloadFile, getScriptDir, extractTarGz, handleError, setupMainExecuti
 
 const dirname = getScriptDir();
 
-const LATEST_JRE = 21;
+const LATEST_JRE = 25;
 
 const platformMapping = {
     "linux-arm64": "linux-aarch64",


### PR DESCRIPTION
## Summary

Updates the bundled JustJ runtime from Java 21 to Java 25.

### Changes

* Updated default bundled JRE version in `scripts/jre.mjs`
* Updated release workflow packaging step to download Java 25 runtime
* Updated CLI usage example in `scripts/index.mjs`

## Validation

* Verified `LATEST_JRE` now points to 25
* Verified release workflow packages VSIX with `--javaVersion 25`
* Verified CLI usage example reflects Java 25

Fixes #4353
