### PR TITLE
Fix #4167: use java.projects context for explorer actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1921,12 +1921,12 @@
           "group": "1_javaactions"
         },
         {
-          "when": "explorerResourceIsFolder&&javaLSReady",
+          "when": "explorerResourceIsFolder&&javaLSReady&&resourceDirname in java.projects",
           "command": "java.project.addToSourcePath.command",
           "group": "1_javaactions@1"
         },
         {
-          "when": "explorerResourceIsFolder&&javaLSReady",
+          "when": "explorerResourceIsFolder&&javaLSReady&&resourceDirname in java.projects",
           "command": "java.project.removeFromSourcePath.command",
           "group": "1_javaactions@2"
         }

--- a/package.json
+++ b/package.json
@@ -1921,12 +1921,12 @@
           "group": "1_javaactions"
         },
         {
-          "when": "explorerResourceIsFolder&&javaLSReady",
+          "when": "explorerResourceIsFolder&&javaLSReady&&resourcePath in java.projects",
           "command": "java.project.addToSourcePath.command",
           "group": "1_javaactions@1"
         },
         {
-          "when": "explorerResourceIsFolder&&javaLSReady",
+          "when": "explorerResourceIsFolder&&javaLSReady&&resourcePath in java.projects",
           "command": "java.project.removeFromSourcePath.command",
           "group": "1_javaactions@2"
         }

--- a/package.json
+++ b/package.json
@@ -1921,12 +1921,12 @@
           "group": "1_javaactions"
         },
         {
-          "when": "explorerResourceIsFolder&&javaLSReady&&resourcePath in java.projects",
+          "when": "explorerResourceIsFolder&&javaLSReady",
           "command": "java.project.addToSourcePath.command",
           "group": "1_javaactions@1"
         },
         {
-          "when": "explorerResourceIsFolder&&javaLSReady&&resourcePath in java.projects",
+          "when": "explorerResourceIsFolder&&javaLSReady",
           "command": "java.project.removeFromSourcePath.command",
           "group": "1_javaactions@2"
         }

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -120,7 +120,7 @@ export class StandardLanguageClient {
 
 	public registerLanguageClientActions(context: ExtensionContext, hasImported: boolean, jdtEventEmitter: EventEmitter<Uri>) {
 		activationProgressNotification.showProgress();
-		this.languageClient.onNotification(StatusNotification.type, (report) => {
+		this.languageClient.onNotification(StatusNotification.type, async (report) => {
 			// Resolve serverRunning on the first status notification from the server,
 			// indicating the server process is alive and can accept requests.
 			apiManager.resolveServerRunningPromise();
@@ -152,6 +152,13 @@ export class StandardLanguageClient {
 					// Disable the client-side snippet provider since LS is ready.
 					snippetCompletionProvider.dispose();
 					registerDocumentValidationListener(context, this.languageClient);
+					try {
+						const projectUris = await getAllJavaProjects();
+						const projectPaths = projectUris.map((uriString) => Uri.parse(uriString).fsPath.replace(/[\\/]$/, ''));
+						await commands.executeCommand('setContext', 'java.projects', projectPaths);
+					} catch (error) {
+						logger.error(error);
+					}
 					commands.executeCommand('setContext', 'javaLSReady', true);
 					break;
 				case 'Started':

--- a/src/standardLanguageClient.ts
+++ b/src/standardLanguageClient.ts
@@ -149,17 +149,17 @@ export class StandardLanguageClient {
 					apiManager.getApiInstance().onDidClasspathUpdate((projectUri: Uri) => {
 						checkLombokDependency(context, projectUri);
 					});
+					apiManager.getApiInstance().onDidProjectsImport(() => {
+						updateJavaProjectsContext();
+					});
+					apiManager.getApiInstance().onDidProjectsDelete(() => {
+						updateJavaProjectsContext();
+					});
 					// Disable the client-side snippet provider since LS is ready.
 					snippetCompletionProvider.dispose();
 					registerDocumentValidationListener(context, this.languageClient);
-					try {
-						const projectUris = await getAllJavaProjects();
-						const projectPaths = projectUris.map((uriString) => Uri.parse(uriString).fsPath.replace(/[\\/]$/, ''));
-						await commands.executeCommand('setContext', 'java.projects', projectPaths);
-					} catch (error) {
-						logger.error(error);
-					}
 					commands.executeCommand('setContext', 'javaLSReady', true);
+					updateJavaProjectsContext();
 					break;
 				case 'Started':
 					this.status = ClientStatus.started;
@@ -849,6 +849,15 @@ export class StandardLanguageClient {
 			affectedEditorDocuments: affectedDocumentUris,
 		});
 	}
+}
+
+function updateJavaProjectsContext(): void {
+	getAllJavaProjects().then((projectUris) => {
+		const projectPaths = projectUris.map((uriString) => Uri.parse(uriString).fsPath.replace(/[\\/]$/, ''));
+		commands.executeCommand('setContext', 'java.projects', projectPaths);
+	}).catch((error) => {
+		logger.error(error);
+	});
 }
 
 async function showImportFinishNotification(context: ExtensionContext) {


### PR DESCRIPTION
This change introduces the java.projects array context and uses it to make the Add/Remove Source Path Explorer actions more precise. These actions are now only shown for Java project folders instead of every folder in the Explorer.

Fixes #4167