### PR TITLE
Sanitize existing command links from hover Javadocs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsdk": "./node_modules/typescript/lib",
+    "js/ts.tsdk.path": "./node_modules/typescript/lib",
     "git.alwaysSignOff": true,
     "vsicons.presets.angular": false // we want to use the TS server from our node_modules folder to control its version
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,6 +110,7 @@ function getHeapDumpFolderFromSettings(): string {
 }
 
 const REPLACE_JDT_LINKS_PATTERN: RegExp = /(\[(?:[^\]])+\]\()(jdt:\/\/(?:(?:(?:\\\))|([^)]))+))\)/g;
+const EXISTING_COMMAND_PATTERN: RegExp = /\[([^\]]+)\]\(command:[^)]+\)/g;
 
 /**
  * Replace `jdt://` links in the documentation with links that execute the VS Code command required to open the referenced file.
@@ -120,7 +121,11 @@ const REPLACE_JDT_LINKS_PATTERN: RegExp = /(\[(?:[^\]])+\]\()(jdt:\/\/(?:(?:(?:\
  * @returns the documentation with fixed links
  */
 export function fixJdtLinksInDocumentation(oldDocumentation: MarkdownString): MarkdownString {
-	const newContent: string = oldDocumentation.value.replace(REPLACE_JDT_LINKS_PATTERN, (_substring, group1, group2) => {
+	// sanitize existing command: links
+	const sanitizedContent = oldDocumentation.value.replace(EXISTING_COMMAND_PATTERN, (_substring, group1: string, group2) => {
+		return group1;
+	});
+	const newContent: string = sanitizedContent.replace(REPLACE_JDT_LINKS_PATTERN, (_substring, group1, group2) => {
 		const uri = `command:${Commands.OPEN_FILE}?${encodeURI(JSON.stringify([encodeURIComponent(group2)]))}`;
 		return `${group1}${uri})`;
 	});


### PR DESCRIPTION
Replace any existing `command:command.name?param=true` style links in hover Javadoc with the display text for the link.

eg. `[click here](command:command.name?param=true)` becomes `click here`.