### PR TITLE
Fix #4426: preserve JDK_HOME priority when sorting JDKs

### DIFF
--- a/src/jdkUtils.ts
+++ b/src/jdkUtils.ts
@@ -60,7 +60,7 @@ export async function listJdks(force?: boolean): Promise<IJavaRuntime[]> {
  * 4. Others
  */
 export function sortJdksBySource(jdks: IJavaRuntime[]) {
-	const rankedJdks = jdks as Array<IJavaRuntime & { rank: number }>;
+	const rankedJdks = jdks as Array<IJavaRuntime & { rank?: number }>;
 	const env: string[] = ["JDK_HOME", "JAVA_HOME", "PATH"];
 	const jdkManagers: string[] = ["SDKMAN", "jEnv", "jabba", "asdf"];
 	for (const jdk of rankedJdks) {
@@ -72,7 +72,7 @@ export function sortJdksBySource(jdks: IJavaRuntime[]) {
 			}
 		}
 
-		if (jdk.rank) {
+		if (typeof jdk.rank === "number") {
 			continue;
 		}
 

--- a/test/standard-mode-suite/utils.test.ts
+++ b/test/standard-mode-suite/utils.test.ts
@@ -2,8 +2,9 @@
 
 import * as assert from 'assert';
 import { getJavaConfiguration, getBuildFilePatterns, getInclusionPatternsFromNegatedExclusion, getExclusionGlob, convertToGlob } from '../../src/utils';
+import { IJavaRuntime } from 'jdk-utils';
 import { WorkspaceConfiguration } from 'vscode';
-import { listJdks } from '../../src/jdkUtils';
+import { listJdks, sortJdksBySource } from '../../src/jdkUtils';
 import { platform } from 'os';
 
 let exclusion: string[];
@@ -117,6 +118,28 @@ suite('Utils Test', () => {
 	test('convertToGlob() - has base patterns', async function () {
 		const result: string = convertToGlob(["**/pom.xml"], ["**/node_modules/test/**"]);
 		assert.equal(result, "{**/node_modules/test/**/**/pom.xml}");
+	});
+
+	test('sortJdksBySource() - ranks JDK_HOME before lower-priority sources', () => {
+		const jdks: IJavaRuntime[] = [
+			{ homedir: "java-home", isJavaHomeEnv: true },
+			{ homedir: "path", isInPathEnv: true },
+			{ homedir: "sdkman", isFromSDKMAN: true },
+			{ homedir: "common" },
+			{ homedir: "gradle", isFromGradle: true },
+			{ homedir: "jdk-home", isJdkHomeEnv: true },
+		];
+
+		sortJdksBySource(jdks);
+
+		assert.deepEqual(jdks.map(jdk => jdk.homedir), [
+			"jdk-home",
+			"java-home",
+			"path",
+			"sdkman",
+			"common",
+			"gradle",
+		]);
 	});
 
 	test('listJdks() - no /usr as Java home on macOS', async function () {


### PR DESCRIPTION
JDK_HOME is assigned the highest source priority in sortJdksBySource(), but the rank check treated rank 0 as if no rank had been assigned. That allowed later source ranking to overwrite the JDK_HOME entry and sort it after lower-priority detected JDKs.

This changes the check to look for an assigned numeric rank and adds a regression test for the ordering.

Fixes #4426