### PR TITLE
Fix #3210: map decorator token to annotation scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,9 @@
           "annotation": [
             "storage.type.annotation.java"
           ],
+          "decorator": [
+            "storage.type.annotation.java"
+          ],
           "annotationMember": [
             "entity.name.annotationMember.java",
             "constant.other.key.java"


### PR DESCRIPTION
Decorator semantic tokens are now emitted by JDT LS as part of #3210.

This change maps the `decorator` semantic token to the existing Java annotation TextMate scope (`storage.type.annotation.java`) so that annotations continue to receive consistent coloring across VS Code themes.

Verified using "Developer: Inspect Editor Tokens and Scopes", where `@Override` is reported as a `decorator` semantic token and resolves to the annotation scope.