### PR TITLE
Start JDT LS with a UTF-8 locale when the environment selects ASCII

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -42,7 +42,7 @@ const SHARED_ARCHIVE_FILE_LOC= '-XX:SharedArchiveFile=';
 export function prepareExecutable(requirements: RequirementsData, workspacePath, context: ExtensionContext, isSyntaxServer: boolean): Executable {
 	const executable: Executable = Object.create(null);
 	const options: ExecutableOptions = Object.create(null);
-	options.env = Object.assign({ syntaxserver: isSyntaxServer }, process.env, getVSCodeVariablesMap());
+	options.env = Object.assign({ syntaxserver: isSyntaxServer }, process.env, getVSCodeVariablesMap(), getUnicodeLocaleEnv());
 	if (os.platform() === 'win32') {
 		const vmargs = getJavaConfiguration().get('jdt.ls.vmargs', '');
 		const watchParentProcess = '-DwatchParentProcess=false';
@@ -73,6 +73,61 @@ export function prepareExecutable(requirements: RequirementsData, workspacePath,
 	logger.info(`Starting Java server with: ${executable.command} ${executable.args?.join(' ')}`);
 	return executable;
 }
+
+/**
+ * Environment variables that select the JVM's file name charset on POSIX systems, in the precedence
+ * order POSIX defines for the `LC_CTYPE` category. The JVM reads them through `setlocale(LC_ALL, "")`
+ * followed by `ParseLocale(LC_CTYPE, ...)` in `unix/native/libjava/java_props_md.c`.
+ */
+export const LOCALE_ENV_VARS: string[] = ['LC_ALL', 'LC_CTYPE', 'LANG'];
+
+/** Locales under which the JVM falls back to ASCII and cannot represent non-ASCII file names. */
+const ASCII_LOCALES: string[] = ['C', 'POSIX', 'C.ASCII'];
+
+export const UTF8_LOCALE: string = 'C.UTF-8';
+
+/**
+ * On POSIX systems the JVM decodes and encodes file names with `sun.jnu.encoding`, which it derives
+ * from the process locale at startup. `-Dsun.jnu.encoding=...` is silently ignored, so neither
+ * `java.jdt.ls.vmargs` nor `-Dfile.encoding` can influence it.
+ *
+ * Containers and services routinely start with an unset or `C`/`POSIX` locale, which makes the JVM
+ * fall back to ASCII. Every workspace file whose name contains non-ASCII characters is then decoded
+ * into U+FFFD by `JNU_NewStringPlatform` and can no longer be encoded back by `UnixPath.encode`,
+ * which throws `InvalidPathException: Malformed input or input contains unmappable characters` and
+ * aborts the whole workspace initialization.
+ * See https://github.com/microsoft/vscode-java-dependency/issues/1041
+ *
+ * Only the unset/`C`/`POSIX` cases are overridden, so a deliberately configured non-UTF-8 locale
+ * (e.g. `zh_CN.GBK`, matching file names actually stored in that encoding) is left untouched. When
+ * the locale has to be corrected, only the `LC_CTYPE` category is set, so message/number/time
+ * formatting keeps following the environment.
+ */
+export function getUnicodeLocaleEnv(): { [key: string]: string } {
+	// Windows is unaffected and does not read these variables: the JVM derives sun.jnu.encoding from
+	// GetACP() there, and file names never go through a charset because WinNTFileSystem hands the
+	// UTF-16 WIN32_FIND_DATAW.cFileName straight to NewString and WindowsPath copies the Java String
+	// into the native buffer verbatim. Injecting POSIX locale variables would only leak into the
+	// child processes JDT LS spawns.
+	if (os.platform() === 'win32') {
+		return {};
+	}
+	const locale = LOCALE_ENV_VARS.map(name => process.env[name]).find(value => !!value);
+	if (locale && !ASCII_LOCALES.includes(locale)) {
+		return {};
+	}
+	logger.info(`Locale '${locale ?? '<unset>'}' cannot represent non-ASCII file names, starting JDT LS with ${UTF8_LOCALE}`);
+	const env: { [key: string]: string } = {};
+	if (process.env.LC_ALL) {
+		// LC_ALL overrides every other category, so it has to be replaced when it is the one selecting ASCII.
+		env.LC_ALL = UTF8_LOCALE;
+	} else {
+		// LC_CTYPE is the only category that selects the charset, so leave the others alone.
+		env.LC_CTYPE = UTF8_LOCALE;
+	}
+	return env;
+}
+
 export function awaitServerConnection(port): Thenable<StreamInfo> {
 	const addr = parseInt(port);
 	return new Promise((res, rej) => {

--- a/test/standard-mode-suite/javaServerStarter.test.ts
+++ b/test/standard-mode-suite/javaServerStarter.test.ts
@@ -1,0 +1,103 @@
+'use strict';
+
+import * as assert from 'assert';
+import { platform } from 'os';
+import { getUnicodeLocaleEnv, LOCALE_ENV_VARS, UTF8_LOCALE } from '../../src/javaServerStarter';
+
+function setLocale(...values: [string, string][]): void {
+	for (const name of LOCALE_ENV_VARS) {
+		delete process.env[name];
+	}
+	for (const [name, value] of values) {
+		process.env[name] = value;
+	}
+}
+
+function utf8Env(variable: string): { [key: string]: string } {
+	const env: { [key: string]: string } = {};
+	env[variable] = UTF8_LOCALE;
+	return env;
+}
+
+suite('Java Server Starter Test', () => {
+
+	const saved: [string, string][] = [];
+
+	suiteSetup(() => {
+		for (const name of LOCALE_ENV_VARS) {
+			if (process.env[name] !== undefined) {
+				saved.push([name, process.env[name]]);
+			}
+		}
+	});
+
+	suiteTeardown(() => {
+		setLocale(...saved);
+	});
+
+	test('getUnicodeLocaleEnv() - never overrides the locale on Windows', function () {
+		if (platform() !== 'win32') {
+			this.skip();
+		}
+		setLocale();
+		assert.deepStrictEqual(getUnicodeLocaleEnv(), {});
+	});
+
+	test('getUnicodeLocaleEnv() - forces UTF-8 when the locale is unset', function () {
+		if (platform() === 'win32') {
+			this.skip();
+		}
+		setLocale();
+		assert.deepStrictEqual(getUnicodeLocaleEnv(), utf8Env('LC_CTYPE'));
+	});
+
+	test('getUnicodeLocaleEnv() - forces UTF-8 for ASCII only locales', function () {
+		if (platform() === 'win32') {
+			this.skip();
+		}
+		for (const locale of ['C', 'POSIX', 'C.ASCII']) {
+			setLocale(['LANG', locale]);
+			assert.deepStrictEqual(getUnicodeLocaleEnv(), utf8Env('LC_CTYPE'), `LANG=${locale}`);
+		}
+	});
+
+	test('getUnicodeLocaleEnv() - keeps an existing UTF-8 locale', function () {
+		if (platform() === 'win32') {
+			this.skip();
+		}
+		setLocale(['LANG', 'en_US.UTF-8']);
+		assert.deepStrictEqual(getUnicodeLocaleEnv(), {});
+	});
+
+	test('getUnicodeLocaleEnv() - keeps a deliberately configured non-UTF-8 locale', function () {
+		if (platform() === 'win32') {
+			this.skip();
+		}
+		setLocale(['LANG', 'zh_CN.GBK']);
+		assert.deepStrictEqual(getUnicodeLocaleEnv(), {});
+	});
+
+	test('getUnicodeLocaleEnv() - replaces LC_ALL because it overrides every other category', function () {
+		if (platform() === 'win32') {
+			this.skip();
+		}
+		setLocale(['LC_ALL', 'C'], ['LANG', 'en_US.UTF-8']);
+		assert.deepStrictEqual(getUnicodeLocaleEnv(), utf8Env('LC_ALL'));
+	});
+
+	test('getUnicodeLocaleEnv() - only corrects LC_CTYPE when LC_ALL is unset', function () {
+		if (platform() === 'win32') {
+			this.skip();
+		}
+		setLocale(['LC_CTYPE', 'C'], ['LANG', 'en_US.UTF-8']);
+		assert.deepStrictEqual(getUnicodeLocaleEnv(), utf8Env('LC_CTYPE'));
+	});
+
+	test('getUnicodeLocaleEnv() - LC_CTYPE takes precedence over LANG', function () {
+		if (platform() === 'win32') {
+			this.skip();
+		}
+		setLocale(['LC_CTYPE', 'en_US.UTF-8'], ['LANG', 'C']);
+		assert.deepStrictEqual(getUnicodeLocaleEnv(), {});
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-java-dependency/issues/1041

## Problem

Inside containers, importing a workspace that contains a file with a non-ASCII name aborts with:

```text
!MESSAGE Progressive import: reporting 1 new project(s)
!MESSAGE Initialization failed
java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters:
  /workspace/JAVA_Projects/RuoYi/doc/????????????????????????.docx
```

Every project after the failing one silently disappears. The reporter saw a 7-module Maven project collapse to a single root project, which looks exactly like a multi-module import bug — the encoding cause is invisible from the UI. The sample is [`yangzongzhuan/RuoYi`](https://github.com/yangzongzhuan/RuoYi), whose `doc/` folder contains `若依环境使用手册.docx`: 8 CJK characters = 24 UTF-8 bytes, matching the 24 replacement characters in the log exactly (one per byte).

It reproduces only in containers. The same workspace works locally and over SSH remote, because those sessions have a UTF-8 locale.

## Root cause

On POSIX systems the JVM decodes and encodes file names with `sun.jnu.encoding`, which it derives from the process locale at startup (OpenJDK `jdk-21+35`):

- [`unix/native/libjava/java_props_md.c#L430-L454`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/unix/native/libjava/java_props_md.c#L430-L454) — `setlocale(LC_ALL, "")` then `ParseLocale(LC_CTYPE, ..., &sprops.encoding)`, and `sprops.sun_jnu_encoding = sprops.encoding`.
- [`UnixFileSystem_md.c#L347`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/unix/native/libjava/UnixFileSystem_md.c#L347) — `readdir` bytes are decoded with `JNU_NewStringPlatform`, which uses that charset ([`System.c#L121`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/share/native/libjava/System.c#L121)). Under ASCII every byte becomes U+FFFD.
- [`UnixPath.java#L124-L130`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/unix/classes/sun/nio/fs/UnixPath.java#L124-L130) — encoding the name back throws `InvalidPathException("Malformed input or input contains unmappable characters")`, the exact message above.

Containers commonly start with an unset or `C`/`POSIX` locale, so `sun.jnu.encoding` becomes `ANSI_X3.4-1968`.

Crucially, **`-Dsun.jnu.encoding` and `-Dfile.encoding` cannot fix this** — the property is written from the OS locale during VM startup and the command-line value is ignored. Verified on JDK 21: `java -Dsun.jnu.encoding=US-ASCII` still reports the locale-derived charset. So `java.jdt.ls.vmargs` gives users no way out; the process locale is the only lever, and this extension is the only component in a position to set it.

## Change

`prepareExecutable` now merges `getUnicodeLocaleEnv()` into the JDT LS process environment. It corrects the locale when, and only when, the inherited one cannot represent non-ASCII file names:

- Reads `LC_ALL` > `LC_CTYPE` > `LANG`, the precedence POSIX defines for `LC_CTYPE`.
- Overrides only the unset / `C` / `POSIX` / `C.ASCII` cases. A deliberately configured non-UTF-8 locale such as `zh_CN.GBK` is left untouched, since file names on such a system may genuinely be stored in that encoding.
- Sets `LC_ALL=C.UTF-8` only when `LC_ALL` is the variable selecting ASCII (it dominates every category); otherwise sets just `LC_CTYPE=C.UTF-8`, so message, number and time formatting keep following the environment.
- Logs one line to the Java output channel when it acts, so the situation stays diagnosable.

### Why Windows returns early

Windows is structurally unaffected, and does not read these variables at all:

- [`windows/native/libjava/java_props_md.c#L691`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/windows/native/libjava/java_props_md.c#L691) + [`#L67-L68`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/windows/native/libjava/java_props_md.c#L67-L68) — `sun.jnu.encoding` comes from `GetACP()`. The file contains no `setlocale`, `LC_ALL` or `LC_CTYPE` reference.
- File names never go through a charset: [`WinNTFileSystem_md.c#L768`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/windows/native/libjava/WinNTFileSystem_md.c#L768) passes the UTF-16 `WIN32_FIND_DATAW.cFileName` straight to `NewString`, and [`WindowsNativeDispatcher.java#L1146-L1167`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java#L1146-L1167) copies the Java String into the native buffer verbatim before `CreateFileW`. ([NTFS stores file names in Unicode.](https://learn.microsoft.com/en-us/windows/win32/intl/character-sets-used-in-file-names))

Setting POSIX locale variables there would be a no-op for the JVM while still leaking into every process JDT LS spawns (Maven/Gradle wrappers, Git for Windows, MSYS-based tooling do read them).

macOS is also unaffected — `sun_jnu_encoding` is hard-coded to UTF-8 there ([`java_props_md.c#L451-L452`](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/unix/native/libjava/java_props_md.c#L451-L452)) — and the ASCII check makes this a no-op in practice anyway.

## Known limitation

`C.UTF-8` requires glibc >= 2.35 or a distro that ships it (Debian and Ubuntu do; RHEL 7 does not). Where it is missing, `setlocale` fails and the JVM falls back to `C`, i.e. current behaviour — no regression, but no fix either. Those users still need `en_US.UTF-8` generated in the image.

Non-VS Code clients that launch JDT LS through `jdtls.py` are unaffected by this change; a matching fix can be made in `eclipse.jdt.ls` separately.

## Tests

`test/standard-mode-suite/javaServerStarter.test.ts` covers the decision table: Windows early return, unset locale, `C`, `POSIX`, `C.ASCII`, `en_US.UTF-8`, `zh_CN.GBK`, `LC_ALL` override, `LC_CTYPE`-only correction, and `LC_CTYPE` precedence over `LANG`.