### PR TITLE
feat: allow java.jdt.ls.java.home to use execution environment names

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -164,6 +164,20 @@ export function getJavaEncoding(): string {
 	return javaEncoding;
 }
 
+function resolveRuntimePathByName(nameOrPath: string | undefined): string | undefined {
+    if (!nameOrPath) {
+        return nameOrPath;
+    }
+    const runtimes = workspace.getConfiguration('java').get<Array<{ name: string; path: string }>>('configuration.runtimes');
+    if (Array.isArray(runtimes)) {
+        const matched = runtimes.find(r => r && r.name === nameOrPath);
+        if (matched && matched.path) {
+            return matched.path;
+        }
+    }
+    return nameOrPath;
+}
+
 export async function checkJavaPreferences(context: ExtensionContext): Promise<{javaHome?: string; preference: string}> {
 	const allow = 'Allow';
 	const disallow = 'Disallow';
@@ -173,6 +187,7 @@ export async function checkJavaPreferences(context: ExtensionContext): Promise<{
 	if (isVerified) {
 		javaHome = getJavaConfiguration().get('jdt.ls.java.home');
 	}
+	javaHome = resolveRuntimePathByName(javaHome);
 	const key = getKey(IS_WORKSPACE_JLS_JDK_ALLOWED, context.storagePath, javaHome);
 	const globalState = context.globalState;
 	if (!isVerified) {
@@ -189,7 +204,7 @@ export async function checkJavaPreferences(context: ExtensionContext): Promise<{
 			isVerified = globalState.get(key);
 		}
 		if (!isVerified) { // java.jdt.ls.java.home from workspace settings is disallowed.
-			javaHome = workspace.getConfiguration().inspect<string>('java.jdt.ls.java.home').globalValue;
+			javaHome = resolveRuntimePathByName(workspace.getConfiguration().inspect<string>('java.jdt.ls.java.home').globalValue);
 		}
 	}
 


### PR DESCRIPTION
### Summary

This change allows `java.jdt.ls.java.home` to accept the name of a configured Java execution environment from `java.configuration.runtimes`, in addition to accepting an absolute JDK path.

### Motivation

Currently, `java.jdt.ls.java.home` expects a filesystem path. If users specify the execution environment name (for example, `"JavaSE-21"`), the value is treated as a path and validation fails.

This change resolves the configured runtime name to its corresponding JDK path before the existing validation logic runs.

### Changes

* Added runtime-name resolution in `checkJavaPreferences()`.
* Preserved existing behavior for absolute JDK paths.
* Left the validation logic in `requirements.ts` unchanged.

### Testing

* Verified that an absolute JDK path continues to work as before.
* Verified that a configured runtime name (for example, `"JavaSE-21"`) is resolved successfully and the Java language server starts normally.