### PR TITLE
Fix #3874: preserve escaped commas in snippet literals

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1305,6 +1305,6 @@ function registerRestartJavaLanguageServerCommand(context: ExtensionContext) {
 
 function escapeSnippetLiterals(value: string): string {
     return value
-        .replace(/\\/g, '\\\\')       // Escape backslashes
+        .replace(/\\(?!,)/g, '\\\\')       // Escape backslashes, but preserve escaped commas
         .replace(/\$(?!\{)/g, '\\$'); // Escape $ only if NOT followed by {
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1303,7 +1303,7 @@ function registerRestartJavaLanguageServerCommand(context: ExtensionContext) {
 	}));
 }
 
-function escapeSnippetLiterals(value: string): string {
+export function escapeSnippetLiterals(value: string): string {
     return value
         .replace(/\\(?!,)/g, '\\\\')       // Escape backslashes, but preserve escaped commas
         .replace(/\$(?!\{)/g, '\\$'); // Escape $ only if NOT followed by {

--- a/test/standard-mode-suite/extension.test.ts
+++ b/test/standard-mode-suite/extension.test.ts
@@ -7,6 +7,7 @@ import { Commands } from '../../src/commands';
 import * as java from '../../src/javaServerStarter';
 import * as plugin from '../../src/plugin';
 import * as requirements from '../../src/requirements';
+import { escapeSnippetLiterals } from '../../src/extension';
 
 suite('Java Language Extension - Standard', () => {
 
@@ -232,5 +233,11 @@ suite('Java Language Extension - Standard', () => {
 		// deprecated flags
 		assert(java.hasDebugFlag(['foo', '--debug=1234']));
 		assert(java.hasDebugFlag(['foo', '--debug-brk=1234']));
+	});
+
+	test('should preserve escaped commas in code action snippets', () => {
+		const snippet = '${1|HashMap<Integer\\,Integer>,Map<Integer\\,Integer>|} ${2:x} = new HashMap<Integer, Integer>();';
+
+		assert.equal(escapeSnippetLiterals(snippet), snippet);
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/3874