### PR TITLE
Migrate Change Method Signature webview off deprecated webview-ui-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@redhat-developer/vscode-extension-proposals": "0.0.23",
         "@redhat-developer/vscode-redhat-telemetry": "0.10.2",
         "@vscode/codicons": "^0.0.32",
-        "@vscode/webview-ui-toolkit": "1.2.2",
         "chokidar": "^3.5.3",
         "expand-home-dir": "^0.0.3",
         "fmtr": "^1.1.2",
@@ -272,47 +271,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@microsoft/fast-element": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.11.0.tgz",
-      "integrity": "sha512-VKJYMkS5zgzHHb66sY7AFpYv6IfFhXrjQcAyNgi2ivD65My1XOhtjfKez5ELcLFRJfgZNAxvI8kE69apXERTkw=="
-    },
-    "node_modules/@microsoft/fast-foundation": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.47.0.tgz",
-      "integrity": "sha512-EyFuioaZQ9ngjUNRQi8R3dIPPsaNQdUOS+tP0G7b1MJRhXmQWIitBM6IeveQA6ZvXG6H21dqgrfEWlsYrUZ2sw==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.11.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
-      }
-    },
-    "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@microsoft/fast-react-wrapper": {
-      "version": "0.1.48",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz",
-      "integrity": "sha512-9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.9.0",
-        "@microsoft/fast-foundation": "^2.41.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "dependencies": {
-        "exenv-es6": "^1.1.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -966,19 +924,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@vscode/webview-ui-toolkit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.2.2.tgz",
-      "integrity": "sha512-xIQoF4FC3Xh6d7KNKIoIezSiFWYFuf6gQMdDyKueKBFGeKwaHWEn+dY2g3makvvEsNMEDji/woEwvg9QSbuUsw==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.6.2",
-        "@microsoft/fast-foundation": "^2.38.0",
-        "@microsoft/fast-react-wrapper": "^0.1.18"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2370,11 +2315,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
     },
     "node_modules/expand-home-dir": {
       "version": "0.0.3",
@@ -5209,11 +5149,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -2132,7 +2132,6 @@
     "@redhat-developer/vscode-extension-proposals": "0.0.23",
     "@redhat-developer/vscode-redhat-telemetry": "0.10.2",
     "@vscode/codicons": "^0.0.32",
-    "@vscode/webview-ui-toolkit": "1.2.2",
     "chokidar": "^3.5.3",
     "expand-home-dir": "^0.0.3",
     "fmtr": "^1.1.2",

--- a/src/refactoring/changeSignaturePanel.ts
+++ b/src/refactoring/changeSignaturePanel.ts
@@ -116,8 +116,8 @@ export class ChangeSignaturePanel {
       <html lang="en">
         <head>
           <meta charset="utf-8">
-		  <!-- We need the 'unsafe-inline' because of webview UI toolkit setting style attributes -->
-		  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webview.cspSource}; font-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'unsafe-inline';">
+		  <!-- CSS is bundled to a file and loaded via <link>; the codicon font is a data: URL covered by font-src -->
+		  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webview.cspSource}; font-src ${webview.cspSource} data:; style-src ${webview.cspSource};">
           <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
           <meta name="theme-color" content="#000000">
           <title>Change Signature</title>

