### PR TITLE
Reduce excessive whitespace in large Javadoc hover documentation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,8 +125,8 @@ export function fixJdtLinksInDocumentation(oldDocumentation: MarkdownString): Ma
 		return `${group1}${uri})`;
 	});
 
-	// Normalize excessive whitespace in large Javadoc content to help 
-	// large hovers render more completely within VS Code's limits.
+	// Normalize excessive whitespace in large Javadoc content
+	// so large hover popups render more compactly.
 	content = content
 		.replace(/[ \t]{2,}/g, ' ')  // Collapse multiple spaces/tabs to a single space
 		.replace(/\n{3,}/g, '\n\n') // Collapse 3 or more newlines to exactly 2

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,11 +120,19 @@ const REPLACE_JDT_LINKS_PATTERN: RegExp = /(\[(?:[^\]])+\]\()(jdt:\/\/(?:(?:(?:\
  * @returns the documentation with fixed links
  */
 export function fixJdtLinksInDocumentation(oldDocumentation: MarkdownString): MarkdownString {
-	const newContent: string = oldDocumentation.value.replace(REPLACE_JDT_LINKS_PATTERN, (_substring, group1, group2) => {
+	let content: string = oldDocumentation.value.replace(REPLACE_JDT_LINKS_PATTERN, (_substring, group1, group2) => {
 		const uri = `command:${Commands.OPEN_FILE}?${encodeURI(JSON.stringify([encodeURIComponent(group2)]))}`;
 		return `${group1}${uri})`;
 	});
-	const mdString = new MarkdownString(newContent);
+
+	// Normalize excessive whitespace in large Javadoc content to help 
+	// large hovers render more completely within VS Code's limits.
+	content = content
+		.replace(/[ \t]{2,}/g, ' ')  // Collapse multiple spaces/tabs to a single space
+		.replace(/\n{3,}/g, '\n\n') // Collapse 3 or more newlines to exactly 2
+		.trim();
+
+	const mdString = new MarkdownString(content);
 	mdString.isTrusted = true;
 	return mdString;
 }


### PR DESCRIPTION
## Summary

This PR reduces excessive whitespace in large Javadoc hover and completion documentation.

Long Javadoc content such as `java.util.regex.Pattern` preserved repeated spaces, tabs, and excessive blank lines, which inflated the rendered markdown size and caused large hover popups to waste vertical space.

## Changes

* collapse repeated spaces/tabs into a single space
* collapse 3+ consecutive newlines into standard markdown paragraph spacing
* trim leading/trailing whitespace
* preserve existing `jdt://` link rewriting behavior

## Validation

Tested with `java.util.regex.Pattern` hover, especially the **Quotation**, **Boundary matchers**, and **Special constructs** sections that previously showed large whitespace gaps.

The hover now renders more compactly and allows significantly more regex constructs to be visible in the same viewport.

 fixes# #4219