### PR TITLE
Fix Go to Super Implementation hover link not clickable (#4438)

### DIFF
--- a/src/hoverAction.ts
+++ b/src/hoverAction.ts
@@ -74,7 +74,7 @@ class JavaHoverProvider implements HoverProvider {
         }
 
         const contributed = new MarkdownString(contributedCommands.map((command) => this.convertCommandToMarkdown(command)).join(' | '));
-        contributed.isTrusted = true;
+        contributed.isTrusted = { enabledCommands: contributedCommands.map((command) => command.command) };
         let contents: MarkdownString[] = [ contributed ];
         let range;
         if (serverHover && serverHover.contents) {

--- a/src/providerDispatcher.ts
+++ b/src/providerDispatcher.ts
@@ -211,7 +211,13 @@ export function fixJdtSchemeHoverLinks(hover: Hover): Hover {
 	const newContents: (MarkedString | MarkdownString)[] = [];
 	for (const content of hover.contents) {
 		if (content instanceof MarkdownString) {
-			newContents.push(fixJdtLinksInDocumentation(content));
+			// Skip our own trusted contributed commands (e.g. "Go to Super Implementation");
+			// only sanitize untrusted server-provided Javadoc.
+			if (content.isTrusted) {
+				newContents.push(content);
+			} else {
+				newContents.push(fixJdtLinksInDocumentation(content));
+			}
 		} else {
 			newContents.push(content);
 		}

--- a/test/standard-mode-suite/hoverLinks.test.ts
+++ b/test/standard-mode-suite/hoverLinks.test.ts
@@ -1,0 +1,37 @@
+'use strict';
+
+import * as assert from 'assert';
+import { Hover, MarkdownString } from 'vscode';
+import { fixJdtSchemeHoverLinks } from '../../src/providerDispatcher';
+
+suite('Hover Links Test', () => {
+
+	test('trusted contributed command links are preserved (super implementation)', () => {
+		const contributed = new MarkdownString('[Go to Super Implementation](command:java.action.navigateToSuperImplementation?%5B%5D)');
+		contributed.isTrusted = { enabledCommands: ['java.action.navigateToSuperImplementation'] };
+		const hover = new Hover([contributed]);
+
+		const fixed = fixJdtSchemeHoverLinks(hover);
+		const value = (fixed.contents[0] as MarkdownString).value;
+		assert.ok(value.includes('(command:java.action.navigateToSuperImplementation'), 'contributed command link should not be sanitized');
+	});
+
+	test('untrusted server command links are sanitized', () => {
+		const javadoc = new MarkdownString('[click here](command:evil.command?param=true)');
+		const hover = new Hover([javadoc]);
+
+		const fixed = fixJdtSchemeHoverLinks(hover);
+		const value = (fixed.contents[0] as MarkdownString).value;
+		assert.strictEqual(value, 'click here', 'server command link should be stripped to its label');
+	});
+
+	test('jdt:// links are converted to command links', () => {
+		const javadoc = new MarkdownString('[String](jdt://contents/Foo.class)');
+		const hover = new Hover([javadoc]);
+
+		const fixed = fixJdtSchemeHoverLinks(hover);
+		const value = (fixed.contents[0] as MarkdownString).value;
+		assert.ok(value.includes('(command:'), 'jdt link should be converted to a command link');
+		assert.ok(!value.includes('jdt://'), 'jdt scheme should be replaced');
+	});
+});


### PR DESCRIPTION
The command-link sanitization added in fixJdtSchemeHoverLinks stripped all [label](command:...) links, including the trusted ones the extension contributes (e.g. Go to Super Implementation). Skip sanitizing trusted contributed content; only untrusted server Javadoc is sanitized.

only affected to "Java: Go to Super Implementation" hover.

before
<img width="763" height="397" alt="image" src="https://github.com/user-attachments/assets/f131ebb0-4716-434e-bb67-9b30e63027b4" />

after
<img width="745" height="175" alt="image" src="https://github.com/user-attachments/assets/80c7362c-84b2-466e-b388-9c907820eb7b" />

relative issue #4438 
relative PR #4429