--- a/src/webview/changeSignature/App.css
+++ b/src/webview/changeSignature/App.css
@@ -4,6 +4,9 @@ main {
 	max-width: 600px;
 	margin-left: auto;
 	margin-right: auto;
+	color: var(--vscode-foreground);
+	font-family: var(--vscode-font-family);
+	font-size: var(--vscode-font-size);
 }
 
 .section {
@@ -13,18 +16,18 @@ main {
 .section-columns {
 	display: flex;
 	width: 100%;
-	padding-left: calc(var(--design-unit) * 1px);
+	padding-left: 4px;
 }
 
 .text-title {
 	margin: 0;
-	height: calc(var(--input-height) * 0.8px);
+	height: 21px;
 }
 
 .text-title-content {
-	padding: 0 0 0 calc(var(--design-unit) * 1px);
+	padding: 0 0 0 4px;
 	margin: 0.5rem 0 0 0;
-	height: calc(var(--input-height) * 0.8px);
+	height: 21px;
 }
 
 .header-left {
@@ -51,6 +54,91 @@ main {
 	box-sizing: border-box;
 }
 
+/* Form controls -------------------------------------------------------- */
+
+.vsc-textfield,
+.vsc-dropdown {
+	box-sizing: border-box;
+	width: 100%;
+	height: 26px;
+	padding: 2px 6px;
+	color: var(--vscode-input-foreground);
+	background-color: var(--vscode-input-background);
+	border: 1px solid var(--vscode-dropdown-border, var(--vscode-input-border, transparent));
+	border-radius: 2px;
+	font-family: inherit;
+	font-size: inherit;
+	outline: none;
+}
+
+.vsc-textfield:focus,
+.vsc-dropdown:focus {
+	border-color: var(--vscode-focusBorder);
+}
+
+.vsc-dropdown {
+	cursor: pointer;
+}
+
+/* Buttons -------------------------------------------------------------- */
+
+.btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	height: 26px;
+	padding: 0 11px;
+	border: 1px solid var(--vscode-button-border, transparent);
+	border-radius: 2px;
+	font-family: inherit;
+	font-size: inherit;
+	cursor: pointer;
+	outline: none;
+}
+
+.btn:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.btn:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+
+.btn-primary {
+	color: var(--vscode-button-foreground);
+	background-color: var(--vscode-button-background);
+}
+
+.btn-primary:hover:not(:disabled) {
+	background-color: var(--vscode-button-hoverBackground);
+}
+
+.btn-secondary {
+	color: var(--vscode-button-secondaryForeground);
+	background-color: var(--vscode-button-secondaryBackground);
+}
+
+.btn-secondary:hover:not(:disabled) {
+	background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.btn-icon {
+	height: 22px;
+	width: 22px;
+	padding: 0;
+	color: var(--vscode-icon-foreground);
+	background-color: transparent;
+	border: none;
+	border-radius: 4px;
+}
+
+.btn-icon:hover:not(:disabled) {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
 .vsc-button-left {
 	float: left;
 	margin: 0 0.5rem 0.5rem 0;
@@ -66,80 +154,150 @@ main {
 }
 
 .bottom-buttons {
-	padding: 0 0 0 calc(var(--design-unit) * 1px);
+	padding: 0 0 0 4px;
 	margin: 0.5rem 0 0 0;
+	overflow: hidden;
 }
 
 .preview {
-	padding: 0 0 0 calc(var(--design-unit) * 1px);
+	box-sizing: border-box;
 	margin: 0 0 0.5rem 0;
 	width: 99%;
+	color: var(--vscode-input-foreground);
+	background-color: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, transparent);
+	border-radius: 2px;
+	padding: 4px 6px;
+	font-family: var(--vscode-editor-font-family, monospace);
+	font-size: inherit;
+	resize: vertical;
+	outline: none;
 }
+
+.preview:focus {
+	border-color: var(--vscode-focusBorder);
+}
+
+/* Tabs ----------------------------------------------------------------- */
 
 .parameters-panel {
 	margin: 0;
 	width: calc(99% + 4px);
 }
 
+.tabs {
+	display: flex;
+	border-bottom: 1px solid var(--vscode-panel-border, var(--vscode-editorGroup-border));
+}
+
+.tab {
+	padding: 6px 10px;
+	background-color: transparent;
+	border: none;
+	border-bottom: 1px solid transparent;
+	color: var(--vscode-panelTitle-inactiveForeground, var(--vscode-foreground));
+	font-family: inherit;
+	font-size: inherit;
+	cursor: pointer;
+	outline: none;
+}
+
+.tab:hover {
+	color: var(--vscode-panelTitle-activeForeground, var(--vscode-foreground));
+}
+
+.tab-active {
+	color: var(--vscode-panelTitle-activeForeground, var(--vscode-foreground));
+	border-bottom-color: var(--vscode-panelTitle-activeBorder, var(--vscode-focusBorder));
+}
+
+.tab:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
 .parameters-view {
-	padding: 0 0 0 calc(var(--design-unit) * 1px);
+	padding: 0 0 0 4px;
+	display: flex;
 	flex-direction: column;
 }
 
-.parameter-cell {
-	padding-left: 0;
-	pointer-events: none;
+.parameters-view[hidden] {
+	display: none;
+}
+
+/* Table ---------------------------------------------------------------- */
+
+.parameter-table {
+	width: 100%;
+	border-collapse: collapse;
+	table-layout: fixed;
+}
+
+.parameter-table th,
+.parameter-table td {
+	text-align: left;
+	vertical-align: middle;
+	padding: 2px 4px;
+	height: 26px;
+	box-sizing: border-box;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .parameter-cell-title {
-	padding-left: 0;
-}
-
-.parameter-cell-title:focus {
-	border-color: var(--vscode-keybindingTable-headerBackground);
-	background-color: inherit;
-	color: inherit;
+	padding-left: 4px;
+	font-weight: 600;
 }
 
 .parameter-cell-header {
 	background-color: var(--vscode-keybindingTable-headerBackground);
 }
 
+.parameter-cell {
+	padding-left: 4px;
+}
+
 .parameter-cell-edit {
-	padding-left: 0;
+	padding: 0 4px;
 	background-color: var(--vscode-input-background);
 }
 
-.parameter-cell-edit-button {
+.parameter-input {
+	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
 	padding: 0;
 	border: 0;
-	display: flex;
-	justify-content: right;
-	background-color: var(--vscode-input-background);
+	outline: none;
+	background-color: transparent;
+	color: var(--vscode-input-foreground);
+	font-family: inherit;
+	font-size: inherit;
 }
 
+.parameter-cell-edit-button,
 .parameter-cell-button {
 	padding: 0;
 	border: 0;
-	display: flex;
-	justify-content: right;
+	text-align: right;
+	width: 1%;
+	white-space: nowrap;
 }
 
-.parameter-cell-button:focus {
-	background-color: inherit;
-}
-
-.parameter-cell-button:active {
-	background-color: inherit;
+.parameter-cell-edit-button {
+	background-color: var(--vscode-input-background);
 }
 
 .table-buttons {
 	display: inline-flex;
+	justify-content: flex-end;
 }
 
 .table-buttons-edit {
 	display: inline-flex;
-	background-color: var(--vscode-editor-background);
+	justify-content: flex-end;
 }
 
 .table-buttons-edit-ok {
@@ -151,7 +309,18 @@ main {
 	margin: 0;
 }
 
+/* Checkbox ------------------------------------------------------------- */
+
 .delegate {
-	padding: 0 0 0 calc(var(--design-unit) * 1px);
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 0 0 0 4px;
 	margin: 0.5rem 0 0.5rem 0;
+	cursor: pointer;
+}
+
+.delegate input[type="checkbox"] {
+	accent-color: var(--vscode-checkbox-background);
+	cursor: pointer;
 }

--- a/src/webview/changeSignature/App.tsx
+++ b/src/webview/changeSignature/App.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/prefer-for-of */
-import { VSCodeButton, VSCodeTextField, VSCodeDropdown, VSCodeOption, VSCodeCheckbox, VSCodePanels, VSCodePanelTab, VSCodePanelView, VSCodeDataGrid, VSCodeDataGridCell, VSCodeDataGridRow, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react";
 import "./App.css";
 import React from "react";
 import { vscode } from "../vscodeApiWrapper";
@@ -8,10 +7,13 @@ import cloneDeep from "lodash/cloneDeep";
 
 type State = UIState & Metadata;
 
+type ActiveTab = "parameters" | "exceptions";
+
 interface UIState {
 	focusRow: number;
 	editParameterRow: number;
 	editExceptionRow: number;
+	activeTab: ActiveTab;
 }
 
 interface Metadata {
@@ -50,6 +52,7 @@ export class App extends React.Component<{}, State> {
 			focusRow: -1,
 			editParameterRow: -1,
 			editExceptionRow: -1,
+			activeTab: "parameters",
 			methodIdentifier: undefined,
 			isDelegate: false,
 			methodName: undefined,
@@ -91,6 +94,10 @@ export class App extends React.Component<{}, State> {
 			this.setState({
 				methodName: event.target.value
 			});
+		} else if (id === "delegate") {
+			this.setState({
+				isDelegate: event.target.checked
+			});
 		}
 		return;
 	};
@@ -121,7 +128,11 @@ export class App extends React.Component<{}, State> {
 		if (!id) {
 			return;
 		}
-		if (id === "refactor") {
+		if (id === "tab-parameters") {
+			this.setState({ activeTab: "parameters", focusRow: -1 });
+		} else if (id === "tab-exceptions") {
+			this.setState({ activeTab: "exceptions", focusRow: -1 });
+		} else if (id === "refactor") {
 			this.doRefactor(false);
 		} else if (id === "preview") {
 			this.doRefactor(true);
@@ -175,11 +186,13 @@ export class App extends React.Component<{}, State> {
 				editParameterRow: selectedRowNumber,
 				editExceptionRow: -1,
 				focusRow: -1,
+			}, () => {
+				const elementToSelect = document.getElementById(`parameterType-${selectedRowNumber}`) as HTMLInputElement | null;
+				if (elementToSelect) {
+					elementToSelect.focus();
+					elementToSelect.select();
+				}
 			});
-			const elementToSelect = document.getElementById(`parameterType-${selectedRowNumber}`);
-			if (elementToSelect) {
-				elementToSelect.focus();
-			}
 		} else if (id.startsWith("editException")) {
 			const selectedRowNumber: number | undefined = this.getSelectedRowNumber(id);
 			if (selectedRowNumber === undefined) {
@@ -189,11 +202,13 @@ export class App extends React.Component<{}, State> {
 				editParameterRow: -1,
 				editExceptionRow: selectedRowNumber,
 				focusRow: -1,
+			}, () => {
+				const elementToSelect = document.getElementById(`exceptionType-${selectedRowNumber}`) as HTMLInputElement | null;
+				if (elementToSelect) {
+					elementToSelect.focus();
+					elementToSelect.select();
+				}
 			});
-			const elementToSelect = document.getElementById(`exceptionType-${selectedRowNumber}`);
-			if (elementToSelect) {
-				elementToSelect.focus();
-			}
 		} else if (id.startsWith("upParameter")) {
 			const selectedRowNumber: number | undefined = this.getSelectedRowNumber(id);
 			if (selectedRowNumber === undefined) {
@@ -244,29 +259,25 @@ export class App extends React.Component<{}, State> {
 					return i !== selectedRowNumber;
 				})
 			});
-		} else if (id === "delegate") {
-			this.setState({
-				isDelegate: event.target.checked
-			});
 		} else if (id.startsWith("confirmParameter")) {
 			const selectedRowNumber: number | undefined = this.getSelectedRowNumber(id);
 			if (selectedRowNumber === undefined) {
 				return;
 			}
-			const parameterType = document.getElementById(`parameterType-${selectedRowNumber}`);
-			const parameterName = document.getElementById(`parameterName-${selectedRowNumber}`);
-			const parameterDefault = this.isDefaultValueEditable(selectedRowNumber) ? document.getElementById(`parameterDefault-${selectedRowNumber}`) : undefined;
+			const parameterType = document.getElementById(`parameterType-${selectedRowNumber}`) as HTMLInputElement | null;
+			const parameterName = document.getElementById(`parameterName-${selectedRowNumber}`) as HTMLInputElement | null;
+			const parameterDefault = this.isDefaultValueEditable(selectedRowNumber) ? document.getElementById(`parameterDefault-${selectedRowNumber}`) as HTMLInputElement | null : undefined;
 			this.setState({
 				parameters: this.state.parameters.map((e, i) => {
 					if (i === selectedRowNumber) {
-						if (parameterType?.outerText) {
-							e.type = parameterType.outerText;
+						if (parameterType?.value) {
+							e.type = parameterType.value;
 						}
-						if (parameterName?.outerText) {
-							e.name = parameterName.outerText;
+						if (parameterName?.value) {
+							e.name = parameterName.value;
 						}
-						if (parameterDefault?.outerText) {
-							e.defaultValue = parameterDefault.outerText;
+						if (parameterDefault?.value) {
+							e.defaultValue = parameterDefault.value;
 						}
 					}
 					return e;
@@ -280,20 +291,6 @@ export class App extends React.Component<{}, State> {
 			if (selectedRowNumber === undefined) {
 				return;
 			}
-			const parameterType = document.getElementById(`parameterType-${selectedRowNumber}`);
-			if (parameterType) {
-				parameterType.textContent = this.state.parameters[selectedRowNumber].type;
-			}
-			const parameterName = document.getElementById(`parameterName-${selectedRowNumber}`);
-			if (parameterName) {
-				parameterName.textContent = this.state.parameters[selectedRowNumber].name;
-			}
-			if (this.isDefaultValueEditable(selectedRowNumber)) {
-				const parameterDefault = document.getElementById(`parameterDefault-${selectedRowNumber}`);
-				if (parameterDefault) {
-					parameterDefault.textContent = this.state.parameters[selectedRowNumber].defaultValue;
-				}
-			}
 			this.setState({
 				editParameterRow: -1,
 				editExceptionRow: -1,
@@ -304,12 +301,12 @@ export class App extends React.Component<{}, State> {
 			if (selectedRowNumber === undefined) {
 				return;
 			}
-			const exceptionType = document.getElementById(`exceptionType-${selectedRowNumber}`);
+			const exceptionType = document.getElementById(`exceptionType-${selectedRowNumber}`) as HTMLInputElement | null;
 			this.setState({
 				exceptions: this.state.exceptions.map((e, i) => {
 					if (i === selectedRowNumber) {
-						if (exceptionType?.outerText) {
-							e.type = exceptionType.outerText;
+						if (exceptionType?.value) {
+							e.type = exceptionType.value;
 						}
 					}
 					return e;
@@ -322,10 +319,6 @@ export class App extends React.Component<{}, State> {
 			const selectedRowNumber: number | undefined = this.getSelectedRowNumber(id);
 			if (selectedRowNumber === undefined) {
 				return;
-			}
-			const exceptionType = document.getElementById(`exceptionType-${selectedRowNumber}`);
-			if (exceptionType) {
-				exceptionType.textContent = this.state.exceptions[selectedRowNumber].type;
 			}
 			this.setState({
 				editParameterRow: -1,
@@ -361,7 +354,9 @@ export class App extends React.Component<{}, State> {
 	};
 
 	onMouseEnter = (event: any) => {
-		const id = event.target.id as string;
+		const currentTarget = event.currentTarget as HTMLElement | null;
+		const target = event.target as HTMLElement | null;
+		const id = currentTarget?.id || target?.id || currentTarget?.closest("tr")?.id || target?.closest("tr")?.id || "";
 		if (id.includes("Header")) {
 			this.setState({
 				focusRow: -1
@@ -383,7 +378,6 @@ export class App extends React.Component<{}, State> {
 	};
 
 	componentDidMount(): void {
-		this.setTextAreaCursorStyle();
 		window.addEventListener("message", this.handleMessage);
 		vscode.postMessage({
 			command: "webviewReady"
@@ -410,19 +404,6 @@ export class App extends React.Component<{}, State> {
 			: o1 === o2;
 	};
 
-	/**
-	 * Set the cursor style of the text area to text. Since the text area is
-	 * inside a shadow DOM, we need to add a style element to the shadow DOM.
-	 */
-	setTextAreaCursorStyle(): void {
-		const host = document.getElementById("textArea");
-		if (host?.shadowRoot) {
-			const style = document.createElement('style');
-			style.innerHTML = '.control { cursor: text !important; }';
-			host.shadowRoot.appendChild(style);
-		}
-	}
-
 	isDefaultValueEditable = (row: number) => {
 		return this.state.parameters[row].originalIndex === -1;
 	};
@@ -431,54 +412,69 @@ export class App extends React.Component<{}, State> {
 		return this.isDefaultValueEditable(row) ? this.state.parameters[row].defaultValue : "-";
 	};
 
+	/**
+	 * Render a table cell whose value can be edited. When editing, a real
+	 * <input> control is rendered so that the typed text is visibly rendered
+	 * and read back reliably via its value (see redhat-developer/vscode-java#4417).
+	 */
+	renderEditableCell = (id: string, value: string, editing: boolean, editable: boolean) => {
+		return <td onMouseEnter={this.onMouseEnter} className={`${editing ? "parameter-cell-edit" : "parameter-cell"}`}>
+			{editable
+				? <input id={id} className={"parameter-input"} defaultValue={value} spellCheck={false} autoComplete={"off"} />
+				: <span id={id}>{value}</span>}
+		</td>;
+	};
+
 	generateParameterDataGridRow = (row: number) => {
-		return <VSCodeDataGridRow onMouseEnter={this.onMouseEnter} id={`parameterRow-${row}`} key={`parameterRow-${row}`}>
-			<VSCodeDataGridCell onMouseEnter={this.onMouseEnter} className={`${row === this.state.editParameterRow ? "parameter-cell-edit" : "parameter-cell"}`} id={`parameterType-${row}`} contentEditable={row === this.state.editParameterRow ? "true" : "false"} suppressContentEditableWarning={true} gridColumn={"1"}>{this.state.parameters[row].type}</VSCodeDataGridCell>
-			<VSCodeDataGridCell onMouseEnter={this.onMouseEnter} className={`${row === this.state.editParameterRow ? "parameter-cell-edit" : "parameter-cell"}`} id={`parameterName-${row}`} contentEditable={row === this.state.editParameterRow ? "true" : "false"} suppressContentEditableWarning={true} gridColumn={"2"}>{this.state.parameters[row].name}</VSCodeDataGridCell>
-			<VSCodeDataGridCell onMouseEnter={this.onMouseEnter} className={`${row === this.state.editParameterRow ? "parameter-cell-edit" : "parameter-cell"}`} id={`parameterDefault-${row}`} contentEditable={row === this.state.editParameterRow && this.isDefaultValueEditable(row) ? "true" : "false"} suppressContentEditableWarning={true} gridColumn={"3"}>{this.getDefaultValue(row)}</VSCodeDataGridCell>
-			<VSCodeDataGridCell onMouseEnter={this.onMouseEnter} className={`${row === this.state.editParameterRow ? "parameter-cell-edit-button" : "parameter-cell-button"}`} id={`parameterButton-${row}`} gridColumn={"4"}>
-				{row === this.state.editParameterRow ?
+		const editing = row === this.state.editParameterRow;
+		return <tr onMouseEnter={this.onMouseEnter} id={`parameterRow-${row}`} key={`parameterRow-${row}`}>
+			{this.renderEditableCell(`parameterType-${row}`, this.state.parameters[row].type, editing, editing)}
+			{this.renderEditableCell(`parameterName-${row}`, this.state.parameters[row].name, editing, editing)}
+			{this.renderEditableCell(`parameterDefault-${row}`, this.getDefaultValue(row), editing, editing && this.isDefaultValueEditable(row))}
+			<td onMouseEnter={this.onMouseEnter} className={`${editing ? "parameter-cell-edit-button" : "parameter-cell-button"}`} id={`parameterButton-${row}`}>
+				{editing ?
 					<div className="table-buttons-edit">
-						<VSCodeButton className={"table-buttons-edit-ok"} disabled={false} appearance="primary" onClick={this.onClick} id={`confirmParameter-${row}`}>OK</VSCodeButton>
-						<VSCodeButton className={"table-buttons-edit-cancel"} disabled={false} appearance="secondary" onClick={this.onClick} id={`cancelParameter-${row}`}>Cancel</VSCodeButton>
+						<button type={"button"} className={"btn btn-primary table-buttons-edit-ok"} onClick={this.onClick} id={`confirmParameter-${row}`}>OK</button>
+						<button type={"button"} className={"btn btn-secondary table-buttons-edit-cancel"} onClick={this.onClick} id={`cancelParameter-${row}`}>Cancel</button>
 					</div> : row === this.state.focusRow ? <div className="table-buttons">
-						{row === 0 ? <></> : <VSCodeButton appearance="icon">
-							<span className={"codicon codicon-arrow-up"} title={"Up"} onClick={this.onClick} id={`upParameter-${row}`}></span>
-						</VSCodeButton>}
-						{row === this.state.parameters.length - 1 ? <></> : <VSCodeButton appearance="icon">
-							<span className={"codicon codicon-arrow-down"} title={"Down"} onClick={this.onClick} id={`downParameter-${row}`}></span>
-						</VSCodeButton>}
-						<VSCodeButton appearance="icon">
-							<span className={"codicon codicon-edit"} title={"Edit"} onClick={this.onClick} id={`editParameter-${row}`}></span>
-						</VSCodeButton>
-						<VSCodeButton appearance="icon">
-							<span className={"codicon codicon-close"} title={"Remove"} onClick={this.onClick} id={`removeParameter-${row}`}></span>
-						</VSCodeButton>
+						{row === 0 ? <></> : <button type={"button"} className={"btn btn-icon"} title={"Up"} onClick={this.onClick} id={`upParameter-${row}`}>
+							<span className={"codicon codicon-arrow-up"} id={`upParameter-${row}`}></span>
+						</button>}
+						{row === this.state.parameters.length - 1 ? <></> : <button type={"button"} className={"btn btn-icon"} title={"Down"} onClick={this.onClick} id={`downParameter-${row}`}>
+							<span className={"codicon codicon-arrow-down"} id={`downParameter-${row}`}></span>
+						</button>}
+						<button type={"button"} className={"btn btn-icon"} title={"Edit"} onClick={this.onClick} id={`editParameter-${row}`}>
+							<span className={"codicon codicon-edit"} id={`editParameter-${row}`}></span>
+						</button>
+						<button type={"button"} className={"btn btn-icon"} title={"Remove"} onClick={this.onClick} id={`removeParameter-${row}`}>
+							<span className={"codicon codicon-close"} id={`removeParameter-${row}`}></span>
+						</button>
 					</div> : <div onMouseEnter={this.onMouseEnter} className="table-buttons"></div>
 				}
-			</VSCodeDataGridCell>
-		</VSCodeDataGridRow>;
+			</td>
+		</tr>;
 	};
 
 	generateExceptionDataGridRow = (row: number) => {
-		return <VSCodeDataGridRow onMouseEnter={this.onMouseEnter} id={`exceptionRow-${row}`} key={`exceptionRow-${row}`}>
-			<VSCodeDataGridCell onMouseEnter={this.onMouseEnter} className={`${row === this.state.editExceptionRow ? "parameter-cell-edit" : "parameter-cell"}`} id={`exceptionType-${row}`} contentEditable={row === this.state.editExceptionRow ? "true" : "false"} suppressContentEditableWarning={true} gridColumn={"1"}>{this.state.exceptions[row].type}</VSCodeDataGridCell>
-			<VSCodeDataGridCell onMouseEnter={this.onMouseEnter} className={`${row === this.state.editExceptionRow ? "parameter-cell-edit-button" : "parameter-cell-button"}`} id={`exceptionButton-${row}`} gridColumn={"2"}>
-				{row === this.state.editExceptionRow ?
+		const editing = row === this.state.editExceptionRow;
+		return <tr onMouseEnter={this.onMouseEnter} id={`exceptionRow-${row}`} key={`exceptionRow-${row}`}>
+			{this.renderEditableCell(`exceptionType-${row}`, this.state.exceptions[row].type, editing, editing)}
+			<td onMouseEnter={this.onMouseEnter} className={`${editing ? "parameter-cell-edit-button" : "parameter-cell-button"}`} id={`exceptionButton-${row}`}>
+				{editing ?
 					<div className="table-buttons-edit">
-						<VSCodeButton className={"table-buttons-edit-ok"} disabled={false} appearance="primary" onClick={this.onClick} id={`confirmException-${row}`}>OK</VSCodeButton>
-						<VSCodeButton className={"table-buttons-edit-cancel"} disabled={false} appearance="secondary" onClick={this.onClick} id={`cancelException-${row}`}>Cancel</VSCodeButton>
+						<button type={"button"} className={"btn btn-primary table-buttons-edit-ok"} onClick={this.onClick} id={`confirmException-${row}`}>OK</button>
+						<button type={"button"} className={"btn btn-secondary table-buttons-edit-cancel"} onClick={this.onClick} id={`cancelException-${row}`}>Cancel</button>
 					</div> : row === this.state.focusRow ? <div className="table-buttons">
-						<VSCodeButton appearance="icon">
-							<span className={"codicon codicon-edit"} title={"Edit"} onClick={this.onClick} id={`editException-${row}`}></span>
-						</VSCodeButton>
-						<VSCodeButton appearance="icon">
-							<span className={"codicon codicon-close"} title={"Remove"} onClick={this.onClick} id={`removeException-${row}`}></span>
-						</VSCodeButton>
+						<button type={"button"} className={"btn btn-icon"} title={"Edit"} onClick={this.onClick} id={`editException-${row}`}>
+							<span className={"codicon codicon-edit"} id={`editException-${row}`}></span>
+						</button>
+						<button type={"button"} className={"btn btn-icon"} title={"Remove"} onClick={this.onClick} id={`removeException-${row}`}>
+							<span className={"codicon codicon-close"} id={`removeException-${row}`}></span>
+						</button>
 					</div> : <div onMouseEnter={this.onMouseEnter} className="table-buttons"></div>
 				}
-			</VSCodeDataGridCell>
-		</VSCodeDataGridRow>;
+			</td>
+		</tr>;
 	};
 
 	render = () => {
@@ -489,76 +485,89 @@ export class App extends React.Component<{}, State> {
 					<div className="flex section-columns">
 						<div className="header-left">
 							<div className="text-title">Access modifier:</div>
-							<VSCodeDropdown className="vsc-dropdown" id={"access-modifier"} onChange={this.onChange} value={this.state.accessType}>
-								<VSCodeOption>public</VSCodeOption>
-								<VSCodeOption>protected</VSCodeOption>
-								<VSCodeOption>package-private</VSCodeOption>
-								<VSCodeOption>private</VSCodeOption>
-							</VSCodeDropdown>
+							<select className="vsc-dropdown" id={"access-modifier"} onChange={this.onChange} value={this.state.accessType ?? "public"}>
+								<option value="public">public</option>
+								<option value="protected">protected</option>
+								<option value="package-private">package-private</option>
+								<option value="private">private</option>
+							</select>
 						</div>
 						<div className="flex-grow header">
 							<div className="text-title">Return type:</div>
-							<VSCodeTextField title={App.TOOLTIP_RETURN_TYPE} value={this.state.returnType} id={"returnType"} onInput={this.onChange}></VSCodeTextField>
+							<input className="vsc-textfield" type="text" title={App.TOOLTIP_RETURN_TYPE} value={this.state.returnType ?? ""} id={"returnType"} onChange={this.onChange}></input>
 						</div>
 						<div className="flex-grow header-right">
 							<div className="text-title">Method name:</div>
-							<VSCodeTextField value={this.state.methodName} id={"methodName"} onInput={this.onChange}></VSCodeTextField>
+							<input className="vsc-textfield" type="text" value={this.state.methodName ?? ""} id={"methodName"} onChange={this.onChange}></input>
 						</div>
 					</div>
 				</div>
-				<VSCodePanels className={"parameters-panel"}>
-					<VSCodePanelTab id="parametersTab">Parameters</VSCodePanelTab>
-					<VSCodePanelTab id="exceptionsTab">Exceptions</VSCodePanelTab>
-					<VSCodePanelView id="parametersView" className={"parameters-view"}>
-						<VSCodeDataGrid onMouseLeave={this.onMouseLeave}>
-							<VSCodeDataGridRow className={"parameter-cell-header"} onMouseEnter={this.onMouseEnter} id={"parameterHeader"}>
-								<VSCodeDataGridCell title={App.TOOLTIP_PARAMETER_TYPE} className={"parameter-cell-title"} cellType={"columnheader"} id={"parameterHeaderType"} gridColumn={"1"}>Type</VSCodeDataGridCell>
-								<VSCodeDataGridCell className={"parameter-cell-title"} cellType={"columnheader"} id={"parameterHeaderName"} gridColumn={"2"}>Name</VSCodeDataGridCell>
-								<VSCodeDataGridCell title={App.TOOLTIP_PARAMETER_DEFAULT} className={"parameter-cell-title"} cellType={"columnheader"} id={"parameterHeaderDefault"} gridColumn={"3"}>Default value</VSCodeDataGridCell>
-								<VSCodeDataGridCell className={"parameter-cell-title"} cellType={"columnheader"} id={"parameterHeaderButton"} gridColumn={"4"}></VSCodeDataGridCell>
-							</VSCodeDataGridRow>
-							{
-								(() => {
-									const options: JSX.Element[] = [];
-									for (let row = 0; row < this.state.parameters.length; row++) {
-										options.push(this.generateParameterDataGridRow(row));
-									}
-									return options;
-								})()
-							}
-						</VSCodeDataGrid>
+				<div className={"parameters-panel"}>
+					<div className="tabs" role="tablist">
+						<button type={"button"} role="tab" aria-selected={this.state.activeTab === "parameters"} aria-controls="panel-parameters" className={`tab ${this.state.activeTab === "parameters" ? "tab-active" : ""}`} id="tab-parameters" onClick={this.onClick}>Parameters</button>
+						<button type={"button"} role="tab" aria-selected={this.state.activeTab === "exceptions"} aria-controls="panel-exceptions" className={`tab ${this.state.activeTab === "exceptions" ? "tab-active" : ""}`} id="tab-exceptions" onClick={this.onClick}>Exceptions</button>
+					</div>
+					<div className={"parameters-view"} role="tabpanel" id="panel-parameters" aria-labelledby="tab-parameters" hidden={this.state.activeTab !== "parameters"}>
+						<table className={"parameter-table"} onMouseLeave={this.onMouseLeave}>
+							<thead>
+								<tr className={"parameter-cell-header"} onMouseEnter={this.onMouseEnter} id={"parameterHeader"}>
+									<th title={App.TOOLTIP_PARAMETER_TYPE} className={"parameter-cell-title"} id={"parameterHeaderType"}>Type</th>
+									<th className={"parameter-cell-title"} id={"parameterHeaderName"}>Name</th>
+									<th title={App.TOOLTIP_PARAMETER_DEFAULT} className={"parameter-cell-title"} id={"parameterHeaderDefault"}>Default value</th>
+									<th className={"parameter-cell-title"} id={"parameterHeaderButton"}></th>
+								</tr>
+							</thead>
+							<tbody>
+								{
+									(() => {
+										const options: JSX.Element[] = [];
+										for (let row = 0; row < this.state.parameters.length; row++) {
+											options.push(this.generateParameterDataGridRow(row));
+										}
+										return options;
+									})()
+								}
+							</tbody>
+						</table>
 						<div className={"add-button"}>
-							<VSCodeButton className={"vsc-button-left"} appearance="primary" onClick={this.onClick} id={"addParameter"}>Add</VSCodeButton>
+							<button type={"button"} className={"btn btn-primary vsc-button-left"} onClick={this.onClick} id={"addParameter"}>Add</button>
 						</div>
-					</VSCodePanelView>
-					<VSCodePanelView id="exceptionsView" className={"parameters-view"}>
-						<VSCodeDataGrid onMouseLeave={this.onMouseLeave}>
-							<VSCodeDataGridRow className={"parameter-cell-header"} onMouseEnter={this.onMouseEnter} id={`exceptionHeader`}>
-								<VSCodeDataGridCell title={App.TOOLTIP_EXCEPTION_TYPE} className={"parameter-cell-title"} cellType={"columnheader"} id={"exceptionHeaderType"} gridColumn={"1"}>Type</VSCodeDataGridCell>
-								<VSCodeDataGridCell className={"parameter-cell-title"} cellType={"columnheader"} id={"exceptionHeaderButton"} gridColumn={"2"}></VSCodeDataGridCell>
-							</VSCodeDataGridRow>
-							{
-								(() => {
-									const options: JSX.Element[] = [];
-									for (let row = 0; row < this.state.exceptions.length; row++) {
-										options.push(this.generateExceptionDataGridRow(row));
-									}
-									return options;
-								})()
-							}
-						</VSCodeDataGrid>
+					</div>
+					<div className={"parameters-view"} role="tabpanel" id="panel-exceptions" aria-labelledby="tab-exceptions" hidden={this.state.activeTab !== "exceptions"}>
+						<table className={"parameter-table"} onMouseLeave={this.onMouseLeave}>
+							<thead>
+								<tr className={"parameter-cell-header"} onMouseEnter={this.onMouseEnter} id={"exceptionHeader"}>
+									<th title={App.TOOLTIP_EXCEPTION_TYPE} className={"parameter-cell-title"} id={"exceptionHeaderType"}>Type</th>
+									<th className={"parameter-cell-title"} id={"exceptionHeaderButton"}></th>
+								</tr>
+							</thead>
+							<tbody>
+								{
+									(() => {
+										const options: JSX.Element[] = [];
+										for (let row = 0; row < this.state.exceptions.length; row++) {
+											options.push(this.generateExceptionDataGridRow(row));
+										}
+										return options;
+									})()
+								}
+							</tbody>
+						</table>
 						<div className={"add-button"}>
-							<VSCodeButton className={"vsc-button-left"} appearance="primary" onClick={this.onClick} id={"addException"}>Add</VSCodeButton>
+							<button type={"button"} className={"btn btn-primary vsc-button-left"} onClick={this.onClick} id={"addException"}>Add</button>
 						</div>
-					</VSCodePanelView>
-				</VSCodePanels>
+					</div>
+				</div>
 				<div className="text-title-content">Method signature:</div>
-				<VSCodeTextArea className={"preview"} value={this.getPreview()} readOnly={true} id={"textArea"}></VSCodeTextArea>
-				<VSCodeCheckbox id="delegate" className={"delegate"} onClick={this.onClick} checked={this.state.isDelegate}>Keep original method as delegate to changed method</VSCodeCheckbox>
+				<textarea className={"preview"} value={this.getPreview()} readOnly={true} id={"textArea"}></textarea>
+				<label className={"delegate"}>
+					<input type="checkbox" id="delegate" onChange={this.onChange} checked={this.state.isDelegate} />
+					Keep original method as delegate to changed method
+				</label>
 				<div className={"bottom-buttons"}>
-					<VSCodeButton className={"vsc-button-left"} appearance="primary" onClick={this.onClick} id={"refactor"}>Refactor</VSCodeButton>
-					<VSCodeButton className={"vsc-button"} appearance="secondary" onClick={this.onClick} id={"preview"}>Preview</VSCodeButton>
-					<VSCodeButton className={"vsc-button"} appearance="secondary" disabled={this.isUnchanged()} onClick={this.onClick} id={"reset"}>Reset</VSCodeButton>
+					<button type={"button"} className={"btn btn-primary vsc-button-left"} onClick={this.onClick} id={"refactor"}>Refactor</button>
+					<button type={"button"} className={"btn btn-secondary vsc-button"} onClick={this.onClick} id={"preview"}>Preview</button>
+					<button type={"button"} className={"btn btn-secondary vsc-button"} disabled={this.isUnchanged()} onClick={this.onClick} id={"reset"}>Reset</button>
 				</div>
 			</main >
 		);


### PR DESCRIPTION
Fixes #4417

This PR is the complete fix: it both resolves the editable-cell bug and migrates the dialog off the deprecated toolkit.

### Background
On **Change Method Signature**, editing a parameter **Type** (or Name / Default, or an exception Type) showed nothing while typing, and on **OK** the typed text was *appended* to the original value instead of replacing it. Root cause: the cells set `contentEditable` directly on the deprecated `@vscode/webview-ui-toolkit` `vscode-data-grid-cell`, whose shadow root is only `<slot>` — typed text became a bare text node on the host, outside the slot, so it never rendered and was read back via `outerText` (concatenated).

### What this PR does
1. **Fixes the bug** — editable cells render a real `<input>` while editing and read its `.value` on commit (visible typing + correct replace semantics).
2. **Migrates the whole dialog off the archived toolkit** to native HTML elements styled with `--vscode-*` theme variables, and removes the dependency.


### Scope
This change only touches the **Change Method Signature** refactoring dialog. It was the only webview in the extension that depended on @vscode/webview-ui-toolkit, so it is the only one affected by this migration. Other webviews (e.g. the dashboard) never used the toolkit and are left completely untouched.
### Component mapping
| Toolkit | Native |
|---|---|
| `VSCodeButton` | `<button>` + `btn`/`btn-primary`/`btn-secondary`/`btn-icon` |
| `VSCodeTextField` | `<input type=text>` |
| `VSCodeDropdown` / `VSCodeOption` | `<select>` / `<option>` |
| `VSCodeCheckbox` | `<label>` + `<input type=checkbox>` |
| `VSCodeTextArea` | readonly `<textarea>` |
| `VSCodePanels` / `Tab` / `View` | native tab bar + `activeTab` state + conditional render |
| `VSCodeDataGrid` / `Row` / `Cell` | `<table>`/`<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>` |

### Notes
- Preserves the existing id scheme (`parameterRow-N`, `parameterButton-N`, `parameterType-N` …) so hover-to-reveal-buttons and edit/confirm/cancel logic is unchanged.
- `delegate` checkbox handling moved from `onClick` to `onChange`.
- Removed the obsolete `setTextAreaCursorStyle` shadow-DOM hack.
- Tightened the webview CSP: dropped `style-src 'unsafe-inline'` (only the toolkit needed it; CSS is now loaded via `<link>` and the codicon font is a `data:` URL covered by `font-src`).
- Removed `@vscode/webview-ui-toolkit` from `package.json` + `package-lock.json`.

### Validation
- `tsc --noEmit` — passes
- `eslint` on changed files — clean
- webpack `changeSignature` bundle — builds successfully; built bundle contains no `vscode-data-grid` references
- Manual VS Code UI walkthrough (edit/add/remove/reorder parameters & exceptions, tabs, dropdown, checkbox, preview, reset, light/dark/high-contrast themes) recommended before merge.

