### PR TITLE
Project-only search scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1644,11 +1644,13 @@
             "type": "string",
             "enum": [
               "all",
-              "main"
+              "main",
+              "projectOnly"
             ],
             "enumDescriptions": [
               "Search on all classpath entries including reference libraries and projects.",
-              "All classpath entries excluding test classpath entries."
+              "All classpath entries excluding test classpath entries.",
+              "Only search sources, tests, and referenced projects, excluding the JDK and referenced libraries from the search."
             ],
             "default": "all",
             "markdownDescription": "Specifies the scope which must be used for search operation like \n - Find Reference\n - Call Hierarchy\n - Workspace Symbols",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -701,7 +701,7 @@ async function postExtensionStartInit(
 	});
 
 	context.subscriptions.push(commands.registerCommand(Commands.CHANGE_JAVA_SEARCH_SCOPE, async () => {
-		const selection = await window.showQuickPick(["all", "main"], {
+		const selection = await window.showQuickPick(["all", "main", "projectOnly"], {
 			canPickMany: false,
 			placeHolder: `Current: ${workspace.getConfiguration().get("java.search.scope")}`,
 		});


### PR DESCRIPTION
See https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3850, this is the client side changes needed to adopt that PR.