### PR TITLE
Fix #3881: add support for field reference CodeLens

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The following settings are supported:
 * `java.configuration.maven.userSettings` : Path to Maven's user settings.xml.
 * `java.configuration.checkProjectSettingsExclusions`: **Deprecated, please use 'java.import.generatesMetadataFilesAtProjectRoot' to control whether to generate the project metadata files at the project root. And use 'files.exclude' to control whether to hide the project metadata files from the file explorer.** Controls whether to exclude extension-generated project settings files (`.project`, `.classpath`, `.factorypath`, `.settings/`) from the file explorer. Defaults to `false`.
 * `java.referencesCodeLens.enabled` : Enable/disable the references code lenses.
+* `java.referencesCodeLens.includeFields` : Enable/disable the references code lens for fields.
 * `java.implementationCodeLens` : Enable/disable the implementations code lens for the provided categories.
 * `java.signatureHelp.enabled` : Enable/disable signature help support (triggered on `(`).
 * `java.signatureHelp.description.enabled` : Enable/disable to show the description in signature help. Defaults to `false`.

--- a/package.json
+++ b/package.json
@@ -1485,6 +1485,13 @@
             "scope": "window",
             "order": 10
           },
+          "java.referencesCodeLens.includeFields": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable/disable the references code lens for fields.",
+            "scope": "window",
+            "order": 15
+          },
           "java.implementationCodeLens": {
             "type": "string",
             "enum": [


### PR DESCRIPTION
This PR exposes the new java.referencesCodeLens.includeFields setting in the VS Code extension and documents it in the README. It depends on the corresponding eclipse.jdt.ls change that adds the field reference CodeLens support.

Fixes https://github.com/redhat-developer/vscode-java/issues/3881