### PR TITLE
Implement confirmation for non-fatal "Move Instance Method" problems before applying edits

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -255,6 +255,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionAPI>
 				advancedExtractRefactoringSupport: true,
 				inferSelectionSupport: ["extractMethod", "extractVariable", "extractField"],
 				moveRefactoringSupport: true,
+				moveRefactoringConfirmationSupport: true,
 				clientHoverProvider: true,
 				clientDocumentSymbolProvider: true,
 				gradleChecksumWrapperPromptSupport: true,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -350,9 +350,11 @@ export interface RenamePosition {
 }
 
 export interface RefactorWorkspaceEdit {
-    edit: WorkspaceEdit;
+    edit?: WorkspaceEdit;
     command?: Command;
     errorMessage?: string;
+    canContinue?: boolean;
+    confirmationToken?: string;
 }
 
 export interface GetRefactorEditParams {
@@ -411,6 +413,7 @@ export interface MoveParams {
     params: CodeActionParams;
     destination?: any;
     updateReferences?: boolean;
+    confirmationToken?: string;
 }
 
 export interface MoveDestinationsResponse {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -353,7 +353,6 @@ export interface RefactorWorkspaceEdit {
     edit?: WorkspaceEdit;
     command?: Command;
     errorMessage?: string;
-    canContinue?: boolean;
     confirmationToken?: string;
 }
 

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -254,7 +254,7 @@ async function applyRefactorEdit(languageClient: LanguageClient, refactorEdit: R
 
 async function requestMoveWithConfirmation(languageClient: LanguageClient, moveParams: MoveParams): Promise<RefactorWorkspaceEdit | undefined> {
     let refactorEdit: RefactorWorkspaceEdit = await languageClient.sendRequest(MoveRequest.type, moveParams);
-    if (!refactorEdit?.canContinue || !refactorEdit.confirmationToken) {
+    if (!refactorEdit?.confirmationToken) {
         await applyRefactorEdit(languageClient, refactorEdit);
         return refactorEdit;
     }

--- a/src/refactorAction.ts
+++ b/src/refactorAction.ts
@@ -6,7 +6,7 @@ import { commands, ExtensionContext, Position, QuickPickItem, TextDocument, Uri,
 import { FormattingOptions, WorkspaceEdit, RenameFile, DeleteFile, TextDocumentEdit, CodeActionParams, SymbolInformation } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { Commands as javaCommands } from './commands';
-import { GetRefactorEditRequest, MoveRequest, RefactorWorkspaceEdit, RenamePosition, GetMoveDestinationsRequest, SearchSymbols, SelectionInfo, InferSelectionRequest, GetChangeSignatureInfoRequest, ChangeSignatureInfo } from './protocol';
+import { GetRefactorEditRequest, MoveRequest, RefactorWorkspaceEdit, RenamePosition, GetMoveDestinationsRequest, SearchSymbols, SelectionInfo, InferSelectionRequest, GetChangeSignatureInfoRequest, ChangeSignatureInfo, MoveParams } from './protocol';
 import { ChangeSignaturePanel } from './refactoring/changeSignaturePanel';
 import { getExtractInterfaceArguments, revealExtractedInterface } from './refactoring/extractInterface';
 
@@ -252,6 +252,32 @@ async function applyRefactorEdit(languageClient: LanguageClient, refactorEdit: R
     }
 }
 
+async function requestMoveWithConfirmation(languageClient: LanguageClient, moveParams: MoveParams): Promise<RefactorWorkspaceEdit | undefined> {
+    let refactorEdit: RefactorWorkspaceEdit = await languageClient.sendRequest(MoveRequest.type, moveParams);
+    if (!refactorEdit?.canContinue || !refactorEdit.confirmationToken) {
+        await applyRefactorEdit(languageClient, refactorEdit);
+        return refactorEdit;
+    }
+
+    const continueAction = 'Continue';
+    const detail = 'Review the details below before continuing:\n\n' + refactorEdit.errorMessage;
+    const selection = await window.showWarningMessage(
+        'This refactoring may change program behavior. Continue anyway?',
+        { modal: true, detail },
+        continueAction,
+    );
+    if (selection !== continueAction) {
+        return undefined;
+    }
+
+    refactorEdit = await languageClient.sendRequest(MoveRequest.type, {
+        ...moveParams,
+        confirmationToken: refactorEdit.confirmationToken,
+    });
+    await applyRefactorEdit(languageClient, refactorEdit);
+    return refactorEdit;
+}
+
 async function moveFile(languageClient: LanguageClient, fileUris: Uri[]) {
     if (!hasCommonParent(fileUris)) {
         window.showErrorMessage("Moving files from different directories are not supported. Please make sure they are from the same directory.");
@@ -417,13 +443,12 @@ async function moveInstanceMethod(languageClient: LanguageClient, params: CodeAc
         return;
     }
 
-    const refactorEdit: RefactorWorkspaceEdit = await languageClient.sendRequest(MoveRequest.type, {
+    await requestMoveWithConfirmation(languageClient, {
         moveKind: 'moveInstanceMethod',
         sourceUris: [ params.textDocument.uri ],
         params,
         destination: selected.destination,
     });
-    await applyRefactorEdit(languageClient, refactorEdit);
 }
 
 async function moveStaticMember(languageClient: LanguageClient, params: CodeActionParams, commandInfo: any) {


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/4460

Depends on and was tested with https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3862

This PR adds a confirmation dialog for non-fatal "Move Instance Method" refactoring problems reported by JDT LS.

In Eclipse IDE, `ERROR`-level refactoring problems are displayed in the **Found problems** dialog. The user can review the problems and choose whether to continue or cancel the refactoring.

<img width="873" height="647" alt="Eclipse IDE Found problems dialog" src="https://github.com/user-attachments/assets/f781c934-d554-407f-ae07-9effc376217b" />

This PR provides the same choice in VS Code:

<img width="272" height="342" alt="VS Code refactoring confirmation dialog" src="https://github.com/user-attachments/assets/61001c9d-0390-4d03-8669-eb35f68c497c" />

When JDT LS reports non-fatal problems, VS Code displays all found problems and asks the user whether to continue. No edit is applied if the dialog is cancelled. If the user selects **Continue**, the move request is repeated with the confirmation token returned by JDT LS.

The confirmation token prevents the user from confirming a refactoring after its source or conditions have changed. To test this behavior: Select **Refactor...** > **Move...** > Wait for the problem dialog to appear > Modify and save the source file in another editor > Select **Continue** in the dialog > The stale confirmation is rejected:

<img width="449" height="152" alt="VS Code stale refactoring confirmation error" src="https://github.com/user-attachments/assets/b47587d7-55b1-4fae-b67e-f5644e99924e" />